### PR TITLE
General parameter scaling

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Contributors (alphabetic)
 * Vikram Bhamre `vikramb1 <https://github.com/vikramb1/>`_
 * Xuheng Ding `dartoon <https://github.com/dartoon/>`_
 * Sydney Erickson `smericks <https://github.com/smericks/>`_
+* Andreas Filipp `andreasfilipp <https://github.com/andreasfilipp/>`_
 * Kevin Fusshoeller
 * Aymeric Galan `aymgal <https://github.com/aymgal/>`_
 * Matthew R. Gomer `mattgomer <https://github.com/mattgomer>`_
@@ -34,7 +35,7 @@ Contributors (alphabetic)
 * Brian Nord `bnord <https://github.com/bnord/>`_
 * Giulia Pagano
 * Ji Won Park `jiwoncpark <https://github.com/jiwoncpark/>`_
-* Andreas Filipp `andreasfilipp <https://github.com/andreasfilipp/>`_
+* Jackson O'Donnell `jhod0 <https://github.com/jhod0/>`_
 * Thomas Schmidt `Thomas-01 <https://github.com/Thomas-01/>`_
 * Dominique Sluse
 * Luca Teodori `lucateo <https://github.com/lucateo/>`_

--- a/docs/lenstronomy.Sampling.rst
+++ b/docs/lenstronomy.Sampling.rst
@@ -45,6 +45,14 @@ lenstronomy.Sampling.special\_param module
     :undoc-members:
     :show-inheritance:
 
+lenstronomy.Sampling.param\_group module
+------------------------------------------
+
+.. automodule:: lenstronomy.Sampling.param_group
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/lenstronomy/PointSource/point_source_param.py
+++ b/lenstronomy/PointSource/point_source_param.py
@@ -17,6 +17,8 @@ class SourcePositionParam(SingleParam):
 class LensedPosition(ArrayParam):
     '''
     Represents lensed positions, possibly many. ra_image and dec_image
+
+    :param num_images: integer. The number of lensed positions to model.
     '''
     _kwargs_lower = {'ra_image': -100, 'dec_image': -100, }
     _kwargs_upper = {'ra_image': 100, 'dec_image': 100, }
@@ -34,9 +36,12 @@ class SourceAmp(SingleParam):
     _kwargs_upper = {'source_amp': 100}
 
 
-class PointAmp(ArrayParam):
+class ImageAmp(ArrayParam):
     '''
-    Point amplification, possibly many
+    Observed amplification of lensed images of a point source. Can model
+    arbitrarily many magnified images
+
+    :param fixed_magnification: integer. The number of lensed images with known magnification to fit.
     '''
     _kwargs_lower = {'point_amp': 0}
     _kwargs_upper = {'point_amp': 100}
@@ -88,7 +93,7 @@ class PointSourceParam(object):
             if fixed_magnification_list[i] and model in ['LENSED_POSITION', 'SOURCE_POSITION']:
                 params.append(SourceAmp(True))
             else:
-                params.append(PointAmp(num))
+                params.append(ImageAmp(num))
 
             self.param_groups.append(params)
 
@@ -96,16 +101,16 @@ class PointSourceParam(object):
             kwargs_lower = []
             for model_params in self.param_groups:
                 fixed_lower = {}
-                for grp in model_params:
-                    fixed_lower = dict(fixed_lower, **grp.kwargs_lower)
+                for param_group in model_params:
+                    fixed_lower = dict(fixed_lower, **param_group.kwargs_lower)
                 kwargs_lower.append(fixed_lower)
 
         if kwargs_upper is None:
             kwargs_upper = []
             for model_params in self.param_groups:
                 fixed_upper = {}
-                for grp in model_params:
-                    fixed_upper = dict(fixed_upper, **grp.kwargs_upper)
+                for param_group in model_params:
+                    fixed_upper = dict(fixed_upper, **param_group.kwargs_upper)
                 kwargs_upper.append(fixed_upper)
 
         self.lower_limit = kwargs_lower

--- a/lenstronomy/PointSource/point_source_param.py
+++ b/lenstronomy/PointSource/point_source_param.py
@@ -41,13 +41,13 @@ class ImageAmp(ArrayParam):
     Observed amplification of lensed images of a point source. Can model
     arbitrarily many magnified images
 
-    :param fixed_magnification: integer. The number of lensed images with known magnification to fit.
+    :param num_point_sources: integer. The number of lensed images without fixed magnification.
     '''
     _kwargs_lower = {'point_amp': 0}
     _kwargs_upper = {'point_amp': 100}
-    def __init__(self, fixed_magnification):
-        self.on = int(fixed_magnification) > 0
-        self.param_names = {'point_amp': int(fixed_magnification)}
+    def __init__(self, num_point_sources):
+        self.on = int(num_point_sources) > 0
+        self.param_names = {'point_amp': int(num_point_sources)}
 
 
 class PointSourceParam(object):

--- a/lenstronomy/PointSource/point_source_param.py
+++ b/lenstronomy/PointSource/point_source_param.py
@@ -2,16 +2,22 @@ import numpy as np
 
 __all__ = ['PointSourceParam']
 
-from ..Sampling.param_group import ModelParamGroup, SingleParam, ArrayParam
+from lenstronomy.Sampling.param_group import ModelParamGroup, SingleParam, ArrayParam
 
 
 class SourcePositionParam(SingleParam):
+    '''
+    Source position parameter, ra_source and dec_source
+    '''
     param_names = ['ra_source', 'dec_source']
     _kwargs_lower = {'ra_source': -100, 'dec_source': -100}
     _kwargs_upper = {'ra_source': 100, 'dec_source': 100}
 
 
 class LensedPosition(ArrayParam):
+    '''
+    Represents lensed positions, possibly many. ra_image and dec_image
+    '''
     _kwargs_lower = {'ra_image': -100, 'dec_image': -100, }
     _kwargs_upper = {'ra_image': 100, 'dec_image': 100, }
     def __init__(self, num_images):
@@ -20,12 +26,18 @@ class LensedPosition(ArrayParam):
 
 
 class SourceAmp(SingleParam):
+    '''
+    Source amplification
+    '''
     param_names = ['source_amp']
     _kwargs_lower = {'source_amp': 0}
     _kwargs_upper = {'source_amp': 100}
 
 
 class PointAmp(ArrayParam):
+    '''
+    Point amplification, possibly many
+    '''
     _kwargs_lower = {'point_amp': 0}
     _kwargs_upper = {'point_amp': 100}
     def __init__(self, fixed_magnification):
@@ -35,7 +47,7 @@ class PointAmp(ArrayParam):
 
 class PointSourceParam(object):
     """
-
+    Point source parameters
     """
 
     def __init__(self, model_list, kwargs_fixed, num_point_source_list=None, linear_solver=True,

--- a/lenstronomy/PointSource/point_source_param.py
+++ b/lenstronomy/PointSource/point_source_param.py
@@ -23,7 +23,7 @@ class LensedPosition(ArrayParam):
     _kwargs_lower = {'ra_image': -100, 'dec_image': -100, }
     _kwargs_upper = {'ra_image': 100, 'dec_image': 100, }
     def __init__(self, num_images):
-        self.on = int(num_images) > 0
+        super().__init__(int(num_images) > 0)
         self.param_names = {'ra_image': int(num_images), 'dec_image': int(num_images)}
 
 
@@ -46,7 +46,7 @@ class ImageAmp(ArrayParam):
     _kwargs_lower = {'point_amp': 0}
     _kwargs_upper = {'point_amp': 100}
     def __init__(self, num_point_sources):
-        self.on = int(num_point_sources) > 0
+        super().__init__(int(num_point_sources) > 0)
         self.param_names = {'point_amp': int(num_point_sources)}
 
 

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -1,0 +1,151 @@
+
+
+
+class ModelParamGroup:
+    def num_params(self):
+        raise NotImplementedError
+
+    def set_params(self, kwargs):
+        raise NotImplementedError
+
+    def get_params(self, args, i):
+        raise NotImplementedError
+
+    @staticmethod
+    def compose_num_params(each_group, *args, **kwargs):
+        tot_param = 0
+        param_names = []
+        for group in each_group:
+            npar, names = group.num_params(*args, **kwargs)
+            tot_param += npar
+            param_names += names
+        return tot_param, param_names
+
+    @staticmethod
+    def compose_set_params(each_group, param_kwargs, *args, **kwargs):
+        output_args = []
+        for group in each_group:
+            output_args += group.set_params(param_kwargs, *args, **kwargs)
+        return output_args
+
+    @staticmethod
+    def compose_get_params(each_group, flat_args, i, *args, **kwargs):
+        output_kwargs = {}
+        for group in each_group:
+            kwargs_grp, i = group.get_params(flat_args, i, *args, **kwargs)
+            output_kwargs = dict(output_kwargs, **kwargs_grp)
+        return output_kwargs, i
+
+class SingleParam(ModelParamGroup):
+    '''
+    Helper for handling parameters in the SpecialGroup.
+
+    Internal use, please ignore. Check below for the actual definitions of special parameters.
+    '''
+    def __init__(self, on):
+        self.on = bool(on)
+
+    def num_params(self, kwargs_fixed):
+        if self.on:
+            npar, names = 0, []
+            for name in self.param_names:
+                if name not in kwargs_fixed:
+                    npar += 1
+                    names.append(name)
+            return npar, names
+        return 0, []
+
+    def set_params(self, kwargs, kwargs_fixed):
+        if self.on:
+            output = []
+            for name in self.param_names:
+                if name not in kwargs_fixed:
+                    output.append(kwargs[name])
+            return output
+        return []
+
+    def get_params(self, args, i, kwargs_fixed):
+        out = {}
+        if self.on:
+            for name in self.param_names:
+                if name in kwargs_fixed:
+                    out[name] = kwargs_fixed[name]
+                else:
+                    out[name] = args[i]
+                    i += 1
+        return out, i
+
+    @property
+    def kwargs_lower(self):
+        if not self.on:
+            return {}
+        return self._kwargs_lower
+
+    @property
+    def kwargs_upper(self):
+        if not self.on:
+            return {}
+        return self._kwargs_upper
+
+class ArrayParam(ModelParamGroup):
+    '''
+    Helper for handling parameters in the SpecialGroup.
+
+    Internal use, please ignore. Check below for the actual definitions of special parameters.
+    '''
+    def num_params(self, kwargs_fixed):
+        if not self.on:
+            return 0, []
+
+        npar = 0
+        names = []
+        for name, count in self.param_names.items():
+            if name not in kwargs_fixed:
+                npar += count
+                names += [name] * count
+
+        return npar, names
+
+    def set_params(self, kwargs, kwargs_fixed):
+        if not self.on:
+            return []
+
+        args = []
+        for name, count in self.param_names.items():
+            if name not in kwargs_fixed:
+                args.extend(kwargs[name])
+        return args
+
+    def get_params(self, args, i, kwargs_fixed):
+        if not self.on:
+            return {}, i
+
+        params = {}
+        for name, count in self.param_names.items():
+            if name not in kwargs_fixed:
+                params[name] = args[i:i + count]
+                i += count
+            else:
+                params[name] = kwargs_fixed[name]
+
+        return params, i
+
+    @property
+    def kwargs_lower(self):
+        if not self.on:
+            return {}
+
+        out = {}
+        for name, count in self.param_names.items():
+            out[name] = [self._kwargs_lower[name]] * count
+        return out
+
+    @property
+    def kwargs_upper(self):
+        if not self.on:
+            return {}
+
+        out = {}
+        for name, count in self.param_names.items():
+            out[name] = [self._kwargs_upper[name]] * count
+        return out

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -142,7 +142,7 @@ class SingleParam(ModelParamGroup):
 
     def num_params(self, kwargs_fixed):
         '''
-        Tells the number of parameters that this group samples and theri names.
+        Tells the number of parameters that this group samples and their names.
 
         :param kwargs_fixed: Dictionary of fixed arguments
         :type kwargs_fixed: dict
@@ -245,7 +245,7 @@ class ArrayParam(ModelParamGroup):
 
     def num_params(self, kwargs_fixed):
         '''
-        Tells the number of parameters that this group samples and theri names.
+        Tells the number of parameters that this group samples and their names.
 
         :param kwargs_fixed: Dictionary of fixed arguments
         :type kwargs_fixed: dict

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -23,7 +23,7 @@ class ModelParamGroup:
     '''
     def num_params(self):
         '''
-        Tells the number of parameters that this group samples and theri names.
+        Tells the number of parameters that this group samples and their names.
 
         :returns: 2-tuple of (num param, list of names)
         '''
@@ -134,7 +134,11 @@ class SingleParam(ModelParamGroup):
     :param _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
     def __init__(self, on):
-        self.on = bool(on)
+        '''
+        :param on: Whether this paramter should be sampled
+        :type on: bool
+        '''
+        self._on = bool(on)
 
     def num_params(self, kwargs_fixed):
         '''
@@ -213,6 +217,10 @@ class SingleParam(ModelParamGroup):
             return {}
         return self._kwargs_upper
 
+    @property
+    def on(self):
+        return self._on
+
 
 class ArrayParam(ModelParamGroup):
     '''
@@ -228,6 +236,13 @@ class ArrayParam(ModelParamGroup):
     :param _kwargs_lower: Dictionary. Lower bounds of each parameter
     :param _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
+    def __init__(self, on):
+        '''
+        :param on: Whether this paramter should be sampled
+        :type on: bool
+        '''
+        self._on = bool(on)
+
     def num_params(self, kwargs_fixed):
         '''
         Tells the number of parameters that this group samples and theri names.
@@ -319,3 +334,7 @@ class ArrayParam(ModelParamGroup):
         for name, count in self.param_names.items():
             out[name] = [self._kwargs_upper[name]] * count
         return out
+
+    @property
+    def on(self):
+        return self._on

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -1,12 +1,11 @@
-__author__ = 'jhodonnell'
-__all__ = ['ModelParamGroup', 'SingleParam', 'ArrayParam']
-
-
 '''
 This module provides helper classes for managing sample parameters. This is
 for internal use, if you are not modifying lenstronomy sampling to include
 new parameters you can safely ignore this.
 '''
+
+__author__ = 'jhodonnell'
+__all__ = ['ModelParamGroup', 'SingleParam', 'ArrayParam']
 
 
 class ModelParamGroup:
@@ -49,6 +48,8 @@ class ModelParamGroup:
 
         :param args: flattened arguments to convert to lenstronomy format
         :type args: list
+        :param i: index to begin at in args
+        :type i: int
         :returns: dictionary of parameters
         '''
         raise NotImplementedError
@@ -136,6 +137,14 @@ class SingleParam(ModelParamGroup):
         self.on = bool(on)
 
     def num_params(self, kwargs_fixed):
+        '''
+        Tells the number of parameters that this group samples and theri names.
+
+        :param kwargs_fixed: Dictionary of fixed arguments
+        :type kwargs_fixed: dict
+
+        :returns: 2-tuple of (num param, list of names)
+        '''
         if self.on:
             npar, names = 0, []
             for name in self.param_names:
@@ -146,6 +155,20 @@ class SingleParam(ModelParamGroup):
         return 0, []
 
     def set_params(self, kwargs, kwargs_fixed):
+        '''
+        Converts lenstronomy semantic parameters in dictionary format into a
+        flattened array of parameters.
+
+        The flattened array is for use in optimization algorithms, e.g. MCMC,
+        Particle swarm, etc.
+
+        :param kwargs: lenstronomy parameters to flatten
+        :type kwargs: dict
+        :param kwargs_fixed: Dictionary of fixed arguments
+        :type kwargs_fixed: dict
+
+        :returns: flattened array of parameters as floats
+        '''
         if self.on:
             output = []
             for name in self.param_names:
@@ -155,6 +178,19 @@ class SingleParam(ModelParamGroup):
         return []
 
     def get_params(self, args, i, kwargs_fixed):
+        '''
+        Converts a flattened array of parameters back into a lenstronomy dictionary,
+        starting at index i.
+
+        :param args: flattened arguments to convert to lenstronomy format
+        :type args: list
+        :param i: index to begin at in args
+        :type i: int
+        :param kwargs_fixed: Dictionary of fixed arguments
+        :type kwargs_fixed: dict
+
+        :returns: dictionary of parameters
+        '''
         out = {}
         if self.on:
             for name in self.param_names:
@@ -193,6 +229,14 @@ class ArrayParam(ModelParamGroup):
     :param _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
     def num_params(self, kwargs_fixed):
+        '''
+        Tells the number of parameters that this group samples and theri names.
+
+        :param kwargs_fixed: Dictionary of fixed arguments
+        :type kwargs_fixed: dict
+
+        :returns: 2-tuple of (num param, list of names)
+        '''
         if not self.on:
             return 0, []
 
@@ -206,6 +250,20 @@ class ArrayParam(ModelParamGroup):
         return npar, names
 
     def set_params(self, kwargs, kwargs_fixed):
+        '''
+        Converts lenstronomy semantic parameters in dictionary format into a
+        flattened array of parameters.
+
+        The flattened array is for use in optimization algorithms, e.g. MCMC,
+        Particle swarm, etc.
+
+        :param kwargs: lenstronomy parameters to flatten
+        :type kwargs: dict
+        :param kwargs_fixed: Dictionary of fixed arguments
+        :type kwargs_fixed: dict
+
+        :returns: flattened array of parameters as floats
+        '''
         if not self.on:
             return []
 
@@ -216,6 +274,19 @@ class ArrayParam(ModelParamGroup):
         return args
 
     def get_params(self, args, i, kwargs_fixed):
+        '''
+        Converts a flattened array of parameters back into a lenstronomy dictionary,
+        starting at index i.
+
+        :param args: flattened arguments to convert to lenstronomy format
+        :type args: list
+        :param i: index to begin at in args
+        :type i: int
+        :param kwargs_fixed: Dictionary of fixed arguments
+        :type kwargs_fixed: dict
+
+        :returns: dictionary of parameters
+        '''
         if not self.on:
             return {}, i
 

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -19,7 +19,7 @@ class ModelParamGroup:
         '''
         Tells the number of parameters that this group samples and theri names.
 
-        returns: 2-tuple of (num param, list of names)
+        :returns: 2-tuple of (num param, list of names)
         '''
         raise NotImplementedError
 
@@ -30,6 +30,8 @@ class ModelParamGroup:
 
         The flattened array is for use in optimization algorithms, e.g. MCMC,
         Particle swarm, etc.
+
+        :returns: flattened array of parameters as floats
         '''
         raise NotImplementedError
 
@@ -38,13 +40,25 @@ class ModelParamGroup:
         Converts a flattened array of parameters back into a lenstronomy dictionary,
         starting at index i.
 
-        args: list of floats
-        returns: dictionary of parameters
+        :param args: flattened arguments to convert to lenstronomy format
+        :type args: list
+        :returns: dictionary of parameters
         '''
         raise NotImplementedError
 
     @staticmethod
     def compose_num_params(each_group, *args, **kwargs):
+        '''
+        Aggregates the number of parameters for a group of parameter groups,
+        calling each instance's `num_params()` method and combining the results
+
+        :param each_group: collection of parameter groups. Should each be subclasses of ModelParamGroup.
+        :type each_group: list
+        :param args: Extra arguments to be passed to each call of `num_params()`
+        :param kwargs: Extra keyword arguments to be passed to each call of `num_params()`
+
+        :returns: As in each individual `num_params()`, a 2-tuple of (num params, list of param names)
+        '''
         tot_param = 0
         param_names = []
         for group in each_group:
@@ -55,6 +69,20 @@ class ModelParamGroup:
 
     @staticmethod
     def compose_set_params(each_group, param_kwargs, *args, **kwargs):
+        '''
+        Converts lenstronomy semantic arguments in dictionary format to a
+        flattened list of floats for use in optimization/fitting algorithms.
+        Combines the results for a set of arbitrarily many parameter groups.
+
+        :param each_group: collection of parameter groups. Should each be subclasses of ModelParamGroup.
+        :type each_group: list
+        :param param_kwargs: the kwargs to process
+        :type param_kwargs: dict
+        :param args: Extra arguments to be passed to each call of `set_params()`
+        :param kwargs: Extra keyword arguments to be passed to each call of `set_params()`
+
+        :returns: As in each individual `set_params()`, a list of floats
+        '''
         output_args = []
         for group in each_group:
             output_args += group.set_params(param_kwargs, *args, **kwargs)
@@ -62,6 +90,22 @@ class ModelParamGroup:
 
     @staticmethod
     def compose_get_params(each_group, flat_args, i, *args, **kwargs):
+        '''
+        Converts a flattened array of parameters to lenstronomy semantic
+        parameters in dictionary format.
+        Combines the results for a set of arbitrarily many parameter groups.
+
+        :param each_group: collection of parameter groups. Should each be subclasses of ModelParamGroup.
+        :type each_group: list
+        :param flat_args: the input array of parameters
+        :type flat_args: list
+        :param i: the index in `flat_args` to start at
+        :type i: int
+        :param args: Extra arguments to be passed to each call of `set_params()`
+        :param kwargs: Extra keyword arguments to be passed to each call of `set_params()`
+
+        :returns: As in each individual `get_params()`, a 2-tuple of (dictionary of params, new index)
+        '''
         output_kwargs = {}
         for group in each_group:
             kwargs_grp, i = group.get_params(flat_args, i, *args, **kwargs)

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -1,14 +1,46 @@
-
+__author__ = 'jhodonnell'
+__all__ = ['ModelParamGroup', 'SingleParam', 'ArrayParam']
 
 
 class ModelParamGroup:
+    '''
+    This abstract class represents any lenstronomy fitting parameters used
+    in the Param class.
+
+    Subclasses should implement num_params(), set_params(), and get_params()
+    to convert parameters from lenstronomy's semantic dictionary format to a
+    flattened array format and back.
+
+    This class also contains three static methods to easily aggregate groups
+    of parameter classes, called `compose_num_params()`, `compose_set_params()`,
+    and `compose_get_params()`.
+    '''
     def num_params(self):
+        '''
+        Tells the number of parameters that this group samples and theri names.
+
+        returns: 2-tuple of (num param, list of names)
+        '''
         raise NotImplementedError
 
     def set_params(self, kwargs):
+        '''
+        Converts lenstronomy semantic parameters in dictionary format into a
+        flattened array of parameters.
+
+        The flattened array is for use in optimization algorithms, e.g. MCMC,
+        Particle swarm, etc.
+        '''
         raise NotImplementedError
 
     def get_params(self, args, i):
+        '''
+        Converts a flattened array of parameters back into a lenstronomy dictionary,
+        starting at index i.
+
+        args: list of floats
+        returns: dictionary of parameters
+        '''
         raise NotImplementedError
 
     @staticmethod
@@ -36,11 +68,17 @@ class ModelParamGroup:
             output_kwargs = dict(output_kwargs, **kwargs_grp)
         return output_kwargs, i
 
+
 class SingleParam(ModelParamGroup):
     '''
-    Helper for handling parameters in the SpecialGroup.
+    Helper for handling parameters which are a single float.
 
-    Internal use, please ignore. Check below for the actual definitions of special parameters.
+    Subclasses should define:
+
+    on: (bool) Whether this parameter is sampled
+    param_names: List of strings, the name of each parameter
+    _kwargs_lower: Dictionary. Lower bounds of each parameter
+    _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
     def __init__(self, on):
         self.on = bool(on)
@@ -89,9 +127,16 @@ class SingleParam(ModelParamGroup):
 
 class ArrayParam(ModelParamGroup):
     '''
-    Helper for handling parameters in the SpecialGroup.
+    Helper for handling parameters which are an array of values. Examples
+    include mass_scaling, which is an array of scaling parameters, and wavelet
+    or gaussian decompositions which have different coefficients for each mode.
 
-    Internal use, please ignore. Check below for the actual definitions of special parameters.
+    Subclasses should define:
+
+    on: (bool) Whether this parameter is sampled
+    param_names: Dictionary mapping the name of each parameter to the number of values needed.
+    _kwargs_lower: Dictionary. Lower bounds of each parameter
+    _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
     def num_params(self, kwargs_fixed):
         if not self.on:

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -2,6 +2,13 @@ __author__ = 'jhodonnell'
 __all__ = ['ModelParamGroup', 'SingleParam', 'ArrayParam']
 
 
+'''
+This module provides helper classes for managing sample parameters. This is
+for internal use, if you are not modifying lenstronomy sampling to include
+new parameters you can safely ignore this.
+'''
+
+
 class ModelParamGroup:
     '''
     This abstract class represents any lenstronomy fitting parameters used
@@ -119,10 +126,11 @@ class SingleParam(ModelParamGroup):
 
     Subclasses should define:
 
-    on: (bool) Whether this parameter is sampled
-    param_names: List of strings, the name of each parameter
-    _kwargs_lower: Dictionary. Lower bounds of each parameter
-    _kwargs_upper: Dictionary. Upper bounds of each parameter
+    :param on: Whether this parameter is sampled
+    :type on: bool
+    :param param_names: List of strings, the name of each parameter
+    :param _kwargs_lower: Dictionary. Lower bounds of each parameter
+    :param _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
     def __init__(self, on):
         self.on = bool(on)
@@ -169,6 +177,7 @@ class SingleParam(ModelParamGroup):
             return {}
         return self._kwargs_upper
 
+
 class ArrayParam(ModelParamGroup):
     '''
     Helper for handling parameters which are an array of values. Examples
@@ -177,10 +186,11 @@ class ArrayParam(ModelParamGroup):
 
     Subclasses should define:
 
-    on: (bool) Whether this parameter is sampled
-    param_names: Dictionary mapping the name of each parameter to the number of values needed.
-    _kwargs_lower: Dictionary. Lower bounds of each parameter
-    _kwargs_upper: Dictionary. Upper bounds of each parameter
+    :param on:  Whether this parameter is sampled
+    :type on: bool
+    :param param_names: Dictionary mapping the name of each parameter to the number of values needed.
+    :param _kwargs_lower: Dictionary. Lower bounds of each parameter
+    :param _kwargs_upper: Dictionary. Upper bounds of each parameter
     '''
     def num_params(self, kwargs_fixed):
         if not self.on:

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -47,6 +47,42 @@ class Param(object):
     'joint_lens_with_source_light': [[i_source, k_lens, ['param_name1', 'param_name2', ...]], [...], ...],
     joint parameter between lens model and source light model. Samples light model parameter only.
 
+    'mass_scaling_list': e.g. [False, 1, 1, False, 2, False, 1, ...]
+    Links lens models to have their masses scaled together. In this example,
+    masses with False are not scaled, masses labeled 1 are scaled together,
+    and those labeled 2 are scaled together independent of 1, etc.
+
+    'general_scaling': { 'param1': [False, 1, 1, False, 1, ...], 'param2': [1, 1, 1, False, 2, 2, ...] }
+    Generalized parameter scaling. Input should be a dictionary mapping
+    parameter names to the masks defining which lens models are scaled together,
+    in the same format as for 'mass_scaling_list'. For each scaled parameter,
+    two special params will be added called '${param}_scale_factor' and
+    '${param}_scale_pow', defining the scaling and power-law of each.
+
+    Each scale will be modified as `param = param_scale_factor * param**param_scale_pow`.
+
+    For example, if we want to jointly constrain the `sigma0` and `Rs` parameters
+    of some lens models, we can add:
+
+    ```
+    'general_scaling': {
+        'sigma0': [False]*num_halo + [1]*nmembers,
+        'Rs': [False]*num_halo + [1]*nmembers,
+    }
+    ```
+
+    Then we can choose to fix the power-law and vary the scale factor like so:
+
+    ```
+    fixed_special = {'sigma0_scale_pow': [alpha*2], 'Rs_scale_pow': [beta]}
+    kwargs_special_init = {'sigma0_scale_factor': [17.0], 'Rs_scale_factor': [8]}
+    kwargs_special_sigma = {'sigma0_scale_factor': [10.0], 'Rs_scale_factor': [3]}
+    kwargs_lower_special = {'sigma0_scale_factor': [0.5], 'Rs_scale_factor': [1]}
+    kwargs_upper_special = {'sigma0_scale_factor': [40], 'Rs_scale_factor': [20]}
+
+    special_params = [kwargs_special_init, kwargs_special_sigma, fixed_special, kwargs_lower_special, kwargs_upper_special]
+    ```
+
     hierarchy is as follows:
     1. Point source parameters are inferred
     2. Lens light joint parameters are set

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -670,6 +670,7 @@ class Param(object):
         num, param_list = self.num_param()
         num_linear = self.num_param_linear()
 
+        # TODO print settings of specailParams?
         print("The following model options are chosen:")
         print("Lens models:", self._lens_model_list)
         print("Source models:", self._source_light_model_list)

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -738,6 +738,8 @@ class Param(object):
         print("Joint lens with light:", self._joint_lens_with_light)
         print("Joint source with point source:", self._joint_source_with_point_source)
         print("Joint lens light with point source:", self._joint_lens_light_with_point_source)
+        print("Mass scaling:", self._num_scale_factor, "groups")
+        print("General lens scaling:", self._general_scaling_masks)
         print("===================")
         print("Number of non-linear parameters being sampled: ", num)
         print("Parameters being sampled: ", param_list)

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -51,7 +51,7 @@ class MassScalingParam(ArrayParam):
     _kwargs_lower = {'scale_factor': 0}
     _kwargs_upper = {'scale_factor': 1000}
     def __init__(self, num_scale_factor):
-        self.on = int(num_scale_factor) > 0
+        super().__init__(on=int(num_scale_factor) > 0)
         self.param_names = {'scale_factor': int(num_scale_factor)}
 
 
@@ -62,7 +62,7 @@ class PointSourceOffsetParam(ArrayParam):
     _kwargs_lower = {'delta_x_image': -1, 'delta_y_image': -1}
     _kwargs_upper = {'delta_x_image': 1, 'delta_y_image': 1}
     def __init__(self, offset, num_images):
-        self.on = offset and (int(num_images) > 0)
+        super().__init__(on=offset and (int(num_images) > 0))
         self.param_names = {
             'delta_x_image': int(num_images),
             'delta_y_image': int(num_images),
@@ -76,7 +76,7 @@ class Tau0ListParam(ArrayParam):
     _kwargs_lower = {'tau0_list': 0}
     _kwargs_upper = {'tau0_list': 1000}
     def __init__(self, num_tau0):
-        self.on = int(num_tau0) > 0
+        super().__init__(on=int(num_tau0) > 0)
         self.param_names = {'tau0_list': int(num_tau0)}
 
 
@@ -87,7 +87,7 @@ class ZSamplingParam(ArrayParam):
     _kwargs_lower = {'z_sampling': 0}
     _kwargs_upper = {'z_sampling': 1000}
     def __init__(self, num_z_sampling):
-        self.on = int(num_z_sampling) > 0
+        super().__init__(on=int(num_z_sampling) > 0)
         self.param_names = {'z_sampling': int(num_z_sampling)}
 
 
@@ -105,10 +105,8 @@ class GeneralScalingParam(ArrayParam):
         self._kwargs_lower = {}
         self._kwargs_upper = {}
 
-        if params:
-            self.on = True
-        else:
-            self.on = False
+        super().__init__(params)
+        if not self.on:
             return
 
         for name, array in params.items():

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -2,6 +2,80 @@ __author__ = 'sibirrer'
 
 __all__ = ['SpecialParam']
 
+from .param_group import ModelParamGroup, SingleParam, ArrayParam
+
+
+# ==================================== #
+# == Defining individual parameters == #
+# ==================================== #
+
+
+class DdtSamplingParam(SingleParam):
+    param_names = ['D_dt']
+    _kwargs_lower = {'D_dt': 0}
+    _kwargs_upper = {'D_dt': 100000}
+
+
+class SourceSizeParam(SingleParam):
+    param_names = ['source_size']
+    _kwargs_lower = {'source_size': 0}
+    _kwargs_upper = {'source_size': 1}
+
+
+class SourceGridOffsetParam(SingleParam):
+    param_names = ['delta_x_source_grid', 'delta_y_source_grid']
+    _kwargs_lower = {
+        'delta_x_source_grid': -100,
+        'delta_y_source_grid': -100
+    }
+    _kwargs_upper = {
+        'delta_x_source_grid': 100,
+        'delta_y_source_grid': 100
+    }
+
+
+class MassScalingParam(ArrayParam):
+    _kwargs_lower = {'scale_factor': 0}
+    _kwargs_upper = {'scale_factor': 1000}
+    def __init__(self, num_scale_factor):
+        self.on = int(num_scale_factor) > 0
+        self.param_names = {'scale_factor': int(num_scale_factor)}
+
+
+class PointSourceOffsetParam(ArrayParam):
+    _kwargs_lower = {'delta_x_image': -1, 'delta_y_image': -1}
+    _kwargs_upper = {'delta_x_image': 1, 'delta_y_image': 1}
+    def __init__(self, offset, num_images):
+        self.on = offset and (int(num_images) > 0)
+        self.param_names = {
+            'delta_x_image': int(num_images),
+            'delta_y_image': int(num_images),
+        }
+
+
+class Tau0ListParam(ArrayParam):
+    _kwargs_lower = {'tau0_list': 0}
+    _kwargs_upper = {'tau0_list': 1000}
+    def __init__(self, num_tau0):
+        self.on = int(num_tau0) > 0
+        self.param_names = {'tau0_list': int(num_tau0)}
+
+
+class ZSamplingParam(ArrayParam):
+    _kwargs_lower = {'z_sampling': 0}
+    _kwargs_upper = {'z_sampling': 1000}
+    def __init__(self, num_z_sampling):
+        self.on = int(num_z_sampling) > 0
+        self.param_names = {'z_sampling': int(num_z_sampling)}
+
+
+
+
+# ======================================== #
+# == All together: Composing into class == #
+# ======================================== #
+
+
 
 class SpecialParam(object):
     """
@@ -32,59 +106,31 @@ class SpecialParam(object):
          Warning: this is only defined for pixel-based source modelling (e.g. 'SLIT_STARLETS' light profile)
         """
 
-        self._D_dt_sampling = Ddt_sampling
-        self._mass_scaling = mass_scaling
-        self._num_scale_factor = num_scale_factor
-        self._point_source_offset = point_source_offset
-        self._num_images = num_images
-        self._num_tau0 = num_tau0
-        self._num_z_sampling = num_z_sampling
-        if num_z_sampling > 0:
-            self._z_sampling = True
-        else:
-            self._z_sampling = False
+        self._D_dt_sampling = DdtSamplingParam(Ddt_sampling)
+        # FIXME mass_scaling argument now unused
+        if not mass_scaling:
+            num_scale_factor = 0
+        self._mass_scaling = MassScalingParam(num_scale_factor)
+        # FIXME point_source_offset argument now unused
+        self._point_source_offset = PointSourceOffsetParam(point_source_offset, num_images)
+        self._source_size = SourceSizeParam(source_size)
+        self._tau0 = Tau0ListParam(num_tau0)
+        self._z_sampling = ZSamplingParam(num_z_sampling)
+        self._source_grid_offset = SourceGridOffsetParam(source_grid_offset)
 
         if kwargs_fixed is None:
             kwargs_fixed = {}
         self._kwargs_fixed = kwargs_fixed
-        self._source_size = source_size
-        self._source_grid_offset = source_grid_offset
+
         if kwargs_lower is None:
             kwargs_lower = {}
-            if self._D_dt_sampling is True:
-                kwargs_lower['D_dt'] = 0
-            if self._mass_scaling is True:
-                kwargs_lower['scale_factor'] = [0] * self._num_scale_factor
-            if self._point_source_offset is True:
-                kwargs_lower['delta_x_image'] = [-1] * self._num_images
-                kwargs_lower['delta_y_image'] = [-1] * self._num_images
-            if self._source_size is True:
-                kwargs_lower['source_size'] = 0
-            if self._num_tau0 > 0:
-                kwargs_lower['tau0_list'] = [0] * self._num_tau0
-            if self._z_sampling is True:
-                kwargs_lower['z_sampling'] = [0] * self._num_z_sampling
-            if self._source_grid_offset:
-                kwargs_lower['delta_x_source_grid'] = -100
-                kwargs_lower['delta_y_source_grid'] = -100
+            for group in self._param_groups:
+                kwargs_lower = dict(kwargs_lower, **group.kwargs_lower)
         if kwargs_upper is None:
             kwargs_upper = {}
-            if self._D_dt_sampling is True:
-                kwargs_upper['D_dt'] = 100000
-            if self._mass_scaling is True:
-                kwargs_upper['scale_factor'] = [1000] * self._num_scale_factor
-            if self._point_source_offset is True:
-                kwargs_upper['delta_x_image'] = [1] * self._num_images
-                kwargs_upper['delta_y_image'] = [1] * self._num_images
-            if self._source_size is True:
-                kwargs_upper[source_size] = 1
-            if self._num_tau0 > 0:
-                kwargs_upper['tau0_list'] = [1000] * self._num_tau0
-            if self._z_sampling is True:
-                kwargs_upper['z_sampling'] = [20] * self._num_z_sampling
-            if self._source_grid_offset:
-                kwargs_upper['delta_x_source_grid'] = 100
-                kwargs_upper['delta_y_source_grid'] = 100
+            for group in self._param_groups:
+                kwargs_upper = dict(kwargs_upper, **group.kwargs_upper)
+
         self.lower_limit = kwargs_lower
         self.upper_limit = kwargs_upper
 
@@ -95,60 +141,10 @@ class SpecialParam(object):
         :param i: integer, list index to start the read out for this class
         :return: keyword arguments related to args, index after reading out arguments of this class
         """
-        kwargs_special = {}
-        if self._D_dt_sampling is True:
-            if 'D_dt' not in self._kwargs_fixed:
-                kwargs_special['D_dt'] = args[i]
-                i += 1
-            else:
-                kwargs_special['D_dt'] = self._kwargs_fixed['D_dt']
-        if self._mass_scaling is True:
-            if 'scale_factor' not in self._kwargs_fixed:
-                kwargs_special['scale_factor'] = args[i: i + self._num_scale_factor]
-                i += self._num_scale_factor
-            else:
-                kwargs_special['scale_factor'] = self._kwargs_fixed['scale_factor']
-        if self._point_source_offset is True:
-            if 'delta_x_image' not in self._kwargs_fixed:
-                kwargs_special['delta_x_image'] = args[i: i + self._num_images]
-                i += self._num_images
-            else:
-                kwargs_special['delta_x_image'] = self._kwargs_fixed['delta_x_image']
-            if 'delta_y_image' not in self._kwargs_fixed:
-                kwargs_special['delta_y_image'] = args[i: i + self._num_images]
-                i += self._num_images
-            else:
-                kwargs_special['delta_y_image'] = self._kwargs_fixed['delta_y_image']
-        if self._source_size is True:
-            if 'source_size' not in self._kwargs_fixed:
-                kwargs_special['source_size'] = args[i]
-                i += 1
-            else:
-                kwargs_special['source_size'] = self._kwargs_fixed['source_size']
-        if self._num_tau0 > 0:
-            if 'tau0_list' not in self._kwargs_fixed:
-                kwargs_special['tau0_list'] = args[i:i + self._num_tau0]
-                i += self._num_tau0
-            else:
-                kwargs_special['tau0_list'] = self._kwargs_fixed['tau0_list']
-        if self._z_sampling is True:
-            if 'z_sampling' not in self._kwargs_fixed:
-                kwargs_special['z_sampling'] = args[i:i + self._num_z_sampling]
-                i += self._num_z_sampling
-            else:
-                kwargs_special['z_sampling'] = self._kwargs_fixed['z_sampling']
-        if self._source_grid_offset:
-            if 'delta_x_source_grid' not in self._kwargs_fixed:
-                kwargs_special['delta_x_source_grid'] = args[i]
-                i += 1
-            else:
-                kwargs_special['delta_x_source_grid'] = self._kwargs_fixed['delta_x_source_grid']
-            if 'delta_y_source_grid' not in self._kwargs_fixed:
-                kwargs_special['delta_y_source_grid'] = args[i]
-                i += 1
-            else:
-                kwargs_special['delta_y_source_grid'] = self._kwargs_fixed['delta_y_source_grid']
-        return kwargs_special, i
+        result = ModelParamGroup.compose_get_params(
+            self._param_groups, args, i, kwargs_fixed=self._kwargs_fixed
+        )
+        return result
 
     def set_params(self, kwargs_special):
         """
@@ -156,83 +152,25 @@ class SpecialParam(object):
         :param kwargs_special: keyword arguments with parameter settings
         :return: argument list of the sampled parameters extracted from kwargs_special
         """
-        args = []
-        if self._D_dt_sampling is True:
-            if 'D_dt' not in self._kwargs_fixed:
-                args.append(kwargs_special['D_dt'])
-        if self._mass_scaling is True:
-            if 'scale_factor' not in self._kwargs_fixed:
-                for i in range(self._num_scale_factor):
-                    args.append(kwargs_special['scale_factor'][i])
-        if self._point_source_offset is True:
-            if 'delta_x_image' not in self._kwargs_fixed:
-                for i in range(self._num_images):
-                    args.append(kwargs_special['delta_x_image'][i])
-            if 'delta_y_image' not in self._kwargs_fixed:
-                for i in range(self._num_images):
-                    args.append(kwargs_special['delta_y_image'][i])
-        if self._source_size is True:
-            if 'source_size' not in self._kwargs_fixed:
-                args.append(kwargs_special['source_size'])
-        if self._num_tau0 > 0:
-            if 'tau0_list' not in self._kwargs_fixed:
-                for i in range(self._num_tau0):
-                    args.append(kwargs_special['tau0_list'][i])
-        if self._z_sampling is True:
-            if 'z_sampling' not in self._kwargs_fixed:
-                for i in range(self._num_z_sampling):
-                    args.append(kwargs_special['z_sampling'][i])
-        if self._source_grid_offset is True:
-            if 'delta_x_source_grid' not in self._kwargs_fixed:
-                args.append(kwargs_special['delta_x_source_grid'])
-            if 'delta_y_source_grid' not in self._kwargs_fixed:
-                args.append(kwargs_special['delta_y_source_grid'])
-        return args
+        return ModelParamGroup.compose_set_params(
+            self._param_groups, kwargs_special, kwargs_fixed=self._kwargs_fixed
+        )
 
     def num_param(self):
         """
 
         :return: integer, number of free parameters sampled (and managed) by this class, parameter names (list of strings)
         """
-        num = 0
-        string_list = []
-        if self._D_dt_sampling is True:
-            if 'D_dt' not in self._kwargs_fixed:
-                num += 1
-                string_list.append('D_dt')
-        if self._mass_scaling is True:
-            if 'scale_factor' not in self._kwargs_fixed:
-                num += self._num_scale_factor
-                for i in range(self._num_scale_factor):
-                    string_list.append('scale_factor')
-        if self._point_source_offset is True:
-            if 'delta_x_image' not in self._kwargs_fixed:
-                num += self._num_images
-                for i in range(self._num_images):
-                    string_list.append('delta_x_image')
-            if 'delta_y_image' not in self._kwargs_fixed:
-                num += self._num_images
-                for i in range(self._num_images):
-                    string_list.append('delta_y_image')
-        if self._source_size is True:
-            if 'source_size' not in self._kwargs_fixed:
-                num += 1
-                string_list.append('source_size')
-        if self._num_tau0 > 0:
-            if 'tau0_list' not in self._kwargs_fixed:
-                num += self._num_tau0
-                for i in range(self._num_tau0):
-                    string_list.append('tau0')
-        if self._z_sampling is True:
-            if 'z_sampling' not in self._kwargs_fixed:
-                num += self._num_z_sampling
-                for i in range(self._num_z_sampling):
-                    string_list.append('z')
-        if self._source_grid_offset is True:
-            if 'delta_x_source_grid' not in self._kwargs_fixed:
-                num += 1
-                string_list.append('delta_x_source_grid')
-            if 'delta_y_source_grid' not in self._kwargs_fixed:
-                num += 1
-                string_list.append('delta_y_source_grid')
-        return num, string_list
+        return ModelParamGroup.compose_num_params(
+            self._param_groups, kwargs_fixed=self._kwargs_fixed
+        )
+
+    @property
+    def _param_groups(self):
+        return [self._D_dt_sampling,
+                self._mass_scaling,
+                self._point_source_offset,
+                self._source_size,
+                self._tau0,
+                self._z_sampling,
+                self._source_grid_offset]

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -12,18 +12,27 @@ from .param_group import ModelParamGroup, SingleParam, ArrayParam
 
 
 class DdtSamplingParam(SingleParam):
+    '''
+    Time delay parameter
+    '''
     param_names = ['D_dt']
     _kwargs_lower = {'D_dt': 0}
     _kwargs_upper = {'D_dt': 100000}
 
 
 class SourceSizeParam(SingleParam):
+    '''
+    Source size parameter
+    '''
     param_names = ['source_size']
     _kwargs_lower = {'source_size': 0}
     _kwargs_upper = {'source_size': 1}
 
 
 class SourceGridOffsetParam(SingleParam):
+    '''
+    Source grid offset, both x and y.
+    '''
     param_names = ['delta_x_source_grid', 'delta_y_source_grid']
     _kwargs_lower = {
         'delta_x_source_grid': -100,
@@ -36,6 +45,9 @@ class SourceGridOffsetParam(SingleParam):
 
 
 class MassScalingParam(ArrayParam):
+    '''
+    Mass scaling. Can scale the masses of arbitrary subsets of lens models
+    '''
     _kwargs_lower = {'scale_factor': 0}
     _kwargs_upper = {'scale_factor': 1000}
     def __init__(self, num_scale_factor):
@@ -44,6 +56,9 @@ class MassScalingParam(ArrayParam):
 
 
 class PointSourceOffsetParam(ArrayParam):
+    '''
+    Point source offset, both x and y
+    '''
     _kwargs_lower = {'delta_x_image': -1, 'delta_y_image': -1}
     _kwargs_upper = {'delta_x_image': 1, 'delta_y_image': 1}
     def __init__(self, offset, num_images):
@@ -55,6 +70,9 @@ class PointSourceOffsetParam(ArrayParam):
 
 
 class Tau0ListParam(ArrayParam):
+    '''
+    Optical depth renormalization parameters
+    '''
     _kwargs_lower = {'tau0_list': 0}
     _kwargs_upper = {'tau0_list': 1000}
     def __init__(self, num_tau0):
@@ -63,6 +81,9 @@ class Tau0ListParam(ArrayParam):
 
 
 class ZSamplingParam(ArrayParam):
+    '''
+    Redshift sampling.
+    '''
     _kwargs_lower = {'z_sampling': 0}
     _kwargs_upper = {'z_sampling': 1000}
     def __init__(self, num_z_sampling):
@@ -71,9 +92,13 @@ class ZSamplingParam(ArrayParam):
 
 
 class GeneralScalingParam(ArrayParam):
-    # Mass scaling needs:
-    #   - name of scaled param
-    #   - number of scaled params
+    '''
+    General lens scaling.
+
+    For each scaled lens parameter, adds a `{param}_scale_factor` and
+    `{param}_scale_pow` special parameter, and updates the scaled param
+    as `param = param_scale_factor * param**param_scale_pow`.
+    '''
     def __init__(self, params: dict):
         # params is a dictionary
         self.param_names = {}

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -107,12 +107,13 @@ class SpecialParam(object):
         """
 
         self._D_dt_sampling = DdtSamplingParam(Ddt_sampling)
-        # FIXME mass_scaling argument now unused
         if not mass_scaling:
             num_scale_factor = 0
         self._mass_scaling = MassScalingParam(num_scale_factor)
-        # FIXME point_source_offset argument now unused
-        self._point_source_offset = PointSourceOffsetParam(point_source_offset, num_images)
+        if point_source_offset:
+            self._point_source_offset = PointSourceOffsetParam(True, num_images)
+        else:
+            self._point_source_offset = PointSourceOffsetParam(False, 0)
         self._source_size = SourceSizeParam(source_size)
         self._tau0 = Tau0ListParam(num_tau0)
         self._z_sampling = ZSamplingParam(num_z_sampling)

--- a/lenstronomy/Workflow/update_manager.py
+++ b/lenstronomy/Workflow/update_manager.py
@@ -300,9 +300,7 @@ class UpdateManager(object):
         if special_add_fixed is None:
             special_add_fixed = []
         for param_name in special_add_fixed:
-            if param_name in special_fixed:
-                pass
-            else:
+            if param_name not in special_fixed:
                 special_fixed[param_name] = special_temp[param_name]
         if special_remove_fixed is None:
             special_remove_fixed = []

--- a/test/test_Sampling/test_param_groups.py
+++ b/test/test_Sampling/test_param_groups.py
@@ -22,9 +22,6 @@ class ExampleArrayParam(ArrayParam):
     _kwargs_lower = {'ap1': [0], 'ap2': [0]*3}
     _kwargs_upper = {'ap1': [10], 'ap2': [10]*3}
 
-    def __init__(self, on):
-        self.on = bool(on)
-
 
 class TestParamGroup(object):
     def setup(self):

--- a/test/test_Sampling/test_param_groups.py
+++ b/test/test_Sampling/test_param_groups.py
@@ -1,0 +1,91 @@
+__author__ = 'jhodonnell'
+
+
+import numpy as np
+import numpy.testing as npt
+import unittest
+import pytest
+
+from lenstronomy.Sampling.param_group import (
+        ModelParamGroup, SingleParam, ArrayParam
+    )
+
+
+class ExampleSingleParam(SingleParam):
+    param_names = ['sp1', 'sp2']
+    _kwargs_lower = {'sp1': 0, 'sp2': 0}
+    _kwargs_upper = {'sp1': 10, 'sp2': 10}
+
+
+class ExampleArrayParam(ArrayParam):
+    param_names = {'ap1': 1, 'ap2': 3}
+    _kwargs_lower = {'ap1': [0], 'ap2': [0]*3}
+    _kwargs_upper = {'ap1': [10], 'ap2': [10]*3}
+
+    def __init__(self, on):
+        self.on = bool(on)
+
+
+class TestParamGroup(object):
+    def setup(self):
+        pass
+
+    def test_single_param(self):
+        sp = ExampleSingleParam(on=True)
+
+        num, names = sp.num_params({})
+        assert num == 2
+        assert names == ['sp1', 'sp2']
+
+        result = sp.set_params({'sp1': 2}, {'sp2': 3})
+        assert result == [2]
+
+        result = sp.set_params({'sp1': 2, 'sp2': 3}, {})
+        assert result == [2, 3]
+
+        kwargs, i = sp.get_params(result, i=0, kwargs_fixed={})
+        assert kwargs['sp1'] == 2
+        assert kwargs['sp2'] == 3
+
+    def test_array_param(self):
+        ap = ExampleArrayParam(on=True)
+
+        num, names = ap.num_params({})
+        assert num == 4
+        assert names == ['ap1'] + ['ap2']*3
+
+        result = ap.set_params({'ap1': [2]}, {'ap2': [1, 1, 1]})
+        assert result == [2]
+
+        result = ap.set_params({'ap1': [2], 'ap2': [1, 2, 3]}, {})
+        assert result == [2, 1, 2, 3]
+
+        kwargs, i = ap.get_params(result, i=0, kwargs_fixed={})
+        assert kwargs['ap1'] == [2]
+        assert kwargs['ap2'] == [1, 2, 3]
+
+    def test_compose(self):
+        sp = ExampleSingleParam(on=True)
+        ap = ExampleArrayParam(on=True)
+
+        num, names = ModelParamGroup.compose_num_params([sp, ap], kwargs_fixed={})
+        assert num == 6
+        assert names == sp.num_params({})[1] + ap.num_params({})[1]
+
+        result = ModelParamGroup.compose_set_params(
+            [sp, ap],
+            {
+                'sp1': 1, 'sp2': 2,
+                'ap1': [3], 'ap2': [4, 5, 6]
+            },
+            kwargs_fixed={}
+        )
+        assert result == [1, 2, 3, 4, 5, 6]
+
+        kwargs, i = ModelParamGroup.compose_get_params([sp, ap], result, i=0, kwargs_fixed={})
+        assert kwargs['sp1'] == 1
+        assert kwargs['ap2'] == [4, 5, 6]
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -192,23 +192,23 @@ class TestParam(object):
         kwargs_return = param_class.args2kwargs(args)
         kwargs_lens = kwargs_return['kwargs_lens']
         print('kwargs_lens:', kwargs_lens)
-        np.testing.assert_almost_equal(kwargs_lens[0]['Rs'], 2.0 * 2.0**1.1)
-        np.testing.assert_almost_equal(kwargs_lens[0]['sigma0'], 3)
-        np.testing.assert_almost_equal(kwargs_lens[1]['Rs'], 3.0)
-        np.testing.assert_almost_equal(kwargs_lens[1]['sigma0'], 3.0 * 2.0**2.0)
-        np.testing.assert_almost_equal(kwargs_lens[2]['alpha_Rs'], 0.3 * 0.1**0.5)
-        np.testing.assert_almost_equal(kwargs_lens[3]['Rs'], 2.0 * 1.5**1.1)
-        np.testing.assert_almost_equal(kwargs_lens[3]['sigma0'], 3.0 * 3**2.0)
-        np.testing.assert_almost_equal(kwargs_lens[4]['alpha_Rs'], 0.3 * 4**0.5)
+        npt.assert_almost_equal(kwargs_lens[0]['Rs'], 2.0 * 2.0**1.1)
+        npt.assert_almost_equal(kwargs_lens[0]['sigma0'], 3)
+        npt.assert_almost_equal(kwargs_lens[1]['Rs'], 3.0)
+        npt.assert_almost_equal(kwargs_lens[1]['sigma0'], 3.0 * 2.0**2.0)
+        npt.assert_almost_equal(kwargs_lens[2]['alpha_Rs'], 0.3 * 0.1**0.5)
+        npt.assert_almost_equal(kwargs_lens[3]['Rs'], 2.0 * 1.5**1.1)
+        npt.assert_almost_equal(kwargs_lens[3]['sigma0'], 3.0 * 3**2.0)
+        npt.assert_almost_equal(kwargs_lens[4]['alpha_Rs'], 0.3 * 4**0.5)
 
         kwargs_return = param_class.args2kwargs(args, bijective=True)
         kwargs_lens = kwargs_return['kwargs_lens']
-        np.testing.assert_almost_equal(kwargs_lens[0]['Rs'], 2.0)
-        np.testing.assert_almost_equal(kwargs_lens[1]['sigma0'], 2.0)
-        np.testing.assert_almost_equal(kwargs_lens[2]['alpha_Rs'], 0.1)
-        np.testing.assert_almost_equal(kwargs_lens[3]['Rs'], 1.5)
-        np.testing.assert_almost_equal(kwargs_lens[3]['sigma0'], 3)
-        np.testing.assert_almost_equal(kwargs_lens[4]['alpha_Rs'], 4)
+        npt.assert_almost_equal(kwargs_lens[0]['Rs'], 2.0)
+        npt.assert_almost_equal(kwargs_lens[1]['sigma0'], 2.0)
+        npt.assert_almost_equal(kwargs_lens[2]['alpha_Rs'], 0.1)
+        npt.assert_almost_equal(kwargs_lens[3]['Rs'], 1.5)
+        npt.assert_almost_equal(kwargs_lens[3]['sigma0'], 3)
+        npt.assert_almost_equal(kwargs_lens[4]['alpha_Rs'], 4)
 
     def test_joint_lens_with_light(self):
         kwargs_model = {'lens_model_list': ['CHAMELEON'], 'lens_light_model_list': ['CHAMELEON']}

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -103,7 +103,7 @@ class TestParam(object):
         args = param_class.kwargs2args(kwargs_true_lens, kwargs_true_source,
                                        kwargs_lens_light=kwargs_true_lens_light, kwargs_ps=kwargs_true_ps,
                                        kwargs_special={'D_dt': 1000})
-        assert param_class.specialParams._D_dt_sampling is True
+        assert param_class.specialParams._D_dt_sampling.on
 
     def test_mass_scaling(self):
         kwargs_model = {'lens_model_list': ['SIS', 'NFW', 'NFW', 'SIS', 'SERSIC', 'HERNQUIST']}

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -144,6 +144,72 @@ class TestParam(object):
         assert kwargs_lens[1]['alpha_Rs'] == 0.1
         assert kwargs_lens[2]['alpha_Rs'] == 0.3
 
+    def test_general_scaling(self):
+        kwargs_model = {'lens_model_list': ['PJAFFE', 'PJAFFE', 'NFW', 'PJAFFE', 'NFW']}
+        # Scale Rs for two of the PJAFFEs, and sigma0 for a different set of PJAFFEs
+        # Scale alpha_Rs for the NFWs
+        kwargs_constraints = {
+            'general_scaling': {
+                'Rs': [1, False, False, 1, False],
+                'sigma0': [False, 1, False, 1, False],
+                'alpha_Rs': [False, False, 1, False, 1],
+            }
+        }
+        # PJAFFE: sigma0, Ra, Rs, center_x, center_y
+        # NFW: Rs, alpha_Rs, center_x, center_y
+        kwargs_fixed_lens = [
+            {'Rs': 2.0, 'center_x': 1.0},
+            {'sigma0': 2.0, 'Ra': 2.0, 'Rs': 3.0, 'center_y': 1.5},
+            {'alpha_Rs': 0.1},
+            {'Ra': 0.1, 'center_x': 0, 'center_y': 0},
+            {'Rs': 3, 'center_x': -1, 'center_y': 3},
+        ]
+        kwargs_fixed_cosmo = {}
+        param_class = Param(kwargs_model, kwargs_fixed_lens=kwargs_fixed_lens, kwargs_fixed_special=kwargs_fixed_cosmo
+                            , **kwargs_constraints)
+        kwargs_lens = [{'sigma0': 3, 'Ra': 2, 'center_y': 5},
+                       {'center_x': 1.},
+                       {'Rs': 3, 'center_x': 0.0, 'center_y': -1.0},
+                       {'sigma0': 3, 'Rs': 1.5},
+                       {'alpha_Rs': 4}]
+        kwargs_source = []
+        kwargs_lens_light = []
+        kwargs_ps = []
+        # Define the scaling and power for each parameter
+        kwargs_cosmo = {
+            'Rs_scale_factor': [2.0],
+            'Rs_scale_pow': [1.1],
+            'sigma0_scale_factor': [3],
+            'sigma0_scale_pow': [2.0],
+            'alpha_Rs_scale_factor': [0.3],
+            'alpha_Rs_scale_pow': [0.5],
+        }
+        args = param_class.kwargs2args(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_special=kwargs_cosmo)
+        num, names = param_class.num_param()
+        print(names)
+        print(args)
+
+        kwargs_return = param_class.args2kwargs(args)
+        kwargs_lens = kwargs_return['kwargs_lens']
+        print('kwargs_lens:', kwargs_lens)
+        np.testing.assert_almost_equal(kwargs_lens[0]['Rs'], 2.0 * 2.0**1.1)
+        np.testing.assert_almost_equal(kwargs_lens[0]['sigma0'], 3)
+        np.testing.assert_almost_equal(kwargs_lens[1]['Rs'], 3.0)
+        np.testing.assert_almost_equal(kwargs_lens[1]['sigma0'], 3.0 * 2.0**2.0)
+        np.testing.assert_almost_equal(kwargs_lens[2]['alpha_Rs'], 0.3 * 0.1**0.5)
+        np.testing.assert_almost_equal(kwargs_lens[3]['Rs'], 2.0 * 1.5**1.1)
+        np.testing.assert_almost_equal(kwargs_lens[3]['sigma0'], 3.0 * 3**2.0)
+        np.testing.assert_almost_equal(kwargs_lens[4]['alpha_Rs'], 0.3 * 4**0.5)
+
+        kwargs_return = param_class.args2kwargs(args, bijective=True)
+        kwargs_lens = kwargs_return['kwargs_lens']
+        np.testing.assert_almost_equal(kwargs_lens[0]['Rs'], 2.0)
+        np.testing.assert_almost_equal(kwargs_lens[1]['sigma0'], 2.0)
+        np.testing.assert_almost_equal(kwargs_lens[2]['alpha_Rs'], 0.1)
+        np.testing.assert_almost_equal(kwargs_lens[3]['Rs'], 1.5)
+        np.testing.assert_almost_equal(kwargs_lens[3]['sigma0'], 3)
+        np.testing.assert_almost_equal(kwargs_lens[4]['alpha_Rs'], 4)
+
     def test_joint_lens_with_light(self):
         kwargs_model = {'lens_model_list': ['CHAMELEON'], 'lens_light_model_list': ['CHAMELEON']}
         i_light, k_lens = 0, 0

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -79,6 +79,18 @@ class TestParam(object):
         assert kwargs_new['delta_x_source_grid'] == kwargs_fixed['delta_x_source_grid']
         assert kwargs_new['delta_y_source_grid'] == kwargs_fixed['delta_y_source_grid']
 
+    def test_general_scaling(self):
+        kwargs_fixed = {}
+        param = SpecialParam(kwargs_fixed=kwargs_fixed,
+                             general_scaling_params={'param': [False, 1, 1, False, 2]})
+        args = param.set_params({'param_scale_factor': [1, 2], 'param_scale_pow': [3, 4]})
+        assert len(args) == 4
+        num_param, param_list = param.num_param()
+        assert num_param == 4
+        kwargs_new, _ = param.get_params(args, i=0)
+        assert kwargs_new['param_scale_factor'] == [1, 2]
+        assert kwargs_new['param_scale_pow'] == [3, 4]
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
# General parameter scaling

This is an implementation of a feature I have discussed with Simon and Anowar. I added a few tests which pass but have not played with it too much yet.

It also includes a small refactor of how parameters are handled, which made it easier for me to implement this. The interface remains the same.

## Explanation

I am working on modeling lensing galaxy clusters and would like to fit the member mass profiles together in a uniform way, scaling their overall mass and radius by their magnitude. Something similar to these equations from [Bergamini 2019](https://ui.adsabs.harvard.edu/abs/2019A%26A...631A.130B/abstract):

![image](https://user-images.githubusercontent.com/8944001/186019141-2f8db310-7e84-4f39-8491-07cdb27b210a.png)

The existing `mass_scaling` parameter is similar but not exactly what I need; it only scales the overall mass linearly.

This PR implements generalized scaling, where any lens parameter can be scaled like this::

```
kwargs_lens[i]['param'] = param_scale * kwargs_lens[i]['param'] ** param_power
```

Where both `param_scale` and `param_power` can be fixed or sampled.

## Use

The interface is similar to `mass_scaling`, a mask is provided for each scaled parameter listing which lenses will be scaled.

This example will scale the `sigma0` and `Rs` parameters of `PJAFFE` profiles, like in the Bergamini example above. The member lens masses are labeled with `1`.

```
kwargs_constraints = {
    'general_scaling': {
        'sigma0': [False]*num_halo + [1]*nmembers,
        'Rs': [False]*num_halo + [1]*nmembers,
    }
}
```

And the initial values and bounds can be provided like this. This fixes the power-law exponent but varies the overall scaling for both `sigma0` and `Rs`.

```
fixed_special = {'sigma0_scale_pow': [alpha*2], 'Rs_scale_pow': [beta]}
kwargs_special_init = {'sigma0_scale_factor': [17.0], 'Rs_scale_factor': [8]}
kwargs_special_sigma = {'sigma0_scale_factor': [10.0], 'Rs_scale_factor': [3]}
kwargs_lower_special = {'sigma0_scale_factor': [0.5], 'Rs_scale_factor': [1]}
kwargs_upper_special = {'sigma0_scale_factor': [40], 'Rs_scale_factor': [20]}

special_params = [kwargs_special_init, kwargs_special_sigma, fixed_special, kwargs_lower_special, kwargs_upper_special]
```