### PR TITLE
Refactor sampling parameter handling

### DIFF
--- a/lenstronomy/LensModel/lens_param.py
+++ b/lenstronomy/LensModel/lens_param.py
@@ -1,7 +1,12 @@
 from lenstronomy.LensModel.single_plane import SinglePlane
 import numpy as np
 
+from ..Sampling.param_group import ModelParamGroup, SingleParam, ArrayParam, MixedParams
+
 __all__ = ['LensParam']
+
+
+# TODO reimplement in new Param classes
 
 
 class LensParam(object):
@@ -147,7 +152,7 @@ class LensParam(object):
                             args.append(kwargs[name])
         return args
 
-    def num_param(self):
+    def num_params(self):
         """
 
         :return: integer, number of free parameters being sampled from the lens model components

--- a/lenstronomy/LightModel/light_param.py
+++ b/lenstronomy/LightModel/light_param.py
@@ -1,6 +1,73 @@
 from lenstronomy.LightModel.light_model import LightModel
+from ..Sampling.param_group import ModelParamGroup, SingleParam, ArrayParam, MixedParams
 
 __all__ = ['LightParam']
+
+
+class LightModelParams(SingleParam):
+    '''
+    Represents parameters of a generic light model
+    '''
+    def __init__(self, param_names, model_type, k, kwargs_fixed):
+        super().__init__(on=True)
+        self.param_names = [
+            name
+            for name in param_names
+        ]
+        self.model_type = model_type
+        self.k = k
+
+
+class ExpansionParams(MixedParams):
+    '''
+    Handles parameters for expansion-type light models: shaplets, starlets,
+    gaussian expansions
+    '''
+    def __init__(self, param_names, model_type, k, kwargs_fixed):
+        if model_type in ['SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP']:
+            if 'n_max' not in kwargs_fixed:
+                raise ValueError(f'n_max needs to be fixed in configuration: {model_type}')
+            n_max = kwargs_fixed['n_max']
+            if model_type in ['SHAPELETS_POLAR_EXP']:
+                num_param = int((n_max + 1) ** 2)
+            else:
+                num_param = int((n_max + 1) * (n_max + 2) / 2)
+        elif model_type in ['MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE']:
+            if 'sigma' not in kwargs_fixed:
+                raise ValueError(f"sigma needs to be fixed in {model_type}")
+            num_param = len(kwargs_fixed['sigma'])
+        elif model_type in ['SLIT_STARLETS', 'SLIT_STARLETS_GEN2']:
+            if 'n_scales' in kwargs_fixed and 'n_pixels' in kwargs_fixed:
+                n_scales = kwargs_fixed['n_scales']
+                n_pixels = kwargs_fixed['n_pixels']
+            else:
+                raise ValueError(
+                    f"'n_scales' and 'n_pixels' both need to be fixed in {model_type}"
+                )
+            for param in ['center_x', 'center_y']:
+                if param not in kwargs_fixed:
+                    raise ValueError("'{}' must be a fixed keyword argument for STARLETS-like models".format(param))
+            num_param = n_scales * n_pixels
+        else:
+            raise ValueError(f'Unknown model {model_type}')
+
+        # Amp is an array: the amplitude of each shapelet mode.
+        array_params = {
+            'amp': num_param
+        }
+        # All other params are a single number
+        single_params = [
+            name
+            for name in param_names
+            if name != 'amp'
+        ]
+
+        self.model_type = model_type
+        super().__init__(
+            single_params=single_params,
+            array_params=array_params,
+        )
+
 
 
 class LightParam(object):
@@ -25,10 +92,13 @@ class LightParam(object):
         self._param_name_list = self._lightModel.param_name_list
         self._type = param_type
         self.model_list = light_model_list
+        if kwargs_fixed is None:
+            kwargs_fixed = []
         self.kwargs_fixed = kwargs_fixed
         if linear_solver:
             self.kwargs_fixed = self._lightModel.add_fixed_linear(self.kwargs_fixed)
         self._linear_solve = linear_solver
+
         if kwargs_lower is None:
             kwargs_lower = []
             for func in self._lightModel.func_list:
@@ -39,7 +109,21 @@ class LightParam(object):
                 kwargs_upper.append(func.upper_limit_default)
         self.lower_limit = kwargs_lower
         self.upper_limit = kwargs_upper
-    
+
+        self.model_params = []
+        for k, (model_type, param_names) in enumerate(
+                zip(light_model_list, self.param_name_list)):
+            if model_type in ['SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP',
+                              'SLIT_STARLETS', 'SLIT_STARLETS_GEN2',
+                              'MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE']:
+                model_class = ExpansionParams
+            else:
+                model_class = LightModelParams
+            self.model_params.append(
+                model_class(param_names, model_type, k,
+                            kwargs_fixed=self.kwargs_fixed[k])
+            )
+
     @property
     def param_name_list(self):
         return self._param_name_list
@@ -53,45 +137,8 @@ class LightParam(object):
          this class
         """
         kwargs_list = []
-        for k, model in enumerate(self.model_list):
-            kwargs = {}
-            kwargs_fixed = self.kwargs_fixed[k]
-            param_names = self._param_name_list[k]
-            for name in param_names:
-                if name not in kwargs_fixed:
-                    if model in ['SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP'] and name == 'amp':
-                        if 'n_max' in kwargs_fixed:
-                            n_max = kwargs_fixed['n_max']
-                        else:
-                            raise ValueError('n_max needs to be fixed in %s.' % model)
-                        if model in ['SHAPELETS_POLAR_EXP']:
-                            num_param = int((n_max + 1) ** 2)
-                        else:
-                            num_param = int((n_max + 1) * (n_max + 2) / 2)
-                        kwargs['amp'] = args[i:i + num_param]
-                        i += num_param
-                    elif model in ['MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE'] and name == 'amp':
-                        if 'sigma' in kwargs_fixed:
-                            num_param = len(kwargs_fixed['sigma'])
-                        else:
-                            raise ValueError('sigma needs to be fixed in %s.' % model)
-                        kwargs['amp'] = args[i:i + num_param]
-                        i += num_param
-                    elif model in ['SLIT_STARLETS', 'SLIT_STARLETS_GEN2'] and name == 'amp':
-                        if 'n_scales' in kwargs_fixed and 'n_pixels' in kwargs_fixed:
-                            n_scales = kwargs_fixed['n_scales']
-                            n_pixels = kwargs_fixed['n_pixels']
-                        else:
-                            raise ValueError("'n_scales' and 'n_pixels' both need to be fixed in %s." % model)
-                        num_param = n_scales * n_pixels
-                        kwargs['amp'] = args[i:i + num_param]
-                        i += num_param
-                    else:
-                        kwargs[name] = args[i]
-                        i += 1
-                else:
-                    kwargs[name] = kwargs_fixed[name]
-
+        for model, kwargs_fixed in zip(self.model_params, self.kwargs_fixed):
+            kwargs, i = model.get_params(args, i, kwargs_fixed)
             kwargs_list.append(kwargs)
         return kwargs_list, i
 
@@ -103,87 +150,28 @@ class LightParam(object):
         :return: list of floats corresponding to the free parameters
         """
         args = []
-        for k, model in enumerate(self.model_list):
-            kwargs = kwargs_list[k]
-            kwargs_fixed = self.kwargs_fixed[k]
-
-            param_names = self._param_name_list[k]
-            for name in param_names:
-                if name not in kwargs_fixed:
-                    if model in ['SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP'] and name == 'amp':
-                        n_max = kwargs_fixed.get('n_max', kwargs['n_max'])
-                        if model in ['SHAPELETS_POLAR_EXP']:
-                            num_param = int((n_max + 1) ** 2)
-                        else:
-                            num_param = int((n_max + 1) * (n_max + 2) / 2)
-                        for i in range(num_param):
-                            args.append(kwargs[name][i])
-                    elif model in ['SLIT_STARLETS', 'SLIT_STARLETS_GEN2'] and name == 'amp':
-                        if 'n_scales' in kwargs_fixed:
-                            n_scales = kwargs_fixed['n_scales']
-                        else:
-                            raise ValueError("'n_scales' for SLIT_STARLETS not found in kwargs_fixed")
-                        if 'n_pixels' in kwargs_fixed:
-                            n_pixels = kwargs_fixed['n_pixels']
-                        else:
-                            raise ValueError("'n_pixels' for SLIT_STARLETS not found in kwargs_fixed")
-                        num_param = n_scales * n_pixels
-                        for i in range(num_param):
-                            args.append(kwargs[name][i])
-                    elif model in ['SLIT_STARLETS', 'SLIT_STARLETS_GEN2'] and name in ['n_scales', 'n_pixels', 'scale',
-                                                                                       'center_x', 'center_y']:
-                        raise ValueError("'{}' must be a fixed keyword argument for STARLETS-like models".format(name))
-                    elif model in ['MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE'] and name == 'amp':
-                        num_param = len(kwargs['sigma'])
-                        for i in range(num_param):
-                            args.append(kwargs[name][i])
-                    elif model in ['MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE'] and name == 'sigma':
-                        raise ValueError("'sigma' must be a fixed keyword argument for MULTI_GAUSSIAN")
-                    else:
-                        args.append(kwargs[name])
+        if kwargs_list is None:
+            kwargs_list = [dict() for _ in self.model_params]
+        for kwargs, model, kwargs_fixed in zip(kwargs_list, self.model_params, self.kwargs_fixed):
+            args.extend(model.set_params(kwargs, kwargs_fixed))
         return args
 
     def num_param(self, latex_style=False):
         """
-        :param latex_style: boolena; if True, returns latex strings for plotting
+        :param latex_style: boolean; if True, returns latex strings for plotting
         :return: int, list of strings with param names
         """
-        num = 0
-        name_list = []
-        for k, model in enumerate(self.model_list):
-            kwargs_fixed = self.kwargs_fixed[k]
-            param_names = self._param_name_list[k]
-            for name in param_names:
-                if name not in kwargs_fixed:
-                    if model in ['SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP'] and name == 'amp':
-                        if 'n_max' not in kwargs_fixed:
-                            raise ValueError("n_max needs to be fixed in this configuration!")
-                        n_max = kwargs_fixed['n_max']
-                        if model in ['SHAPELETS_POLAR_EXP']:
-                            num_param = int((n_max + 1) ** 2)
-                        else:
-                            num_param = int((n_max + 1) * (n_max + 2) / 2)
-                        num += num_param
-                        for i in range(num_param):
-                            name_list.append(str(name + '_' + self._type + str(k)))
-                    elif model in ['SLIT_STARLETS', 'SLIT_STARLETS_GEN2'] and name == 'amp':
-                        if 'n_scales' not in kwargs_fixed or 'n_pixels' not in kwargs_fixed:
-                            raise ValueError("n_scales and n_pixels need to be fixed when using STARLETS-like models!")
-                        n_scales = kwargs_fixed['n_scales']
-                        n_pixels = kwargs_fixed['n_pixels']
-                        num_param = n_scales * n_pixels
-                        num += num_param
-                        for i in range(num_param):
-                            name_list.append(str(name + '_' + self._type + str(k)))
-                    elif model in ['MULTI_GAUSSIAN', 'MULTI_GAUSSIAN_ELLIPSE'] and name == 'amp':
-                        num_param = len(kwargs_fixed['sigma'])
-                        num += num_param
-                        for i in range(num_param):
-                            name_list.append(str(name + '_' + self._type + str(k)))
-                    else:
-                        num += 1
-                        name_list.append(str(name + '_' + self._type + str(k)))
-        return num, name_list
+        # latex_style is ignored? This was true before JOD's change
+        num_total = 0
+        name_list_total = []
+        for k, (model_param, kwargs_fixed) in enumerate(zip(self.model_params, self.kwargs_fixed)):
+            num, name_list = model_param.num_params(kwargs_fixed)
+            num_total += num
+            name_list_total += [
+                f'{name}_{self._type}_{k}'
+                for name in name_list
+            ]
+        return num_total, name_list_total
 
     def num_param_linear(self):
         """

--- a/lenstronomy/LightModel/light_param.py
+++ b/lenstronomy/LightModel/light_param.py
@@ -1,5 +1,5 @@
 from lenstronomy.LightModel.light_model import LightModel
-from ..Sampling.param_group import ModelParamGroup, SingleParam, ArrayParam, MixedParams
+from ..Sampling.param_group import SingleParam, MixedParams
 
 __all__ = ['LightParam']
 
@@ -156,7 +156,7 @@ class LightParam(object):
             args.extend(model.set_params(kwargs, kwargs_fixed))
         return args
 
-    def num_param(self, latex_style=False):
+    def num_params(self, latex_style=False):
         """
         :param latex_style: boolean; if True, returns latex strings for plotting
         :return: int, list of strings with param names

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -338,3 +338,30 @@ class ArrayParam(ModelParamGroup):
     @property
     def on(self):
         return self._on
+
+
+class MixedParams(ModelParamGroup):
+    '''
+    Represents a mixture of single and array parameters
+    '''
+    def __init__(self, single_params, array_params):
+        self._single = SingleParam(on=True)
+        self._single.param_names = single_params
+
+        self._array = ArrayParam(on=True)
+        self._array.param_names = array_params
+
+    def num_params(self, kwargs_fixed):
+        npar_s, names_s = self._single.num_params(kwargs_fixed)
+        npar_a, names_a = self._array.num_params(kwargs_fixed)
+        return npar_s + npar_a, names_s + names_a
+
+    def set_params(self, kwargs, kwargs_fixed):
+        single = self._single.set_params(kwargs, kwargs_fixed)
+        array = self._array.set_params(kwargs, kwargs_fixed)
+        return single + array
+
+    def get_params(self, args, i, kwargs_fixed):
+        params_s, i = self._single.get_params(args, i, kwargs_fixed)
+        params_a, i = self._array.get_params(args, i, kwargs_fixed)
+        return dict(params_s, **params_a), i

--- a/test/test_LensModel/test_lens_param.py
+++ b/test/test_LensModel/test_lens_param.py
@@ -73,7 +73,7 @@ class TestParam(object):
         assert len(lens_model_list) == len(param_name_list)
 
     def test_num_params(self):
-        num, list = self.param.num_param()
+        num, list = self.param.num_params()
         assert num == 20
 
     def test_shapelet_solver(self):
@@ -85,7 +85,7 @@ class TestParam(object):
         kwargs_out, i = lensParam.get_params(args, i=0)
         assert kwargs_out[0]['coeffs'][1] == 0
         assert kwargs_out[0]['beta'] == kwargs_lens[0]['beta']
-        num, param_list = lensParam.num_param()
+        num, param_list = lensParam.num_params()
         assert num == 8
 
         lensParam = LensParam(lens_model_list, kwargs_fixed=[{}], num_images=4, solver_type='SHAPELETS',
@@ -95,7 +95,7 @@ class TestParam(object):
         kwargs_out, i = lensParam.get_params(args, i=0)
         assert kwargs_out[0]['coeffs'][5] == 0
         assert kwargs_out[0]['beta'] == kwargs_lens[0]['beta']
-        num, param_list = lensParam.num_param()
+        num, param_list = lensParam.num_params()
         assert num == 5
 
 

--- a/test/test_LightModel/test_light_param.py
+++ b/test/test_LightModel/test_light_param.py
@@ -51,11 +51,11 @@ class TestParam(object):
         #     {'amp_sigma': 0.1},  # 'UNIFORM'
         # ]
         self.kwargs_fixed = [
-            {}, {'sigma': [1, 3]}, {}, {}, {}, {'n_max': 1}, {}, {}, {}, {}, {}, {'n_max': 0}, {'n_max': 0}, 
+            {}, {'sigma': [1, 3]}, {}, {}, {}, {'n_max': 1}, {}, {}, {}, {}, {}, {'n_max': 0}, {'n_max': 0},
             {'n_scales': 3, 'n_pixels': 20**2, 'scale': 0.05, 'center_x': 0, 'center_y': 0},
         ]
         self.kwargs_fixed_linear = [
-            {}, {'sigma': [1, 3]}, {}, {}, {}, {'n_max': 1}, {}, {}, {}, {}, {}, {}, {},
+            {}, {'sigma': [1, 3]}, {}, {}, {}, {'n_max': 1}, {}, {}, {}, {}, {}, {'n_max': 0,}, {'n_max': 0},
             {'n_scales': 3, 'n_pixels': 20**2, 'scale': 0.05, 'center_x': 0, 'center_y': 0},
         ]
         # self.kwargs_mean = []
@@ -91,7 +91,7 @@ class TestParam(object):
 
     def test_num_params(self):
         num, list = self.param.num_param()
-        assert num == (66+1200)
+        assert num == (66+1200), list
 
     def test_param_name_list(self):
         param_name_list = self.param.param_name_list
@@ -132,7 +132,7 @@ class TestRaise(unittest.TestCase):
             lighModel = LightParam(light_model_list=['SLIT_STARLETS'], kwargs_fixed=[{}], linear_solver=False)
             lighModel.get_params(args=[1], i=0)
         with self.assertRaises(ValueError):
-            # no fixed params provided 
+            # no fixed params provided
             lighModel = LightParam(light_model_list=['SLIT_STARLETS'], kwargs_fixed=[{}], linear_solver=False)
             lighModel.set_params(kwargs_list=[{'amp': np.ones((3 * 20 ** 2))}])
         with self.assertRaises(ValueError):

--- a/test/test_LightModel/test_light_param.py
+++ b/test/test_LightModel/test_light_param.py
@@ -90,7 +90,7 @@ class TestParam(object):
             npt.assert_almost_equal(args[k], args_new[k], decimal=8)
 
     def test_num_params(self):
-        num, list = self.param.num_param()
+        num, list = self.param.num_params()
         assert num == (66+1200), list
 
     def test_param_name_list(self):
@@ -121,7 +121,7 @@ class TestRaise(unittest.TestCase):
             lighModel.set_params(kwargs_list=[{'amp': 1, 'sigma': 1}])
         with self.assertRaises(ValueError):
             lighModel = LightParam(light_model_list=['SHAPELETS'], kwargs_fixed=[{}], linear_solver=False)
-            lighModel.num_param()
+            lighModel.num_params()
         with self.assertRaises(ValueError):
             lighModel = LightParam(light_model_list=['SHAPELETS'], kwargs_fixed=[{}], linear_solver=False)
             lighModel.get_params(args=[], i=0)
@@ -142,7 +142,7 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(ValueError):
             # missing fixed params
             lighModel = LightParam(light_model_list=['SLIT_STARLETS'], kwargs_fixed=[{'n_scales': 3}], linear_solver=False)
-            lighModel.num_param()
+            lighModel.num_params()
         with self.assertRaises(ValueError):
             # missing fixed params
             lighModel = LightParam(light_model_list=['SLIT_STARLETS'], kwargs_fixed=[{'amp': np.ones((3*20**2))}],


### PR DESCRIPTION
This PR would continue the refactor of parameter handling implemented in #350 

It will reimplement the following two parameter classes with the framework in `Sampling/param_group.py`:

[x] Refactor LightParams 
[ ] Refactor LightParams

Of course, this is low-priority. It adds no features but would hopefully ease maintenance in the future, and make it simpler to add new sampled parameters to these classes.

Just opening the PR for discussion