### PR TITLE
updates in numerical lens equation solver to allow for more candidate solutions

### DIFF
--- a/lenstronomy/LensModel/Solver/epl_shear_solver.py
+++ b/lenstronomy/LensModel/Solver/epl_shear_solver.py
@@ -1,4 +1,4 @@
-__author__ = 'ewoudwempe'
+__author__ = 'ewoudwempe', 'sibirrer'
 
 import numpy as np
 from lenstronomy.LensModel.Util.epl_util import min_approx, pol_to_cart, cart_to_pol, cdot, ps, rotmat, solvequadeq, brentq_inline

--- a/lenstronomy/LensModel/Solver/epl_shear_solver.py
+++ b/lenstronomy/LensModel/Solver/epl_shear_solver.py
@@ -88,6 +88,7 @@ def _getphi(thpl, args):
     """
     Finds all roots to both versions the 1-dimensional lens equation in phi, by doing a grid search for sign changes on
     the supplied thpl. In the case of extrema, refine at the relevant location.
+
     :param thpl: What points to calculate the equation on use for detecting sign changes
     :param args: Parameters to be passed to the lens equation
     :return: an array containing all roots
@@ -163,6 +164,9 @@ def _check_center(kwargs_lens):
     if kwargs_lens[1]['ra_0'] != kwargs_lens[0]['center_x'] or kwargs_lens[1]['dec_0'] != kwargs_lens[0]['center_y']:
         raise ValueError("Center of lens (center_{x,y}) must be the same as center of shear ({ra,dec}_0). "
                          "This can be ensured by supplying a dictionary-style joint_setting_list to the model.")
+    # TODO: calculate (inverse) displacement caused by the offset between shear and lens centroid
+    # this shift needs to be added to the source position such that the solution of the lens equation
+    # without this shift in the shear is the correct one
 
 
 def solve_lenseq_pemd(pos_, kwargs_lens, Nmeas=400, Nmeas_extra=80, **kwargs):

--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -124,7 +124,7 @@ class LensEquationSolver(object):
         """
         lens_model_list = list(self.lensModel.lens_model_list)
         if lens_model_list not in (['SIE', 'SHEAR'], ['SIE'], ['EPL_NUMBA', 'SHEAR'], ['EPL_NUMBA'], ['EPL', 'SHEAR'], ['EPL']):
-            raise ValueError("Only SIE or PEMD (+shear) supported in the analytical solver for now")
+            raise ValueError("Only SIE, EPL, EPL_NUMBA (+shear) supported in the analytical solver for now.")
 
         x_mins, y_mins = solve_lenseq_pemd((x, y), kwargs_lens, **kwargs_solver)
         if arrival_time_sort:

--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -100,7 +100,7 @@ class LensEquationSolver(object):
         absmapped = util.displaceAbs(x_mapped, y_mapped, sourcePos_x, sourcePos_y)
         # select minima in the grid points and select grid points that do not deviate more than the
         # width of the grid point to a solution of the lens equation
-        x_mins, y_mins, delta_map = util.neighborSelect(absmapped, x_grid, y_grid)
+        x_mins, y_mins, delta_map = util.local_minima_2d(absmapped, x_grid, y_grid)
         # pixel width
         pixel_width = x_grid[1]-x_grid[0] 
             

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -485,6 +485,40 @@ def points_on_circle(radius, num_points, connect_ends=True):
     y_coord = np.sin(angle) * radius
     return x_coord, y_coord
 
+@export
+@jit()
+def local_minima_2d(a, x, y):
+    """
+    finds (local) minima in a 2d grid
+    applies less rigid criteria for maximum without second-order tangential minima criteria
+
+    :param a: 1d array of displacements from the source positions
+    :type a: numpy array with length numPix**2 in float
+    :param x: 1d coordinate grid in x-direction
+    :type x: numpy array with length numPix**2 in float
+    :param y: 1d coordinate grid in x-direction
+    :type y: numpy array with length numPix**2 in float
+    :returns:  array of indices of local minima, values of those minima
+    :raises: AttributeError, KeyError
+    """
+    dim = int(np.sqrt(len(a)))
+    values = []
+    x_mins = []
+    y_mins = []
+    for i in range(dim + 1, len(a) - dim - 1):
+        if (a[i] < a[i - 1]
+                and a[i] < a[i + 1]
+                and a[i] < a[i - dim]
+                and a[i] < a[i + dim]
+                and a[i] < a[i - (dim - 1)]
+                and a[i] < a[i - (dim + 1)]
+                and a[i] < a[i + (dim - 1)]
+                and a[i] < a[i + (dim + 1)]):
+            x_mins.append(x[i])
+            y_mins.append(y[i])
+            values.append(a[i])
+    return np.array(x_mins), np.array(y_mins), np.array(values)
+
 
 @export
 @jit()
@@ -545,7 +579,7 @@ def neighborSelect(a, x, y):
 def fwhm2sigma(fwhm):
     """
 
-    :param fwhm: full-widt-half-max value
+    :param fwhm: full-width-half-max value
     :return: gaussian sigma (sqrt(var))
     """
     sigma = fwhm / (2 * np.sqrt(2 * np.log(2)))

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -145,6 +145,24 @@ class TestLensEquationSolver(object):
         for x, y in zip(x_pos_ls, y_pos_ls):  # Check if it found all solutions lenstronomy found
             assert np.sqrt((x-x_pos)**2+(y-y_pos)**2).min() < 1e-8
 
+        # here we test with shear and mass profile centroids not aligned
+        """
+        
+        lensModel = LensModel(['EPL_NUMBA', 'SHEAR'])
+        lensEquationSolver = LensEquationSolver(lensModel)
+        sourcePos_x = 0.03
+        sourcePos_y = 0.0
+        kwargs_lens = [{'theta_E': 1., 'gamma': 2.2, 'center_x': 0.01, 'center_y': 0.02, 'e1': 0.01, 'e2': 0.05},
+                       {'gamma1': -0.04, 'gamma2': -0.1, 'ra_0': 0.0, 'dec_0': 0.0}]
+
+        x_pos, y_pos = lensEquationSolver.image_position_from_source(sourcePos_x, sourcePos_y, kwargs_lens,
+                                                                     solver='analytical')
+        source_x, source_y = lensModel.ray_shooting(x_pos, y_pos, kwargs_lens)
+        assert len(source_x) == len(source_y) >= 4
+        npt.assert_almost_equal(sourcePos_x, source_x, decimal=10)
+        npt.assert_almost_equal(sourcePos_y, source_y, decimal=10)
+        """
+
     def test_caustics(self):
         lm = LensModel(['EPL_NUMBA', 'SHEAR'])
         leqs = LensEquationSolver(lm)

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -151,7 +151,7 @@ class TestLensEquationSolver(object):
         sourcePos_x = 0.03
         sourcePos_y = 0.0
         kwargs_lens = [{'theta_E': 1., 'gamma': 2.2, 'center_x': 0.01, 'center_y': 0.02, 'e1': 0.01, 'e2': 0.05},
-                       {'gamma1': -0.04, 'gamma2': -0.1, 'ra_0': 1.0, 'dec_0': 1.0}]
+                       {'gamma1': -0.04, 'gamma2': -0.1, 'ra_0': 0.0, 'dec_0': 1.0}]
 
         x_pos, y_pos = lensEquationSolver.image_position_from_source(sourcePos_x, sourcePos_y, kwargs_lens,
                                                                      solver='analytical')
@@ -174,7 +174,8 @@ class TestLensEquationSolver(object):
         lensplane_cut = caustics_epl_shear(kwargs, return_which='cut', sourceplane=False)
         twoimg = caustics_epl_shear(kwargs, return_which='double')
         fourimg = caustics_epl_shear(kwargs, return_which='quad')
-        assert np.abs(lm.magnification(*lensplane_caus, kwargs)).min() > 1e12
+        min_mag = np.abs(lm.magnification(*lensplane_caus, kwargs)).min()
+        assert min_mag > 1e12
         assert np.abs(lm.magnification(*lensplane_cut, kwargs)).min() > 1e12
 
         # Test whether the caustics indeed the number of images they say
@@ -227,11 +228,6 @@ class TestLensEquationSolver(object):
 
         with pytest.raises(ValueError):
             lensEquationSolver.image_position_from_source(0.1, 0., kwargs_lens, solver='nonexisting')
-
-        # with pytest.raises(ValueError):
-        #    kwargs_lens[1]['ra_0']=0.1
-        #    lensEquationSolver.image_position_from_source(0.1, 0., kwargs_lens, solver='analytical')
-
 
 
 if __name__ == '__main__':

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -146,22 +146,19 @@ class TestLensEquationSolver(object):
             assert np.sqrt((x-x_pos)**2+(y-y_pos)**2).min() < 1e-8
 
         # here we test with shear and mass profile centroids not aligned
-        """
-        
         lensModel = LensModel(['EPL_NUMBA', 'SHEAR'])
         lensEquationSolver = LensEquationSolver(lensModel)
         sourcePos_x = 0.03
         sourcePos_y = 0.0
         kwargs_lens = [{'theta_E': 1., 'gamma': 2.2, 'center_x': 0.01, 'center_y': 0.02, 'e1': 0.01, 'e2': 0.05},
-                       {'gamma1': -0.04, 'gamma2': -0.1, 'ra_0': 0.0, 'dec_0': 0.0}]
+                       {'gamma1': -0.04, 'gamma2': -0.1, 'ra_0': 1.0, 'dec_0': 1.0}]
 
         x_pos, y_pos = lensEquationSolver.image_position_from_source(sourcePos_x, sourcePos_y, kwargs_lens,
                                                                      solver='analytical')
         source_x, source_y = lensModel.ray_shooting(x_pos, y_pos, kwargs_lens)
-        assert len(source_x) == len(source_y) >= 4
+        assert len(source_x) == len(source_y) >= 2
         npt.assert_almost_equal(sourcePos_x, source_x, decimal=10)
         npt.assert_almost_equal(sourcePos_y, source_y, decimal=10)
-        """
 
     def test_caustics(self):
         lm = LensModel(['EPL_NUMBA', 'SHEAR'])
@@ -231,9 +228,9 @@ class TestLensEquationSolver(object):
         with pytest.raises(ValueError):
             lensEquationSolver.image_position_from_source(0.1, 0., kwargs_lens, solver='nonexisting')
 
-        with pytest.raises(ValueError):
-            kwargs_lens[1]['ra_0']=0.1
-            lensEquationSolver.image_position_from_source(0.1, 0., kwargs_lens, solver='analytical')
+        # with pytest.raises(ValueError):
+        #    kwargs_lens[1]['ra_0']=0.1
+        #    lensEquationSolver.image_position_from_source(0.1, 0., kwargs_lens, solver='analytical')
 
 
 

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -322,11 +322,22 @@ def test_min_square_dist():
     assert dist[1] == 1
 
 
+def test_neighbor_select_fast():
+    a = np.ones(100)
+    a[41] = 0
+    x = np.linspace(0, 99, 100)
+    y = np.linspace(0, 99, 100)
+    x_mins, y_mins, values = util.local_minima_2d(a, x, y)
+    assert x_mins[0] == 41
+    assert y_mins[0] == 41
+    assert values[0] == 0
+
+
 def test_neighborSelect():
     a = np.ones(100)
     a[41] = 0
-    x = np.linspace(0,99,100)
-    y = np.linspace(0,99,100)
+    x = np.linspace(0, 99, 100)
+    y = np.linspace(0, 99, 100)
     x_mins, y_mins, values = util.neighborSelect(a, x, y)
     assert x_mins[0] == 41
     assert y_mins[0] == 41

--- a/test/test_Workflow/test_fitting_sequence.py
+++ b/test/test_Workflow/test_fitting_sequence.py
@@ -278,7 +278,6 @@ class TestFittingSequence(object):
 
         chain_list = fittingSequence.fit_sequence(fitting_list)
 
-
     def test_multinest(self):
         # Nested sampler tests
         # further decrease the parameter space for nested samplers to run faster
@@ -321,8 +320,9 @@ class TestFittingSequence(object):
         assert kwargs_out['kwargs_lens'] == 1
 
     def test_dynesty(self):
+        np.random.seed(42)
         kwargs_params = copy.deepcopy(self.kwargs_params)
-        kwargs_params['lens_model'][0][0]['theta_E'] += 0.01
+        kwargs_params['lens_model'][0][0]['theta_E'] += 0.2
         fittingSequence = FittingSequence(self.kwargs_data_joint, self.kwargs_model, self.kwargs_constraints,
                                           self.kwargs_likelihood, kwargs_params)
 
@@ -341,6 +341,7 @@ class TestFittingSequence(object):
         chain_list = fittingSequence.fit_sequence(fitting_list)
 
     def test_nautilus(self):
+        np.random.seed(42)
         kwargs_params = copy.deepcopy(self.kwargs_params)
         fittingSequence = FittingSequence(self.kwargs_data_joint, self.kwargs_model, self.kwargs_constraints,
                                           self.kwargs_likelihood, kwargs_params)

--- a/test/test_Workflow/test_fitting_sequence.py
+++ b/test/test_Workflow/test_fitting_sequence.py
@@ -198,6 +198,7 @@ class TestFittingSequence(object):
         assert kwargs_set['kwargs_ps'][0]['ra_source'] == 0.007
 
     def test_zeus(self):
+        np.random.seed(42)
         # we make a very basic lens+source model to feed to check zeus can be run through fitting sequence
         # we don't use the kwargs defined in setup() as those are modified during the tests; using unique kwargs here is safer
 
@@ -214,8 +215,6 @@ class TestFittingSequence(object):
         data_class = ImageData(**kwargs_data)
         kwargs_psf_gaussian = {'psf_type': 'GAUSSIAN', 'fwhm': fwhm, 'pixel_size': deltaPix, 'truncation': 3}
         psf_gaussian = PSF(**kwargs_psf_gaussian)
-        kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': psf_gaussian.kernel_point_source, 'psf_error_map': np.zeros_like(psf_gaussian.kernel_point_source)}
-        psf_class = PSF(**kwargs_psf)
 
         # make a lens
         lens_model_list = ['EPL']
@@ -232,7 +231,7 @@ class TestFittingSequence(object):
 
         kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False}
 
-        imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class, kwargs_numerics=kwargs_numerics)
+        imageModel = ImageModel(data_class, psf_gaussian, lens_model_class, source_model_class, kwargs_numerics=kwargs_numerics)
         image_sim = sim_util.simulate_simple(imageModel, kwargs_lens, kwargs_source)
 
         data_class.update_data(image_sim)
@@ -260,12 +259,12 @@ class TestFittingSequence(object):
 
         kwargs_constraints = {}
 
-        multi_band_list = [[kwargs_data, kwargs_psf, kwargs_numerics]]
+        multi_band_list = [[kwargs_data, kwargs_psf_gaussian, kwargs_numerics]]
 
         kwargs_data_joint = {'multi_band_list': multi_band_list,
                              'multi_band_type': 'multi-linear'}
 
-        kwargs_likelihood = {'source_marg': True}
+        kwargs_likelihood = {'source_marg': False}
 
         fittingSequence = FittingSequence(kwargs_data_joint, kwargs_model,
                                           kwargs_constraints, kwargs_likelihood,


### PR DESCRIPTION
The current local minima finder for candidate solutions to the lens equations check in the off-diagonal axis beyond the neighboring points whether there is a local minima. This was intended to avoid many candidate solutions along a highly magnified region that all result eventually to the same solution.
However, there are examples where this fails and no candidate solution is provided and hence some images are missing.

Below is an example of this.

The proposed PR simplifies the candidate solution calculation (also speed-up) resulting in generally more candidate solutions that are being investigated (more computational costs). I think this is a better trade-off.

#lens model
from lenstronomy.LensModel.lens_model import LensModel
lens_model_list = ['EPL_NUMBA','SHEAR']
lens_model = LensModel(lens_model_list=lens_model_list)
kwargs_lens = [
    {
        'theta_E':0.7666888232,
        'gamma':2.0269779852,
        'e1':-0.2836849885,
        'e2':0.0991617441,
        'center_x':0.0892853015,
        'center_y':0.0845201544
    },
    {
        'gamma1':-0.2211806041,
        'gamma2':-0.026305004,
        'ra_0':0.0,
        'dec_0':0.0
    }
]

kwargs_ps = [
    {
        'ra_source':0.1122538938,
        'dec_source':0.0304589556,
        'mag_pert':[1.221,1.008,0.933,0.838],
        'source_amp':15.030721591529167
    }
]
from lenstronomy.LensModel.Solver.lens_equation_solver import LensEquationSolver
solver = LensEquationSolver(lens_model)

lens_equation_params={
    'min_distance':0.03999594047039023,
    'search_window':2.5597401901049746,
    'x_center':0.0199923838,
    'y_center':-0.0200037159
}

x_image, y_image = solver.image_position_from_source(kwargs_ps[0]['ra_source'], 
                                                     kwargs_ps[0]['dec_source'], 
                                                     kwargs_lens, verbose=True,
                                                     **lens_equation_params)
print(x_image, y_image)

Credits to @smericks for the undesired behavior and the example posted here.

