### PR TITLE
Fix link to tutorials in usage docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,7 @@ user to directly access a lot of tools and each module can also be used as stand
 Example notebooks
 -----------------
 
-We have made an extension module available at `https://github.com/lenstronomy/lenstronom-tutorials <https://github.com/lenstronomy/lenstronom-tutorials/>`_.
+We have made an extension module available at `https://github.com/lenstronomy/lenstronomy-tutorials <https://github.com/lenstronomy/lenstronomy-tutorials/>`_.
 You can find simple example notebooks for various cases. The latest versions of the notebooks should be compatible with the recent pip version of lenstronomy.
 
 


### PR DESCRIPTION
One of the links to the lenstronomy tutorials repo in the docs has a typo (it refers to 'lenstronom-tutorials' instead).