### PR TITLE
minor update in 'INTERPOL' light model documentation 

### DIFF
--- a/lenstronomy/LightModel/Profiles/interpolation.py
+++ b/lenstronomy/LightModel/Profiles/interpolation.py
@@ -13,7 +13,7 @@ class Interpol(object):
     class which uses an interpolation of an image to compute the surface brightness
 
     parameters are
-    'image': 2d numpy array of surface brightness (not integrated flux per pixel!)
+    'image': 2d numpy array of surface brightness per square arc second (not integrated flux per pixel!)
     'center_x': coordinate of center of image in angular units (i.e. arc seconds)
     'center_y': coordinate of center of image in angular units (i.e. arc seconds)
     'phi_G': rotation of image relative to the rectangular ra-to-dec orientation
@@ -32,8 +32,10 @@ class Interpol(object):
 
         :param x: x-coordinate to evaluate surface brightness
         :param y: y-coordinate to evaluate surface brightness
-        :param image: 2d numpy array (image) to be used to interpolate
-        :param amp: amplitude of surface brightness scaling in respect of original image
+        :param image: pixelized surface brightness (an image) to be used to interpolate in units of surface brightness
+         (flux per square arc seconds, not flux per pixel!)
+        :type image: 2d numpy array
+        :param amp: amplitude of surface brightness scaling in respect of original input image
         :param center_x: center of interpolated image
         :param center_y: center of interpolated image
         :param phi_G: rotation angle of simulated image in respect to input gird
@@ -60,12 +62,14 @@ class Interpol(object):
         # (try reversing, the unit tests will fail)
         return self._image_interp(y, x, grid=False)
 
-    def total_flux(self, image, scale, amp=1, center_x=0, center_y=0, phi_G=0):
+    @staticmethod
+    def total_flux(image, scale, amp=1, center_x=0, center_y=0, phi_G=0):
         """
-        sums up all the image surface brightness (image pixels defined in surface brightness at the coordinate of the pixel)
-        times pixel area
+        sums up all the image surface brightness (image pixels defined in surface brightness at the coordinate of the
+         pixel) times pixel area
 
-        :param image: pixelized surface brightness
+        :param image: pixelized surface brightness used to interpolate in units of surface brightness
+         (flux per square arc seconds, not flux per pixel!)
         :param scale: scale of the pixel in units of angle
         :param amp: linear scaling parameter of the surface brightness multiplicative with the initial image
         :param center_x: center of image in angular coordinates

--- a/test/test_LightModel/test_Profiles/test_interpolation.py
+++ b/test/test_LightModel/test_Profiles/test_interpolation.py
@@ -3,6 +3,7 @@ import numpy.testing as npt
 from lenstronomy.LightModel.Profiles.interpolation import Interpol
 from lenstronomy.LightModel.Profiles.gaussian import Gaussian
 import lenstronomy.Util.util as util
+import numpy as np
 
 
 class TestInterpol(object):
@@ -42,9 +43,6 @@ class TestInterpol(object):
             out = interp.function(x=1000, y=0, **kwargs_interp)
             assert out == 0
 
-        # TODO: test for scale !=1
-
-
         # test change of center without re-doing interpolation
         out = interp.function(x=0, y=0, image=image, scale=1., phi_G=0, center_x=0, center_y=0)
         out_shift = interp.function(x=1, y=0, image=image, scale=1., phi_G=0, center_x=1, center_y=0)
@@ -57,6 +55,33 @@ class TestInterpol(object):
         out = interp.function(x=1., y=0, image=image, scale=1., phi_G=0, center_x=0, center_y=0)
         out_scaled = interp.function(x=2., y=0, image=image, scale=2, phi_G=0, center_x=0, center_y=0)
         assert out_scaled == out
+
+    def test_flux_normalization(self):
+        interp = Interpol()
+        delta_pix = 0.1
+        len_x, len_y = 21, 21
+        x, y = util.make_grid(numPix=(len_x, len_y), deltapix=delta_pix)
+        gauss = Gaussian()
+        flux = gauss.function(x, y, amp=1., center_x=0., center_y=0., sigma=0.3)
+        image = util.array2image(flux, nx=len_y, ny=len_x)
+        flux_total = np.sum(image)
+
+        kwargs_interp = {'image': image, 'scale': delta_pix, 'phi_G': 0., 'center_x': 0., 'center_y': 0.}
+        image_interp = interp.function(x, y, **kwargs_interp)
+        flux_interp = np.sum(image_interp)
+        npt.assert_almost_equal(flux_interp, flux_total, decimal=3)
+
+        # test for scale !=1
+        # demands same surface brightness values. We rescale the pixel grid by the same amount as the image
+        scale = 0.5
+        x, y = util.make_grid(numPix=(len_x, len_y), deltapix=delta_pix * scale)
+        kwargs_interp = {'image': image, 'scale': delta_pix * scale, 'phi_G': 0., 'center_x': 0., 'center_y': 0.}
+        output = interp.function(x, y, **kwargs_interp)
+
+        npt.assert_almost_equal(output / image_interp, 1, decimal=5)
+
+        from lenstronomy.ImSim.image_model import ImageModel
+
 
     def test_delete_cache(self):
         x, y = util.make_grid(numPix=20, deltapix=1.)

--- a/test/test_LightModel/test_Profiles/test_interpolation.py
+++ b/test/test_LightModel/test_Profiles/test_interpolation.py
@@ -80,9 +80,6 @@ class TestInterpol(object):
 
         npt.assert_almost_equal(output / image_interp, 1, decimal=5)
 
-        from lenstronomy.ImSim.image_model import ImageModel
-
-
     def test_delete_cache(self):
         x, y = util.make_grid(numPix=20, deltapix=1.)
         gauss = Gaussian()


### PR DESCRIPTION
minor update in 'INTERPOL' light model documentation and testing, no changes to actual calculations.
The input is a surface brightness map in units of square arc seconds and not flux per pixel. This might cause problems when not understood this way. I tried to update the documentation and made test cases with 'scale' != 1