### PR TITLE
cmap.copy() AttributeError fix

### DIFF
--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -1,6 +1,9 @@
+import copy
+
 import numpy as np
 import math
 import matplotlib.pyplot as plt
+import copy
 
 from lenstronomy.Util.package_util import exporter
 export, __all__ = exporter()
@@ -238,7 +241,8 @@ def cmap_conf(cmap_string):
         cmap = plt.get_cmap(cmap_string)
     else:
         cmap = cmap_string
-    cmap_new = cmap.copy()
+    #cmap_new = cmap.copy()
+    cmap_new = copy.deepcopy(cmap)
     cmap_new.set_bad(color='k', alpha=1.)
     cmap_new.set_under('k')
     return cmap_new

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -1,5 +1,3 @@
-import copy
-
 import numpy as np
 import math
 import matplotlib.pyplot as plt

--- a/test/test_Plots/test_plot_util.py
+++ b/test/test_Plots/test_plot_util.py
@@ -96,6 +96,9 @@ class TestPlotUtil(object):
                                            origin=[1, 1], flipped_x=True, pixel_offset=True)
         plt.close()
 
-
+    def test_cmap_copy(self):
+        from lenstronomy.Plots.plot_util import cmap_conf
+        cmap_new = cmap_conf("gist_heat")
+        
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
Hello,
`plot_util.py` makes an error while copying `cmap`.
The error message is as follows.
`AttributeError: 'LinearSegmentedColormap' object has no attribute 'copy'`

I changed the copying method from `cmap.copy()` to `copy.deepcopy(cmap)`, which does not make the same error.

Please review my first-ever pull request!
Thanks :)