### PR TITLE
Add primary beam to image simulation (ImageModel) and linear solver (…

### DIFF
--- a/lenstronomy/Data/angular_sensitivity.py
+++ b/lenstronomy/Data/angular_sensitivity.py
@@ -1,0 +1,31 @@
+__all__ = ['AngularSensitivity']
+
+
+class AngularSensitivity(object):
+    """
+    Telescope Angular Sensitivity class.
+    This class provides functions describing the EM radiation sensitivity along different directions of 
+    some specific telescopes, including radio antennae of an interferometric array.
+    
+    A general reference of telescope angular sensitivity can be found in Section 5.4 of 
+    Bradt, H. (2004). Astronomy methods: A physical approach to astronomical observations. Cambridge University Press.
+    """
+    
+    def __init__(self, antenna_primary_beam = None):
+        """
+
+        :param antenna_primary_beam: 2d numpy array. 
+         Primary beam is the angular power sensitivity of EM radiation antennae of some specific telescopes.
+         Usually the radiation sensitivity is largest at the center of the Field of View (FOV), and decays as the distance increases from the center. 
+         If the primary beam applies, it should be multiplied on the unconvolved model images, as regions with less EM sensitivity 
+         get less flux from the model image after the multiplication with the corresponding primary beam.
+         For interferometric users, the primary beam should be provided by data reduction softwares like CASA.
+        """
+        self._pb = antenna_primary_beam
+        
+    @property
+    def primary_beam(self):
+        """
+        :return: 2d numpy array of primary beam
+        """
+        return self._pb

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -37,7 +37,7 @@ class ImageData(PixelGrid, ImageNoise):
 
     """
     def __init__(self, image_data, exposure_time=None, background_rms=None, noise_map=None, gradient_boost_factor=None,
-                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0):
+                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0, primary_beam=None):
         """
 
         :param image_data: 2d numpy array of the image data
@@ -52,6 +52,7 @@ class ImageData(PixelGrid, ImageNoise):
         :param dec_at_xy_0: dec coordinate at pixel (0,0)
         :param ra_shift: RA shift of pixel grid
         :param dec_shift: DEC shift of pixel grid
+        :param primary_beam: 2d numpy array; primary beam is specifically for interferometry images; should have the same size of image data
         """
         nx, ny = np.shape(image_data)
         if transform_pix2angle is None:
@@ -59,6 +60,13 @@ class ImageData(PixelGrid, ImageNoise):
         PixelGrid.__init__(self, nx, ny, transform_pix2angle, ra_at_xy_0 + ra_shift, dec_at_xy_0 + dec_shift)
         ImageNoise.__init__(self, image_data, exposure_time=exposure_time, background_rms=background_rms,
                             noise_map=noise_map, gradient_boost_factor=gradient_boost_factor, verbose=False)
+        
+        if primary_beam is not None:
+            pbx,pby=np.shape(primary_beam)
+            if (pbx,pby) != (nx,ny):
+                raise ValueError("The primary beam should have the same size with the image data!")
+                
+        self._pb = primary_beam
 
     def update_data(self, image_data):
         """
@@ -101,3 +109,10 @@ class ImageData(PixelGrid, ImageNoise):
         X2 = np.array(X2)
         logL = - np.sum(X2) / 2
         return logL
+
+    def give_pb(self):
+        """
+        :return: 2d numpy array of primary beam
+
+        """
+        return self._pb

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -57,16 +57,10 @@ class ImageData(PixelGrid, ImageNoise):
         nx, ny = np.shape(image_data)
         if transform_pix2angle is None:
             transform_pix2angle = np.array([[1, 0], [0, 1]])
-        PixelGrid.__init__(self, nx, ny, transform_pix2angle, ra_at_xy_0 + ra_shift, dec_at_xy_0 + dec_shift)
+        PixelGrid.__init__(self, nx, ny, transform_pix2angle, ra_at_xy_0 + ra_shift, dec_at_xy_0 + dec_shift, primary_beam)
         ImageNoise.__init__(self, image_data, exposure_time=exposure_time, background_rms=background_rms,
                             noise_map=noise_map, gradient_boost_factor=gradient_boost_factor, verbose=False)
         
-        if primary_beam is not None:
-            pbx,pby=np.shape(primary_beam)
-            if (pbx,pby) != (nx,ny):
-                raise ValueError("The primary beam should have the same size with the image data!")
-                
-        self._pb = primary_beam
 
     def update_data(self, image_data):
         """
@@ -109,10 +103,3 @@ class ImageData(PixelGrid, ImageNoise):
         X2 = np.array(X2)
         logL = - np.sum(X2) / 2
         return logL
-
-    def give_pb(self):
-        """
-        :return: 2d numpy array of primary beam
-
-        """
-        return self._pb

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -28,6 +28,8 @@ class ImageData(PixelGrid, ImageNoise):
     - 'noise_map': Gaussian noise (1-sigma) for each individual pixel.
     If this keyword is set, the other noise properties will be ignored.
 
+    optional keywords for interferometric quantities:
+    - 'antenna_primary_beam': primary beam pattern of antennae (now treat each antenna with the same primary beam)
 
     ** notes **
     the likelihood for the data given model P(data|model) is defined in the function below. Please make sure that
@@ -37,7 +39,7 @@ class ImageData(PixelGrid, ImageNoise):
 
     """
     def __init__(self, image_data, exposure_time=None, background_rms=None, noise_map=None, gradient_boost_factor=None,
-                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0, primary_beam=None):
+                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0, antenna_primary_beam=None):
         """
 
         :param image_data: 2d numpy array of the image data
@@ -52,15 +54,15 @@ class ImageData(PixelGrid, ImageNoise):
         :param dec_at_xy_0: dec coordinate at pixel (0,0)
         :param ra_shift: RA shift of pixel grid
         :param dec_shift: DEC shift of pixel grid
-        :param primary_beam: 2d numpy array; primary beam is specifically for interferometry images; should have the same size of image data
+        :param antenna_primary_beam: 2d numpy array with the same size of imaga_data;
+         more descriptions of the primary beam can be found in the AngularSensitivity class
         """
         nx, ny = np.shape(image_data)
         if transform_pix2angle is None:
             transform_pix2angle = np.array([[1, 0], [0, 1]])
-        PixelGrid.__init__(self, nx, ny, transform_pix2angle, ra_at_xy_0 + ra_shift, dec_at_xy_0 + dec_shift, primary_beam)
+        PixelGrid.__init__(self, nx, ny, transform_pix2angle, ra_at_xy_0 + ra_shift, dec_at_xy_0 + dec_shift, antenna_primary_beam)
         ImageNoise.__init__(self, image_data, exposure_time=exposure_time, background_rms=background_rms,
                             noise_map=noise_map, gradient_boost_factor=gradient_boost_factor, verbose=False)
-        
 
     def update_data(self, image_data):
         """

--- a/lenstronomy/Data/pixel_grid.py
+++ b/lenstronomy/Data/pixel_grid.py
@@ -1,15 +1,16 @@
 import numpy as np
 from lenstronomy.Data.coord_transforms import Coordinates
+from lenstronomy.Data.angular_sensitivity import AngularSensitivity
 
 __all__ = ['PixelGrid']
 
 
-class PixelGrid(Coordinates):
+class PixelGrid(Coordinates, AngularSensitivity):
     """
     class that manages a specified pixel grid (rectangular at the moment) and its coordinates
     """
 
-    def __init__(self, nx, ny, transform_pix2angle, ra_at_xy_0, dec_at_xy_0, primary_beam=None):
+    def __init__(self, nx, ny, transform_pix2angle, ra_at_xy_0, dec_at_xy_0, antenna_primary_beam=None):
         """
 
         :param nx: number of pixels in x-axis
@@ -17,19 +18,18 @@ class PixelGrid(Coordinates):
         :param transform_pix2angle: 2x2 matrix, mapping of pixel to coordinate
         :param ra_at_xy_0: ra coordinate at pixel (0,0)
         :param dec_at_xy_0: dec coordinate at pixel (0,0)
-        :param primary_beam: 2d numpy array; primary beam is specifically for interferometry images; should have the same size of image data
+        :param antenna_primary_beam: 2d numpy array with the same size of imaga_data;
+         more descriptions of the primary beam can be found in the AngularSensitivity class
         """
         super(PixelGrid, self).__init__(transform_pix2angle, ra_at_xy_0, dec_at_xy_0)
         self._nx = nx
         self._ny = ny
         self._x_grid, self._y_grid = self.coordinate_grid(nx, ny)
-        
-        if primary_beam is not None:
-            pbx,pby=np.shape(primary_beam)
+        if antenna_primary_beam is not None:
+            pbx,pby=np.shape(antenna_primary_beam)
             if (pbx,pby) != (nx,ny):
                 raise ValueError("The primary beam should have the same size with the image data!")
-                
-        self._pb = primary_beam
+        AngularSensitivity.__init__(self, antenna_primary_beam)
 
     @property
     def num_pixel(self):
@@ -81,11 +81,3 @@ class PixelGrid(Coordinates):
         :return: RA coords, DEC coords
         """
         return self._x_grid, self._y_grid
-    
-    @property
-    def give_pb(self):
-        """
-        :return: 2d numpy array of primary beam
-
-        """
-        return self._pb

--- a/lenstronomy/Data/pixel_grid.py
+++ b/lenstronomy/Data/pixel_grid.py
@@ -26,8 +26,8 @@ class PixelGrid(Coordinates, AngularSensitivity):
         self._ny = ny
         self._x_grid, self._y_grid = self.coordinate_grid(nx, ny)
         if antenna_primary_beam is not None:
-            pbx,pby=np.shape(antenna_primary_beam)
-            if (pbx,pby) != (nx,ny):
+            pbx, pby = np.shape(antenna_primary_beam)
+            if (pbx, pby) != (nx, ny):
                 raise ValueError("The primary beam should have the same size with the image data!")
         AngularSensitivity.__init__(self, antenna_primary_beam)
 

--- a/lenstronomy/Data/pixel_grid.py
+++ b/lenstronomy/Data/pixel_grid.py
@@ -9,7 +9,7 @@ class PixelGrid(Coordinates):
     class that manages a specified pixel grid (rectangular at the moment) and its coordinates
     """
 
-    def __init__(self, nx, ny, transform_pix2angle, ra_at_xy_0, dec_at_xy_0):
+    def __init__(self, nx, ny, transform_pix2angle, ra_at_xy_0, dec_at_xy_0, primary_beam=None):
         """
 
         :param nx: number of pixels in x-axis
@@ -17,11 +17,19 @@ class PixelGrid(Coordinates):
         :param transform_pix2angle: 2x2 matrix, mapping of pixel to coordinate
         :param ra_at_xy_0: ra coordinate at pixel (0,0)
         :param dec_at_xy_0: dec coordinate at pixel (0,0)
+        :param primary_beam: 2d numpy array; primary beam is specifically for interferometry images; should have the same size of image data
         """
         super(PixelGrid, self).__init__(transform_pix2angle, ra_at_xy_0, dec_at_xy_0)
         self._nx = nx
         self._ny = ny
         self._x_grid, self._y_grid = self.coordinate_grid(nx, ny)
+        
+        if primary_beam is not None:
+            pbx,pby=np.shape(primary_beam)
+            if (pbx,pby) != (nx,ny):
+                raise ValueError("The primary beam should have the same size with the image data!")
+                
+        self._pb = primary_beam
 
     @property
     def num_pixel(self):
@@ -73,3 +81,11 @@ class PixelGrid(Coordinates):
         :return: RA coords, DEC coords
         """
         return self._x_grid, self._y_grid
+    
+    @property
+    def give_pb(self):
+        """
+        :return: 2d numpy array of primary beam
+
+        """
+        return self._pb

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -289,7 +289,7 @@ class ImageLinearFit(ImageModel):
         for i in range(0, n_source):
             image = source_light_response[i]
             
-            #multiply with primary beam before convolution
+            # multiply with primary beam before convolution
             if self._pb is not None:
                 image *= self._pb_1d
             
@@ -301,7 +301,7 @@ class ImageLinearFit(ImageModel):
         for i in range(0, n_lens_light):
             image = lens_light_response[i]
             
-            #multiply with primary beam before convolution
+            # multiply with primary beam before convolution
             if self._pb is not None:
                 image *= self._pb_1d
                 
@@ -310,6 +310,11 @@ class ImageLinearFit(ImageModel):
             n += 1
         # response of point sources
         for i in range(0, n_points):
+            
+            # raise warnings when primary beam is attempted to be applied for point sources
+            if self._pb is not None:
+                raise Warning("Antenna primary beam does not apply to point sources!")
+            
             image = self.ImageNumerics.point_source_rendering(ra_pos[i], dec_pos[i], amp[i])
             A[n, :] = np.nan_to_num(self.image2array_masked(image), copy=False)
             n += 1

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -288,6 +288,11 @@ class ImageLinearFit(ImageModel):
         # response of lensed source profile
         for i in range(0, n_source):
             image = source_light_response[i]
+            
+            #multiply with primary beam before convolution
+            if self._pb is not None:
+                image *= self._pb_1d
+            
             image *= extinction
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
             A[n, :] = np.nan_to_num(self.image2array_masked(image), copy=False)
@@ -295,6 +300,11 @@ class ImageLinearFit(ImageModel):
         # response of deflector light profile (or any other un-lensed extended components)
         for i in range(0, n_lens_light):
             image = lens_light_response[i]
+            
+            #multiply with primary beam before convolution
+            if self._pb is not None:
+                image *= self._pb_1d
+                
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
             A[n, :] = np.nan_to_num(self.image2array_masked(image), copy=False)
             n += 1

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -76,7 +76,7 @@ class ImageModel(object):
         else:
             self.source_mapping = Image2SourceMapping(lensModel=lens_model_class, sourceModel=source_model_class)
             
-        self._pb = data_class.give_pb
+        self._pb = data_class.primary_beam
         if self._pb is not None:
             self._pb_1d = util.image2array(self._pb)
         else:
@@ -154,7 +154,7 @@ class ImageModel(object):
             source_light *= self._extinction.extinction(ra_grid, dec_grid, kwargs_extinction=kwargs_extinction,
                                                         kwargs_special=kwargs_special)
             
-        #multiply with primary beam before convolution
+        # multiply with primary beam before convolution
         if self._pb is not None:
             source_light *= self._pb_1d
             
@@ -216,7 +216,7 @@ class ImageModel(object):
         ra_grid, dec_grid = self.ImageNumerics.coordinates_evaluate
         lens_light = self.LensLightModel.surface_brightness(ra_grid, dec_grid, kwargs_lens_light, k=k)
         
-        #multiply with primary beam before convolution
+        # multiply with primary beam before convolution
         if self._pb is not None:
             lens_light *= self._pb_1d
             
@@ -250,6 +250,9 @@ class ImageModel(object):
         if unconvolved or self.PointSource is None:
             return point_source_image
         ra_pos, dec_pos, amp = self.PointSource.point_source_list(kwargs_ps, kwargs_lens=kwargs_lens, k=k)
+        # raise warnings when primary beam is attempted to be applied to point sources.
+        if len(ra_pos) != 0 and self._pb is not None:
+            raise Warning("Antenna primary beam does not apply to point sources in ImageModel!")
         ra_pos, dec_pos = self._displace_astrometry(ra_pos, dec_pos, kwargs_special=kwargs_special)
         point_source_image += self.ImageNumerics.point_source_rendering(ra_pos, dec_pos, amp)
         return point_source_image

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -75,6 +75,12 @@ class ImageModel(object):
             self.source_mapping = None  # handled with pixelated operator
         else:
             self.source_mapping = Image2SourceMapping(lensModel=lens_model_class, sourceModel=source_model_class)
+            
+        self._pb = data_class.give_pb()
+        if self._pb is not None:
+            self._pb_1d = util.image2array(self._pb)
+        else:
+            self._pb_1d = None
 
     def reset_point_source_cache(self, cache=True):
         """
@@ -147,6 +153,11 @@ class ImageModel(object):
             source_light = self.source_mapping.image_flux_joint(ra_grid, dec_grid, kwargs_lens, kwargs_source, k=k)
             source_light *= self._extinction.extinction(ra_grid, dec_grid, kwargs_extinction=kwargs_extinction,
                                                         kwargs_special=kwargs_special)
+            
+        #multiply with primary beam before convolution
+        if self._pb is not None:
+            source_light *= self._pb_1d
+            
         source_light_final = self.ImageNumerics.re_size_convolve(source_light, unconvolved=unconvolved)
         return source_light_final
 
@@ -204,6 +215,11 @@ class ImageModel(object):
         """
         ra_grid, dec_grid = self.ImageNumerics.coordinates_evaluate
         lens_light = self.LensLightModel.surface_brightness(ra_grid, dec_grid, kwargs_lens_light, k=k)
+        
+        #multiply with primary beam before convolution
+        if self._pb is not None:
+            lens_light *= self._pb_1d
+            
         lens_light_final = self.ImageNumerics.re_size_convolve(lens_light, unconvolved=unconvolved)
         return lens_light_final
 

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -76,7 +76,7 @@ class ImageModel(object):
         else:
             self.source_mapping = Image2SourceMapping(lensModel=lens_model_class, sourceModel=source_model_class)
             
-        self._pb = data_class.give_pb()
+        self._pb = data_class.give_pb
         if self._pb is not None:
             self._pb_1d = util.image2array(self._pb)
         else:

--- a/test/test_ImSim/test_image_model_with_interferometric_changes.py
+++ b/test/test_ImSim/test_image_model_with_interferometric_changes.py
@@ -1,0 +1,65 @@
+import numpy.testing as npt
+import numpy as np
+
+from lenstronomy.LensModel.lens_model import LensModel
+from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.ImSim.image_model import ImageModel
+import lenstronomy.Util.simulation_util as sim_util
+from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.Data.psf import PSF
+
+"""
+test the antenna primary beam (maybe be modified further to test all interferometric changes)
+The idea of this test is to define two data classes, one with the antenna primary beam, one without, 
+and compare the (image_with_pb) with (image_no_pb * pb). ('pb' is short for primary beam.)
+"""
+
+def test_interferometric_changes():
+
+    sigma_bkg = .05  # background noise per pixel
+    exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
+    numPix = 100  # cutout pixel size
+    deltaPix = 0.05  # pixel size in arcsec (area per pixel = deltaPix**2)
+    
+    primary_beam = np.zeros((numPix,numPix))
+    for i in range(numPix):
+        for j in range(numPix):
+            primary_beam[i,j] = np.exp(-1e-4*((i-78)**2+(j-56)**2))
+    primary_beam /= np.max(primary_beam)
+    
+    kwargs_data_no_pb = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg, inverse=True)
+    data_class_no_pb = ImageData(**kwargs_data_no_pb)
+    
+    kwargs_data_with_pb = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg, inverse=True)
+    kwargs_data_with_pb['antenna_primary_beam'] = primary_beam
+    data_class_with_pb = ImageData(**kwargs_data_with_pb)
+    
+    kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': np.ones((1,1))}
+    psf_class = PSF(**kwargs_psf)
+    
+    kwargs_shear = {'gamma1': 0.01, 'gamma2': 0.01}
+    kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.04}
+    lens_model_list = ['SPEP', 'SHEAR']
+    kwargs_lens = [kwargs_spemd, kwargs_shear]
+    lens_model_class = LensModel(lens_model_list=lens_model_list)
+            
+    kwargs_sersic = {'amp': 30., 'R_sersic': 0.3, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
+    lens_light_model_list = ['SERSIC']
+    kwargs_lens_light = [kwargs_sersic]
+    lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
+    
+    kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 7, 'center_x': 0, 'center_y': 0,
+                                     'e1': 0.05, 'e2': 0.02}
+    source_model_list = ['SERSIC_ELLIPSE']
+    kwargs_source = [kwargs_sersic_ellipse]
+    source_model_class = LightModel(light_model_list=source_model_list)
+    
+    kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False}
+    
+    imageModel_no_pb = ImageModel(data_class_no_pb, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    image_sim_no_pb = imageModel_no_pb.image(kwargs_lens, kwargs_source,kwargs_lens_light)
+    
+    imageModel_with_pb = ImageModel(data_class_with_pb, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    image_sim_with_pb = imageModel_with_pb.image(kwargs_lens, kwargs_source,kwargs_lens_light)
+    
+    npt.assert_almost_equal(image_sim_with_pb, image_sim_no_pb * primary_beam, decimal=8)


### PR DESCRIPTION
…ImageLinearFit)

Add the primary beam to image simulation and linear solver (where the light response is computed).

The 'primary beam' is input into ImageData class and is inherited by ImageModel and further ImageLinearFit. It should be a 2d numpy array and has the same size of the data image.

Physically, the primary beam is the angular response function of each antenna of an interferometry array. Numerically, it serves as a multiplier on an unconvolved image.

In other words, a convolved interferometric image is I_convolved = (I_unconvolved . primary beam ) * PSF, where . denotes multiplication and * denotes convolution.

For more info on primary beam, consult
https://casaguides.nrao.edu/index.php/VLA_CASA_Imaging-CASA5.0.0#Primary_and_Synthesized_Beam https://casadocs.readthedocs.io/en/stable/notebooks/synthesis_imaging.html?highlight=primary%20beam%20#Antenna-Voltage/Power-Patterns:-Primary-Beam