### PR TITLE
Change raise error of psf negative pixels to warning, allow user to choose if they need the automatical psf normalization

### DIFF
--- a/lenstronomy/Util/kernel_util.py
+++ b/lenstronomy/Util/kernel_util.py
@@ -173,7 +173,7 @@ def kernel_pixelsize_change(kernel, deltaPix_in, deltaPix_out):
 
 
 @export
-def cut_psf(psf_data, psf_size):
+def cut_psf(psf_data, psf_size, normalisation=True):
     """
     cut the psf properly
 
@@ -182,7 +182,8 @@ def cut_psf(psf_data, psf_size):
     :return: re-sized and re-normalized PSF
     """
     kernel = image_util.cut_edges(psf_data, psf_size)
-    kernel = kernel_norm(kernel)
+    if normalisation is True:
+        kernel = kernel_norm(kernel)
     return kernel
 
 

--- a/test/test_Data/test_psf.py
+++ b/test/test_Data/test_psf.py
@@ -168,8 +168,6 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(ValueError):
             psf = PSF(psf_type='GAUSSIAN', fwhm=100, pixel_size=0.0001)
             psf.kernel_point_source_supersampled(supersampling_factor=3)
-        with self.assertRaises(ValueError):
-            psf = PSF(psf_type='PIXEL', kernel_point_source=-np.ones((3, 3)))
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.

--- a/test/test_ImSim/test_image_model_with_interferometric_changes.py
+++ b/test/test_ImSim/test_image_model_with_interferometric_changes.py
@@ -5,15 +5,16 @@ from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.LightModel.light_model import LightModel
 from lenstronomy.ImSim.image_model import ImageModel
 import lenstronomy.Util.simulation_util as sim_util
+from lenstronomy.Util import kernel_util
 from lenstronomy.Data.imaging_data import ImageData
 from lenstronomy.Data.psf import PSF
+import scipy.signal
 
 """
-test the antenna primary beam (maybe be modified further to test all interferometric changes)
-The idea of this test is to define two data classes, one with the antenna primary beam, one without, 
-and compare the (image_with_pb) with (image_no_pb * pb). ('pb' is short for primary beam.)
+test the antenna primary beam and interferometric PSF (containing negative pixels and do not want normalisation)
+The idea of this test is to define two sets of data class and psf class, one with the antenna primary beam and PSF, one without, 
+and compare the (image_with_pb_and_psf) with scipy.signal.fftconvolve(image_without_pb_psf * pb, PSF, mode='same').
 """
-
 
 def test_interferometric_changes():
 
@@ -21,46 +22,70 @@ def test_interferometric_changes():
     exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
     numPix = 100  # cutout pixel size
     deltaPix = 0.05  # pixel size in arcsec (area per pixel = deltaPix**2)
-    
+
+    # simulate a primary beam (pb)
     primary_beam = np.zeros((numPix,numPix))
     for i in range(numPix):
         for j in range(numPix):
             primary_beam[i,j] = np.exp(-1e-4*((i-78)**2+(j-56)**2))
     primary_beam /= np.max(primary_beam)
+
+    # simulate a spherical sinc function as psf, which contains negative pixels
+    psf_test = np.zeros((221,221))
+    for i in range(221):
+        for j in range(221):
+            if i > j:
+                psf_test[i,j] = psf_test[j,i]
+            r = np.sqrt((i-110)**2 + (j-110)**2)
+            if r == 0:
+                psf_test[i,j] = 1
+            else:
+                psf_test[i,j] = np.sin(r*0.5)/(r*0.5)
     
-    kwargs_data_no_pb = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg, inverse=True)
+    # define two data classes
+    kwargs_data_no_pb = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
     data_class_no_pb = ImageData(**kwargs_data_no_pb)
-    
-    kwargs_data_with_pb = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg, inverse=True)
+
+    kwargs_data_with_pb = sim_util.data_configure_simple(numPix, deltaPix, exp_time, sigma_bkg)
     kwargs_data_with_pb['antenna_primary_beam'] = primary_beam
     data_class_with_pb = ImageData(**kwargs_data_with_pb)
-    
-    kwargs_psf = {'psf_type': 'PIXEL', 'kernel_point_source': np.ones((1,1))}
+
+    # define two psf classes
+    kwargs_psf_none = {'psf_type': 'NONE'}
+    psf_class_none = PSF(**kwargs_psf_none)
+
+    kernel_cut = kernel_util.cut_psf(psf_test, 201, normalisation = False)
+    kwargs_psf = {'psf_type': 'PIXEL', 'pixel_size': deltaPix, 'kernel_point_source': kernel_cut,'kernel_point_source_normalisation': False }
     psf_class = PSF(**kwargs_psf)
-    
+
+    # define lens model and source model
     kwargs_shear = {'gamma1': 0.01, 'gamma2': 0.01}
     kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.04}
     lens_model_list = ['SPEP', 'SHEAR']
     kwargs_lens = [kwargs_spemd, kwargs_shear]
     lens_model_class = LensModel(lens_model_list=lens_model_list)
-            
+
     kwargs_sersic = {'amp': 30., 'R_sersic': 0.3, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
     lens_light_model_list = ['SERSIC']
     kwargs_lens_light = [kwargs_sersic]
     lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
-    
+
     kwargs_sersic_ellipse = {'amp': 1., 'R_sersic': .6, 'n_sersic': 7, 'center_x': 0, 'center_y': 0,
-                                     'e1': 0.05, 'e2': 0.02}
+                                         'e1': 0.05, 'e2': 0.02}
     source_model_list = ['SERSIC_ELLIPSE']
     kwargs_source = [kwargs_sersic_ellipse]
     source_model_class = LightModel(light_model_list=source_model_list)
-    
+
     kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False}
-    
-    imageModel_no_pb = ImageModel(data_class_no_pb, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
-    image_sim_no_pb = imageModel_no_pb.image(kwargs_lens, kwargs_source,kwargs_lens_light)
-    
-    imageModel_with_pb = ImageModel(data_class_with_pb, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
-    image_sim_with_pb = imageModel_with_pb.image(kwargs_lens, kwargs_source,kwargs_lens_light)
-    
-    npt.assert_almost_equal(image_sim_with_pb, image_sim_no_pb * primary_beam, decimal=8)
+
+    # make images using 1) data and psf classes without pb and or psf
+    imageModel_no_pb_psf = ImageModel(data_class_no_pb, psf_class_none, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    image_sim_no_pb_psf = imageModel_no_pb_psf.image(kwargs_lens, kwargs_source,kwargs_lens_light)
+
+    # make images using 2) data and psf classes with defined pb and or psf
+    imageModel_with_pb_psf = ImageModel(data_class_with_pb, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    image_sim_with_pb_psf = imageModel_with_pb_psf.image(kwargs_lens, kwargs_source,kwargs_lens_light)
+
+    # add pb and psf to 1) out of the imageModel, compare them to check if the pb and psf changes make sense
+    image_sim_with_pb_psf2 = scipy.signal.fftconvolve(image_sim_no_pb_psf * primary_beam,kernel_cut,mode='same')
+    npt.assert_almost_equal(image_sim_with_pb_psf, image_sim_with_pb_psf2, decimal=8)


### PR DESCRIPTION
Change raise error of psf negative pixels to warning, allow user to choose if they need the automatical psf normalization

4 files have been changed.

psf.py: change the raise ValueError to warnings.warn if the PSF contains negative pixels; add one more parameter 'kernel_point_source_normalisation' to control if the user want the PSF auto-normalization. The default of 'kernel_point_source_normalisation' is True, so it should not change anything if people just igore it.

kernel_util.py: change the cut_psf function to have one more parameter 'normalisation' to control if the normalization should be done by the psf_cut.

test_psf.py: delete the 'assertRaises(ValueError)' part for negative PSF pixels. It should be replaced by some catching warning functions of pytest. But I am not sure how to do that.

test_image_model_with_interferometric_changes.py: modify this test file to test the primary beam and psf (with negative pixels) in ImageModel.