### PR TITLE
simplify LensCosmo class

### DIFF
--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -27,15 +27,6 @@ class LensCosmo(object):
         self.background = Background(cosmo=cosmo)
         self.nfw_param = NFWParam(cosmo=cosmo)
 
-    def a_z(self, z):
-        """
-        convert redshift into scale factor
-
-        :param z: redshift
-        :return: scale factor
-        """
-        return 1. / (1. + z)
-
     @property
     def h(self):
         return self.background.cosmo.H(0).value / 100.

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -54,6 +54,17 @@ def text_description(ax, d, text, color='w', backgroundcolor='k',
 
 @export
 def scale_bar(ax, d, dist=1., text='1"', color='w', font_size=15, flipped=False):
+    """
+
+    :param ax: matplotlib.axes instance
+    :param d: diameter of frame
+    :param dist: distance scale printed
+    :param text: string printed on scale bar
+    :param color: color of scale bar
+    :param font_size: font size
+    :param flipped: boolean
+    :return: None, updated ax instance
+    """
     if flipped:
         p0 = d - d / 15. - dist
         p1 = d / 15.
@@ -68,6 +79,16 @@ def scale_bar(ax, d, dist=1., text='1"', color='w', font_size=15, flipped=False)
 
 @export
 def coordinate_arrows(ax, d, coords, color='w', font_size=15, arrow_size=0.05):
+    """
+
+    :param ax: matplotlib axes instance
+    :param d: diameter of frame in ax
+    :param coords: lenstronomy.Data.coord_transforms Coordinates() instance
+    :param color: color string
+    :param font_size: font size of length scale
+    :param arrow_size: size of arrow
+    :return: updated ax instance
+    """
     d0 = d / 8.
     p0 = d / 15.
     pt = d / 9.

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -105,7 +105,7 @@ class TestLensCosmo(object):
 
     def test_a_z(self):
 
-        a = self.lensCosmo.a_z(z=1)
+        a = self.lensCosmo.background.a_z(z=1)
         npt.assert_almost_equal(a, 0.5)
 
     def test_sersic_m_star2k_eff(self):


### PR DESCRIPTION
I remove the a(z) definition from the LensCosmo class as it's a duplicate of the background class and not strictly presents a class feature