### PR TITLE
Add interferometric likelihood and linear solver

### DIFF
--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -29,7 +29,10 @@ class ImageData(PixelGrid, ImageNoise):
     If this keyword is set, the other noise properties will be ignored.
 
     optional keywords for interferometric quantities:
-    - 'antenna_primary_beam': primary beam pattern of antennae (now treat each antenna with the same primary beam)
+    - 'likelihood_method': need to be specified to 'interferometry_natwt' if one needs to use the interferometric likelihood function.
+    The default of 'likelihood_method' is 'diagonal', which is used for non-correlated noises (usually for the CCD images.)
+    - 'log_likelihood_constant': a constant that adds to logL.
+    - 'antenna_primary_beam': primary beam pattern of antennae (now treat each antenna dish with the same primary beam).
 
     ** notes **
     the likelihood for the data given model P(data|model) is defined in the function below. Please make sure that
@@ -39,7 +42,8 @@ class ImageData(PixelGrid, ImageNoise):
 
     """
     def __init__(self, image_data, exposure_time=None, background_rms=None, noise_map=None, gradient_boost_factor=None,
-                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0, antenna_primary_beam=None):
+                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0,  log_likelihood_constant=0,
+                 antenna_primary_beam=None, likelihood_method='diagonal'):
         """
 
         :param image_data: 2d numpy array of the image data
@@ -54,8 +58,12 @@ class ImageData(PixelGrid, ImageNoise):
         :param dec_at_xy_0: dec coordinate at pixel (0,0)
         :param ra_shift: RA shift of pixel grid
         :param dec_shift: DEC shift of pixel grid
+        :param log_likelihood_constant: float, allows user to input a constant that will be added to the log likelihood. Note that, as for now, this variable is ONLY used for interferometric mode.
         :param antenna_primary_beam: 2d numpy array with the same size of imaga_data;
          more descriptions of the primary beam can be found in the AngularSensitivity class
+        :param likelihood_method: string, type of method of log_likelihood computation: options are 'diagonal', 'interferometry_natwt'.
+         The default option 'diagonal' uses a diagonal covariance matrix, which is case for CCD images.
+         The 'interferometry_natwt' option uses our special interferometric likelihood function based on natural weighting images.
         """
         nx, ny = np.shape(image_data)
         if transform_pix2angle is None:
@@ -63,6 +71,11 @@ class ImageData(PixelGrid, ImageNoise):
         PixelGrid.__init__(self, nx, ny, transform_pix2angle, ra_at_xy_0 + ra_shift, dec_at_xy_0 + dec_shift, antenna_primary_beam)
         ImageNoise.__init__(self, image_data, exposure_time=exposure_time, background_rms=background_rms,
                             noise_map=noise_map, gradient_boost_factor=gradient_boost_factor, verbose=False)
+
+        self._logL_constant = log_likelihood_constant
+        self._logL_method = likelihood_method
+        if self._logL_method != 'diagonal' and self._logL_method != 'interferometry_natwt':
+            raise ValueError("likelihood_method %s not supported! likelihood_method can only be 'diagonal' or 'interferometry_natwt'!" % self._logL_method)
 
     def update_data(self, image_data):
         """
@@ -100,8 +113,44 @@ class ImageData(PixelGrid, ImageNoise):
             This can e.g. come from model errors in the PSF estimation.
         :return: the natural logarithm of the likelihood p(data|model)
         """
+        # if the likelihood method is assigned to be 'interferometry_natwt', it will return logL computed using the interfermetric likelihood function
+        if self._logL_method == 'interferometry_natwt':
+            return self.log_likelihood_interferometry(model)
+        
         C_D = self.C_D_model(model)
         X2 = (model - self._data) ** 2 / (C_D + np.abs(additional_error_map)) * mask
         X2 = np.array(X2)
         logL = - np.sum(X2) / 2
         return logL
+    
+    def log_likelihood_interferometry(self, model):
+        """
+        For the interferometry case, the model should be in the form [array1, array2], 
+        where array1 and array2 are unconvolved and convolved model images respectively.
+        They are both 2d array with the same shape of the data.
+        
+        The chi^2 of interferometry is computed by
+        .. math::
+        \\chi^2 =  (d-Ax)^TC^{-1}(d-Ax) = \\frac{1}{\\sigma^2}(d^TA^{-1}d - 2x^Td + x^TAx)
+        where :math:`d` and :math:`x` are the data vector and the unconvolved model image vector respectively.
+        :math:`A` is the convolution operation matrix, where we normalize the PSF by setting its central pixel to 1.
+        :math:`C` is the noise covariance matrix, its diagonal entries are rms^2 of noises, :math:`\\sigma^2`.
+        For natural weighting interferometric images, we used the relation
+        .. math::
+        C = \\sigma^2 A
+        to simplify the likelihood function above. 
+        """
+        
+        xd = np.sum(model[0] * self._data)
+        xAx = np.sum(model[0] * model[1])
+        logL = - (xAx - 2 * xd) / (2 * self._background_rms ** 2) + self._logL_constant
+        return logL
+    
+    def likelihood_method(self):
+        """
+        
+        pass the likelihood_method to the ImageModel and will be used to identify the method of 
+        likelihood computation in ImageLinearFit.
+        :return: string, likelihood method
+        """
+        return self._logL_method

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -131,13 +131,13 @@ class ImageData(PixelGrid, ImageNoise):
         
         The chi^2 of interferometry is computed by
         .. math::
-        \\chi^2 =  (d-Ax)^TC^{-1}(d-Ax) = \\frac{1}{\\sigma^2}(d^TA^{-1}d - 2x^Td + x^TAx)
+            \\chi^2 =  (d-Ax)^TC^{-1}(d-Ax) = \\frac{1}{\\sigma^2}(d^TA^{-1}d - 2x^Td + x^TAx)
         where :math:`d` and :math:`x` are the data vector and the unconvolved model image vector respectively.
         :math:`A` is the convolution operation matrix, where we normalize the PSF by setting its central pixel to 1.
         :math:`C` is the noise covariance matrix, its diagonal entries are rms^2 of noises, :math:`\\sigma^2`.
         For natural weighting interferometric images, we used the relation
         .. math::
-        C = \\sigma^2 A
+            C = \\sigma^2 A
         to simplify the likelihood function above. 
         """
         

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -42,7 +42,7 @@ class ImageData(PixelGrid, ImageNoise):
 
     """
     def __init__(self, image_data, exposure_time=None, background_rms=None, noise_map=None, gradient_boost_factor=None,
-                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0,  log_likelihood_constant=0,
+                 ra_at_xy_0=0, dec_at_xy_0=0, transform_pix2angle=None, ra_shift=0, dec_shift=0, log_likelihood_constant=0,
                  antenna_primary_beam=None, likelihood_method='diagonal'):
         """
 
@@ -62,7 +62,7 @@ class ImageData(PixelGrid, ImageNoise):
         :param antenna_primary_beam: 2d numpy array with the same size of imaga_data;
          more descriptions of the primary beam can be found in the AngularSensitivity class
         :param likelihood_method: string, type of method of log_likelihood computation: options are 'diagonal', 'interferometry_natwt'.
-         The default option 'diagonal' uses a diagonal covariance matrix, which is case for CCD images.
+         The default option 'diagonal' uses a diagonal covariance matrix, which is the case for CCD images.
          The 'interferometry_natwt' option uses our special interferometric likelihood function based on natural weighting images.
         """
         nx, ny = np.shape(image_data)

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -125,6 +125,9 @@ class ImageData(PixelGrid, ImageNoise):
     
     def log_likelihood_interferometry(self, model):
         """
+        log_likelihood function for natural weighting interferometric images,
+        based on (place holder for Nan Zhang's paper).
+        
         For the interferometry case, the model should be in the form [array1, array2], 
         where array1 and array2 are unconvolved and convolved model images respectively.
         They are both 2d array with the same shape of the data.
@@ -135,7 +138,8 @@ class ImageData(PixelGrid, ImageNoise):
         where :math:`d` and :math:`x` are the data vector and the unconvolved model image vector respectively.
         :math:`A` is the convolution operation matrix, where we normalize the PSF by setting its central pixel to 1.
         :math:`C` is the noise covariance matrix, its diagonal entries are rms^2 of noises, :math:`\\sigma^2`.
-        For natural weighting interferometric images, we used the relation
+        For natural weighting interferometric images, we used the relation 
+        (see Section 3.2 of https://doi.org/10.1093/mnras/staa2740 for the relation of natural weighting covariance matrix and PSF convolution)
         .. math::
             C = \\sigma^2 A
         to simplify the likelihood function above. 

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -560,7 +560,6 @@ class ImageLinearFit(ImageModel):
             return True
         else:
             return False
-
     
     # linear solver for interferometric natwt method
     def _image_linear_solve_interferometry_natwt(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
@@ -585,7 +584,8 @@ class ImageLinearFit(ImageModel):
 
     def _image_linear_solve_interferometry_natwt_solving(self, A, d):
         """
-        linearly solve the amplitude of each light profile response to the image.
+        Linearly solve the amplitude of each light profile response to the natural weighting interferometry images,
+        based on (place holder for Nan Zhang's paper).
         
         Theories:
             Suppose there are a set of light responses :math:`\\{x_i\\}`, we want to solve the set of amplitudes :math:`\\{\\alpha_i\\}`,
@@ -594,20 +594,22 @@ class ImageLinearFit(ImageModel):
                     \\chi^2 = (d - A_{PSF}\\sum_i \\alpha_i x_i)^TC^{-1}(d - A_{PSF}\\sum_i \\alpha_i x_i),
             where :math:`A_{PSF}` is the PSF convolution operation matrix (not to be confused with the input A of this function) 
             and :math:`C` is the noise covariance matrix. :math:`d` is the data image.
-            For natural weighting interferometric images, we have :math:`C = \\sigma^2 A_{PSF}`, therefore the chi^2 function simplifies to 
+            For natural weighting interferometric images, we have :math:`C = \\sigma^2 A_{PSF}`, 
+            (see Section 3.2 of https://doi.org/10.1093/mnras/staa2740 for the relation of natural weighting covariance matrix and PSF convolution)
+            therefore the chi^2 function simplifies to 
             .. math::
                     \\chi^2 = \\frac{1}{\\sigma^2}(d^TA_{PSF}^{-1}d + \\sum_{i,j}\\alpha_i\\alpha_j x_i^TA_{PSF}x_j - 2\\sum_{i}x_i^Td),
             from which the optimal amplitudes :math:`\\{\\alpha_i\\}` can be solved linearly by solving
             .. math::
                     \\sum_{j} M_{ij}\\alpha_{j} = b_i,
-            where :math:`M_{ij} = \\frac{1}{\sigma^2}x_i^TA_{PSF}x_j` and :math:`b_{i} = \\frac{1}{\sigma^2}x_i^Td`.
+            where :math:`M_{ij} = \\frac{1}{\\sigma^2}x_i^TA_{PSF}x_j` and :math:`b_{i} = \\frac{1}{\\sigma^2}x_i^Td`.
         
         The steps of this function are:
-            (1.) Making the entris :math:`M_{ij}` and :math:`b_i` defined above.
-            (2.) Solve the linear function to get optimal amplitudes.
+            (1.) Making the entries :math:`M_{ij}` and :math:`b_i` defined above.
+            (2.) Solve the linear function to get the optimal amplitudes.
             (3.) Apply these optimal amplitudes to make unconvolved and convolved model images.
                 The output model images are in the form [array1, array2]. 
-                (Note that this different from the non-interferometric linear solve of Lenstronomy, 
+                (Note that this is different from the non-interferometric linear solver of Lenstronomy, 
                  this output form saves time for likelihood computations in imaging_data for interferometric method.)
                 array1 is the unconvolved model image :math:`array1 = \\sum_i \\alpha_i x_i`, where :math:`\\alpha_i` is the solved optimal amplitudes.
                 array2 is the convolved model image :math:`array2 = A_{PSF}\\sum_i \\alpha_i x_i`, where :math:`\\alpha_i`.
@@ -615,8 +617,8 @@ class ImageLinearFit(ImageModel):
         :param A: response of unconvolved light profiles, [x_1, x_2, ...]
         :param d: data image, d
         :return: [array1, array2], [amp_array] 
-        where the [array1, array2] are unconvolved and convolved model images with marginalized amplitudes
-        and [amp_array] are marginalized optimal amplitudes.
+        where the [array1, array2] are unconvolved and convolved model images with solved amplitudes
+        and [amp_array] are the solved optimal amplitudes.
         
         """
         num_of_light, num_of_image_pixel = np.shape(A)

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -1,6 +1,7 @@
 from lenstronomy.ImSim.image_model import ImageModel
 import lenstronomy.ImSim.de_lens as de_lens
 from lenstronomy.Util import util
+from lenstronomy.ImSim.Numerics.convolution import PixelKernelConvolution
 import numpy as np
 
 __all__ = ['ImageLinearFit']
@@ -50,6 +51,10 @@ class ImageLinearFit(ImageModel):
             # update the pixel-based solver with the likelihood mask
             self.PixelSolver.set_likelihood_mask(self.likelihood_mask)
 
+        # prepare to use fft convolution for the natwt linear solver 
+        if self.Data.likelihood_method() == 'interferometry_natwt':
+            self._convolution = PixelKernelConvolution(kernel = self.PSF.kernel_point_source)
+            
     def image_linear_solve(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                            kwargs_extinction=None, kwargs_special=None, inv_bool=False):
         """
@@ -88,13 +93,18 @@ class ImageLinearFit(ImageModel):
             model, model_error, cov_param, param = self.image_pixelbased_solve(kwargs_lens, kwargs_source, 
                                                                                kwargs_lens_light, kwargs_ps, 
                                                                                kwargs_extinction, kwargs_special)
-        else:
+        elif self.Data.likelihood_method() == 'diagonal':
             A = self._linear_response_matrix(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction, kwargs_special)
             C_D_response, model_error = self._error_response(kwargs_lens, kwargs_ps, kwargs_special=kwargs_special)
             d = self.data_response
             param, cov_param, wls_model = de_lens.get_param_WLS(A.T, 1 / C_D_response, d, inv_bool=inv_bool)
             model = self.array_masked2image(wls_model)
             _, _, _, _ = self.update_linear_kwargs(param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps)
+        elif self.Data.likelihood_method() == 'interferometry_natwt':
+            model, model_error, cov_param, param = self._image_linear_solve_interferometry_natwt(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps,
+                            kwargs_extinction, kwargs_special)
+        else:
+            raise ValueError("likelihood_method %s not supported!" % self.Data.likelihood_method())
         return model, model_error, cov_param, param
 
     def image_pixelbased_solve(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, 
@@ -550,3 +560,96 @@ class ImageLinearFit(ImageModel):
             return True
         else:
             return False
+
+    
+    # linear solver for interferometric natwt method
+    def _image_linear_solve_interferometry_natwt(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
+                            kwargs_extinction=None, kwargs_special=None):
+        """
+        'interferometry_natwt' method does NOT support model_error, cov_param.
+        The interferometry linear solver just does the linear solving to get the optimal linear amplitudes
+        and apply the marginalized amplitudes to make the model images.
+        
+        :return: model, model_error, cov_param, param
+        model and param are the same returns of self._image_linear_solve_interferometry_natwt_solving(A, d) function
+        model_error =0 and cov_param = None for the interferometric method.
+        
+        """
+        A = self._linear_response_matrix(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction, kwargs_special, unconvolved=True)
+        d = self.data_response
+        model, param = self._image_linear_solve_interferometry_natwt_solving(A, d)
+        model_error = 0 # just a place holder 
+        cov_param = None # just a place holder
+        _, _, _, _ = self.update_linear_kwargs(param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps)
+        return model, model_error, cov_param, param
+
+    def _image_linear_solve_interferometry_natwt_solving(self, A, d):
+        """
+        linearly solve the amplitude of each light profile response to the image.
+        
+        Theories:
+            Suppose there are a set of light responses :math:`\\{x_i\\}`, we want to solve the set of amplitudes :math:`\\{\\alpha_i\\}`,
+            such that minimizes the chi^2 given by 
+            .. math::
+                    \\chi^2 = (d - A_{PSF}\\sum_i \\alpha_i x_i)^TC^{-1}(d - A_{PSF}\\sum_i \\alpha_i x_i),
+            where :math:`A_{PSF}` is the PSF convolution operation matrix (not to be confused with the input A of this function) 
+            and :math:`C` is the noise covariance matrix. :math:`d` is the data image.
+            For natural weighting interferometric images, we have :math:`C = \\sigma^2 A_{PSF}`, therefore the chi^2 function simplifies to 
+            .. math::
+                    \\chi^2 = \\frac{1}{\\sigma^2}(d^TA_{PSF}^{-1}d + \\sum_{i,j}\\alpha_i\\alpha_j x_i^TA_{PSF}x_j - 2\\sum_{i}x_i^Td),
+            from which the optimal amplitudes :math:`\\{\\alpha_i\\}` can be solved linearly by solving
+            .. math::
+                    \\sum_{j} M_{ij}\\alpha_{j} = b_i,
+            where :math:`M_{ij} = \\frac{1}{\sigma^2}x_i^TA_{PSF}x_j` and :math:`b_{i} = \\frac{1}{\sigma^2}x_i^Td`.
+        
+        The steps of this function are:
+            (1.) Making the entris :math:`M_{ij}` and :math:`b_i` defined above.
+            (2.) Solve the linear function to get optimal amplitudes.
+            (3.) Apply these optimal amplitudes to make unconvolved and convolved model images.
+                The output model images are in the form [array1, array2]. 
+                (Note that this different from the non-interferometric linear solve of Lenstronomy, 
+                 this output form saves time for likelihood computations in imaging_data for interferometric method.)
+                array1 is the unconvolved model image :math:`array1 = \\sum_i \\alpha_i x_i`, where :math:`\\alpha_i` is the solved optimal amplitudes.
+                array2 is the convolved model image :math:`array2 = A_{PSF}\\sum_i \\alpha_i x_i`, where :math:`\\alpha_i`.
+         
+        :param A: response of unconvolved light profiles, [x_1, x_2, ...]
+        :param d: data image, d
+        :return: [array1, array2], [amp_array] 
+        where the [array1, array2] are unconvolved and convolved model images with marginalized amplitudes
+        and [amp_array] are marginalized optimal amplitudes.
+        
+        """
+        num_of_light, num_of_image_pixel = np.shape(A)
+        
+        A_convolved = np.zeros(np.shape(A))
+        
+        # convolve each response separately
+        for i in range(num_of_light):
+            A_convolved[i] = util.image2array(self._convolution._static_fft(util.array2image(A[i]), mode='same'))
+            
+        M = np.zeros((num_of_light,num_of_light))
+        for i in range(num_of_light):
+            for j in range(num_of_light):
+                if j < i:
+                    M[i,j] = M[j,i]
+                else:
+                    M[i,j] = np.sum(A_convolved[j] * A[i])
+        
+        b = np.zeros((num_of_light))
+        for i in range(num_of_light):
+            b[i] = np.sum(A[i] * (d))
+            
+        param_amps = np.linalg.lstsq(M, b)[0]
+        
+        clean_temp = np.zeros((num_of_image_pixel))
+        dirty_temp = np.zeros((num_of_image_pixel))
+        for i in range(num_of_light):
+            clean_temp += param_amps[i] * A[i]
+            dirty_temp += param_amps[i] * A_convolved[i]
+            
+        clean_model = util.array2image(clean_temp)
+        dirty_model = util.array2image(dirty_temp)
+            
+        model = [clean_model, dirty_model]
+        
+        return model, param_amps

--- a/test/test_Data/test_imaging_data.py
+++ b/test/test_Data/test_imaging_data.py
@@ -98,6 +98,8 @@ class TestRaise(unittest.TestCase):
         image_data_new = np.zeros((5, 5))
         with self.assertRaises(ValueError):
             out = Data.update_data(image_data_new)
+        with self.assertRaises(ValueError):
+            ImageData(**kwargs_data, likelihood_method = 'WRONG')
 
 
 if __name__ == '__main__':

--- a/test/test_Data/test_imaging_data_with_interferometric_changes.py
+++ b/test/test_Data/test_imaging_data_with_interferometric_changes.py
@@ -1,0 +1,27 @@
+import numpy as np
+import numpy.testing as npt
+from lenstronomy.Data.imaging_data import ImageData
+
+def test_interferometry_likelihood():
+    """
+    
+    test interferometry natural weighting likelihood function, test likelihood_method function output
+
+    """
+    
+    test_data = np.zeros((5,5))
+    test_data[0,:] = 1
+    test_data[:,4] = 2
+    
+    mask = np.ones((5,5))
+    model_unconvolved = np.zeros((5,5))
+    model_convolved = np.zeros((5,5))
+    model_unconvolved[0,4] = 1.2
+    model_convolved[0,:] = 1
+    model_convolved[:,4] = 1
+    
+    data_class = ImageData(image_data = test_data, background_rms = 2.5, log_likelihood_constant = -1.0,  likelihood_method = 'interferometry_natwt')
+    
+    assert data_class.likelihood_method() == 'interferometry_natwt'
+    npt.assert_almost_equal(data_class.log_likelihood([model_unconvolved,model_convolved],mask), -0.712, decimal=8)
+    

--- a/test/test_ImSim/test_image_linear_solve_with_interferometric_changes.py
+++ b/test/test_ImSim/test_image_linear_solve_with_interferometric_changes.py
@@ -1,0 +1,118 @@
+import numpy as np
+import numpy.testing as npt
+import scipy.signal
+from lenstronomy.ImSim.image_model import ImageModel
+from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.Data.psf import PSF
+from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.LensModel.lens_model import LensModel
+import lenstronomy.Util.simulation_util as sim_util
+from lenstronomy.Util import kernel_util
+import lenstronomy.Util.util as util
+
+from lenstronomy.ImSim.image_linear_solve import ImageLinearFit
+
+"""
+Test the linear solver for natwt (natural weighting) interferometric data.
+Test the _image_linear_solve function of ImageLinearFit class.
+The idea is to define data, psf, source, lens, lens light classes respectively, and run the linear solving
+inside and outside of the _image_linear_solve function. Verify the 1st and 4th output of _image_linear_solve.
+The test should be independent of the specific definitions of the light and lens profiles.
+"""
+
+
+def test_image_linear_solve_with_primary_beam_and_interferometry_psf():
+    
+    background_rms = .05 
+    exp_time = np.inf 
+    numPix = 80 
+    deltaPix = 0.05  
+    psf_type = 'PIXEL'  
+    kernel_size = 161 
+    
+    # simulate a primary beam (pb)
+    primary_beam = np.zeros((numPix,numPix))
+    for i in range(numPix):
+        for j in range(numPix):
+            primary_beam[i,j] = np.exp(-1e-4*((i-78)**2+(j-56)**2))
+    primary_beam /= np.max(primary_beam)
+    
+    # simulate a spherical sinc function as psf, which contains negative pixels
+    psf_test = np.zeros((221,221))
+    for i in range(221):
+        for j in range(221):
+            if i > j:
+                psf_test[i,j] = psf_test[j,i]
+            r = np.sqrt((i-110)**2 + (j-110)**2)
+            if r == 0:
+                psf_test[i,j] = 1
+            else:
+                psf_test[i,j] = np.sin(r*0.5)/(r*0.5)
+    
+    # note that the simulated noise here is not the interferometric noise. we just use it to test the numerics
+    test_noise = scipy.signal.fftconvolve(np.random.normal(0,1,(numPix,numPix)),psf_test,mode='same')
+    
+    kwargs_data = sim_util.data_configure_simple(numPix, deltaPix, exp_time, background_rms)
+    kwargs_data['ra_at_xy_0'] = -(40)*deltaPix
+    kwargs_data['dec_at_xy_0'] = -(40)*deltaPix 
+    kwargs_data['antenna_primary_beam'] = primary_beam
+    kwargs_data['likelihood_method'] = 'interferometry_natwt' # testing just for interferometry natwt method
+    data_class = ImageData(**kwargs_data)
+    
+    kernel_cut = kernel_util.cut_psf(psf_test, kernel_size, normalisation = False)
+    kwargs_psf = {'psf_type': psf_type,'pixel_size': deltaPix, 'kernel_point_source': kernel_cut,'kernel_point_source_normalisation': False}
+    psf_class = PSF(**kwargs_psf)
+    
+    # define lens model and source model
+    kwargs_shear = {'gamma1': 0.01, 'gamma2': 0.01}
+    kwargs_spemd = {'theta_E': 1., 'gamma': 1.8, 'center_x': 0, 'center_y': 0, 'e1': 0.1, 'e2': 0.04}
+    lens_model_list = ['SPEP', 'SHEAR']
+    kwargs_lens = [kwargs_spemd, kwargs_shear]
+    lens_model_class = LensModel(lens_model_list=lens_model_list)
+    
+    kwargs_sersic = {'amp': 25., 'R_sersic': 0.3, 'n_sersic': 2, 'center_x': 0, 'center_y': 0}
+    lens_light_model_list = ['SERSIC']
+    kwargs_lens_light = [kwargs_sersic]
+    lens_light_model_class = LightModel(light_model_list=lens_light_model_list)
+    
+    kwargs_sersic_ellipse = {'amp': 10., 'R_sersic': .6, 'n_sersic': 7, 'center_x': 0, 'center_y': 0,
+                                             'e1': 0.05, 'e2': 0.02}
+    source_model_list = ['SERSIC_ELLIPSE']
+    kwargs_source = [kwargs_sersic_ellipse]
+    source_model_class = LightModel(light_model_list=source_model_list)
+    
+    kwargs_numerics = {'supersampling_factor': 1, 'supersampling_convolution': False}
+
+    imageModel = ImageModel(data_class, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    image_sim = imageModel.image(kwargs_lens, kwargs_source, kwargs_lens_light)
+    
+    # normalize the noise to make it small compared to the model image
+    test_noise *= 1e-2 * (np.max(image_sim) / np.std(test_noise))
+    sim_data = image_sim + test_noise
+    data_class.update_data(sim_data)
+    
+    # define the ImageLinearFit class using the materials defined above, run the _image_linear_solve function
+    imageLinearFit = ImageLinearFit(data_class, psf_class, lens_model_class, source_model_class, lens_light_model_class, kwargs_numerics=kwargs_numerics)
+    model,_,_,amps = imageLinearFit._image_linear_solve(kwargs_lens, kwargs_source, kwargs_lens_light)
+    
+    # execute the same linear solving outside of the _image_linear_solve function
+    A = imageLinearFit._linear_response_matrix(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps = None, unconvolved=True)
+    A0 = util.array2image(A[0])
+    A1 = util.array2image(A[1])
+    A0c = scipy.signal.fftconvolve(A0, psf_test, mode = 'same')
+    A1c = scipy.signal.fftconvolve(A1, psf_test, mode = 'same')
+    M = np.zeros((2,2))
+    b = np.zeros((2))
+    M[0,0] = np.sum(A0c * A0)
+    M[0,1] = np.sum(A0c * A1)
+    M[1,0] = np.sum(A1c * A0)
+    M[1,1] = np.sum(A1c * A1)
+    b[0] = np.sum(A0 * sim_data)
+    b[1] = np.sum(A1 * sim_data)
+    
+    amps0 = np.linalg.lstsq(M, b)[0]
+    clean_model = amps0[0] * A0 + amps0[1] * A1
+    dirty_model = amps0[0] * A0c + amps0[1] * A1c
+    
+    npt.assert_almost_equal([clean_model, dirty_model], model, decimal=8)
+    npt.assert_almost_equal(amps0, amps, decimal=8)

--- a/test/test_ImSim/test_image_model_with_interferometric_changes.py
+++ b/test/test_ImSim/test_image_model_with_interferometric_changes.py
@@ -16,12 +16,12 @@ The idea of this test is to define two sets of data class and psf class, one wit
 and compare the (image_with_pb_and_psf) with scipy.signal.fftconvolve(image_without_pb_psf * pb, PSF, mode='same').
 """
 
-def test_interferometric_changes():
+def test_ImageModel_with_primary_beam_and_interferometry_psf():
 
-    sigma_bkg = .05  # background noise per pixel
-    exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
-    numPix = 100  # cutout pixel size
-    deltaPix = 0.05  # pixel size in arcsec (area per pixel = deltaPix**2)
+    sigma_bkg = .05  
+    exp_time = np.inf
+    numPix = 100  
+    deltaPix = 0.05
 
     # simulate a primary beam (pb)
     primary_beam = np.zeros((numPix,numPix))


### PR DESCRIPTION
Here is an updated version of PR #400, for the interferometric image fitting.
It is based on the newest version of Lenstronomy and I have packaged the log_likelihood and linear_solve functions for interferometric images into new functions that will be invoked by the general log_likelihood and linear_solve functions if 'likelihood_method' is assigned to 'interferometry_natwt'.

With this pull request merged, lenstronomy is able to do the parametric fitting for interferometric images.

Changes speciafically:

ImageData:

Variables added: log_likelihood_constant and likelihood_method
i. log_likelihood_constant allows user to input a float that will be added to the output of the log_likelihood function.
ii. likelihood_method allows user to choose the likelihood method, the default is 'diagonal', which will compute the likelihood in the normal way of lenstronomy. If the user set this parameter to 'interferometry_natwt', it will compute the logL using our natwt special method.

New functions:
i. log_likelihood_interferometry(self, model): returns the logL of interferometric method. There are math formulae in the comments of this function, explains how it is working.
ii. likelihood_method: passes 'likelihood_method' to ImageLinearFit to decide which linear solver method to use.

Raise error if likelihood_method is not input as 'diagonal' or 'interferometry_natwt'.


ImageLinearFit:

Add _image_linear_solve_natwt_special,  _image_linear_solve_interferometry_natwt functions to execute the linear solving for the interferometric method. There are math equations in the comments explaining the method.

Changes on Test files:

test_imaging_data.py:
Added one more raiseError checking. If the likelihood_method is not input as 'diagonal' or 'interferometry_natwt', it should raise a ValueError.

Add and fix the test files:
test_imaging_data_with_interferometric_changes.py
test_image_linear_solve_with_interferometric_changes.py
test_image_model_with_interferometric_changes.py
to test the interferometry natwt likelihood and linear solver changes.