### PR TITLE
Fix the model plot linear solver for interferometric likelihood method

### DIFF
--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -86,6 +86,10 @@ class SingleBandMultiModel(ImageLinearFit):
         wls_model, error_map, cov_param, param = self._image_linear_solve(kwargs_lens_i, kwargs_source_i,
                                                                           kwargs_lens_light_i, kwargs_ps_i,
                                                                           kwargs_extinction_i, kwargs_special, inv_bool=inv_bool)
+        # For the interfometric likelihood method, 
+        # return the array2 of [array1, array2] of the model output of _image_linear_solver.
+        if self.Data.likelihood_method() == "interferometry_natwt":
+            wls_model = wls_model[1]
         return wls_model, error_map, cov_param, param
 
     def likelihood_data_given_model(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -296,6 +296,23 @@ class TestRaise(unittest.TestCase):
                                                   [kwargs_data, {'psf_type': 'NONE'}, {}]],
                                  kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
                                  arrow_size=0.02, cmap_string="gist_heat", linear_solver=False)
+        
+        # test no error would be raised if kwargs_data['likelihood_method'] = 'interferometry_natwt' for Model Plot
+        with self.assertRaises(ValueError):
+            try:
+                kwargs_data = sim_util.data_configure_simple(numPix=10, deltaPix=1, background_rms=1, exposure_time=1)
+                kwargs_data['likelihood_method'] = 'interferometry_natwt'
+                kwargs_model = {'source_light_model_list': ['GAUSSIAN']}
+                kwargs_params = {'kwargs_lens': [],
+                                 'kwargs_source': [{'amp': 2, 'sigma': 1, 'center_x': 0, 'center_y': 0}],
+                                 'kwargs_ps': [], 'kwargs_lens_light': []}
+                lensPlot = ModelPlot(multi_band_list=[[kwargs_data, {'psf_type': 'NONE'}, {}]],
+                                     kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
+                                     arrow_size=0.02, cmap_string="gist_heat", linear_solver=True)
+            except:
+                pass
+            else:
+                raise ValueError("There is error raised for model plot when likelihood method is 'interferometry_natwt'.")
 
 
 if __name__ == '__main__':

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -298,5 +298,21 @@ class TestRaise(unittest.TestCase):
                                  arrow_size=0.02, cmap_string="gist_heat", linear_solver=False)
 
 
+def test_interferometry_natwt_Model_Plot_linear_solver():
+    # Test no errors are raised in the Model Plot linear solver for 'interferometry_natwt' likelihood function.
+    try:
+        kwargs_data = sim_util.data_configure_simple(numPix=10, deltaPix=1, background_rms=1, exposure_time=1)
+        kwargs_data['likelihood_method'] = 'interferometry_natwt'
+        kwargs_model = {'source_light_model_list': ['GAUSSIAN']}
+        kwargs_params = {'kwargs_lens': [],
+                         'kwargs_source': [{'amp': 2, 'sigma': 1, 'center_x': 0, 'center_y': 0}],
+                         'kwargs_ps': [], 'kwargs_lens_light': []}
+        lensPlot = ModelPlot(multi_band_list=[[kwargs_data, {'psf_type': 'NONE'}, {}]],
+                             kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
+                             arrow_size=0.02, cmap_string="gist_heat", linear_solver=True)
+    except:
+        pytest.fail("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
+
+
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -296,23 +296,6 @@ class TestRaise(unittest.TestCase):
                                                   [kwargs_data, {'psf_type': 'NONE'}, {}]],
                                  kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
                                  arrow_size=0.02, cmap_string="gist_heat", linear_solver=False)
-        
-        # test no error would be raised if kwargs_data['likelihood_method'] = 'interferometry_natwt' for Model Plot
-        with self.assertRaises(ValueError):
-            try:
-                kwargs_data = sim_util.data_configure_simple(numPix=10, deltaPix=1, background_rms=1, exposure_time=1)
-                kwargs_data['likelihood_method'] = 'interferometry_natwt'
-                kwargs_model = {'source_light_model_list': ['GAUSSIAN']}
-                kwargs_params = {'kwargs_lens': [],
-                                 'kwargs_source': [{'amp': 2, 'sigma': 1, 'center_x': 0, 'center_y': 0}],
-                                 'kwargs_ps': [], 'kwargs_lens_light': []}
-                lensPlot = ModelPlot(multi_band_list=[[kwargs_data, {'psf_type': 'NONE'}, {}]],
-                                     kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
-                                     arrow_size=0.02, cmap_string="gist_heat", linear_solver=True)
-            except:
-                pass
-            else:
-                raise ValueError("There is error raised for model plot when likelihood method is 'interferometry_natwt'.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix the model plot linear solver for interferometric likelihood method.

In the SingleBandMultiModel.image_linear_solve, the wls_model should be the convolved model image, where the returned wls_model from the interferometric _image_linear_solve is [unconvolved, convolved] images. Here wls_model just needs to be assigned to get the second array of _image_linear_solve model output. By doing this, no errors would be raised.

Add a part in test_model_plot to ensure that the error will NOT be raised for the interferometry model plot linear solver, using a try, except, else structure.

