### PR TITLE
Hernquist functionality to convert physical to angular properties

### DIFF
--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -254,8 +254,9 @@ class LensCosmo(object):
         :return: sigma0, Rs_angle
         """
         rs_angle = rs / self.dd / const.arcsec  # Rs in arcsec
-        rhos = mass / (2 * np.pi) / rs_angle ** 3
-        sigma0 = rhos * rs_angle
+        rhos = mass / (2 * np.pi) / rs ** 3  # units of M_sun / Mpc^3
+        sigma0 = rhos * rs  # units of M_sun / Mpc^2
+        sigma0 /= self.sigma_crit
         return sigma0, rs_angle
 
     def hernquist_angular2phys(self, sigma0, rs_angle):
@@ -268,8 +269,8 @@ class LensCosmo(object):
         :return: mass [M_sun], rs  [Mpc]
         """
         rs = rs_angle * self.dd * const.arcsec  # units of Mpc
-        rhos = sigma0 / rs_angle
-        m_tot = 2*np.pi*rhos*rs_angle**3
+        rhos = sigma0 / rs * self.sigma_crit
+        m_tot = 2*np.pi*rhos*rs**3
         return m_tot, rs
 
     def uldm_angular2phys(self, kappa_0, theta_c):

--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -201,7 +201,7 @@ class LensCosmo(object):
         """
         returns the NFW parameters in physical units
 
-        :param M: physical mass in M_sun
+        :param M: physical mass in M_sun in definition m200
         :param c: concentration
         :return: rho0 [Msun/Mpc^3], Rs [Mpc], r200 [Mpc]
         """
@@ -240,6 +240,37 @@ class LensCosmo(object):
         """
         theta_E = 4 * np.pi * (v_sigma * 1000./const.c) ** 2 * self.dds / self.ds / const.arcsec
         return theta_E
+
+    def hernquist_phys2angular(self, mass, rs):
+        """
+        Translates physical mass definitions of the Hernquist profile to the angular units used in the Hernquist lens
+        profile of lenstronomy.
+
+        'sigma0' is defined such that the deflection at projected RS leads to
+        alpha = 2./3 * Rs * sigma0
+
+        :param mass: A spherical overdensity mass in M_sun corresponding to the mass definition mdef at redshift z
+        :param rs: rs in units of physical Mpc
+        :return: sigma0, Rs_angle
+        """
+        rs_angle = rs / self.dd / const.arcsec  # Rs in arcsec
+        rhos = mass / (2 * np.pi) / rs_angle ** 3
+        sigma0 = rhos * rs_angle
+        return sigma0, rs_angle
+
+    def hernquist_angular2phys(self, sigma0, rs_angle):
+        """
+        'sigma0' is defined such that the deflection at projected RS leads to
+        alpha = 2./3 * Rs * sigma0
+
+        :param sigma0: convergence normalization
+        :param rs_angle: rs in angular units [arcseconds]
+        :return: mass [M_sun], rs  [Mpc]
+        """
+        rs = rs_angle * self.dd * const.arcsec  # units of Mpc
+        rhos = sigma0 / rs_angle
+        m_tot = 2*np.pi*rhos*rs_angle**3
+        return m_tot, rs
 
     def uldm_angular2phys(self, kappa_0, theta_c):
         """

--- a/lenstronomy/LensModel/Profiles/hernquist.py
+++ b/lenstronomy/LensModel/Profiles/hernquist.py
@@ -37,12 +37,13 @@ class Hernquist(LensProfileBase):
 
     """
     _diff = 0.00001
-    _s = 0.00000001
+    _s = 0.00001
     param_names = ['sigma0', 'Rs', 'center_x', 'center_y']
     lower_limit_default = {'sigma0': 0, 'Rs': 0, 'center_x': -100, 'center_y': -100}
     upper_limit_default = {'sigma0': 100, 'Rs': 100, 'center_x': 100, 'center_y': 100}
 
-    def density(self, r, rho0, Rs):
+    @staticmethod
+    def density(r, rho0, Rs):
         """
         computes the 3-d density
 
@@ -92,7 +93,8 @@ class Hernquist(LensProfileBase):
         sigma = sigma0 / (X**2-1)**2 * (-3 + (2+X**2)*self._F(X))
         return sigma
 
-    def mass_3d(self, r, rho0, Rs):
+    @staticmethod
+    def mass_3d(r, rho0, Rs):
         """
         mass enclosed a 3d sphere or radius r
 
@@ -109,6 +111,7 @@ class Hernquist(LensProfileBase):
         mass enclosed a 3d sphere or radius r for lens parameterisation
         This function converts the lensing definition sigma0 into the 3d density
 
+        :param r: radius
         :param sigma0: rho0 * Rs (units of projected density)
         :param Rs: Hernquist radius
         :return: enclosed mass in 3d
@@ -160,7 +163,8 @@ class Hernquist(LensProfileBase):
 
         :param x: x-coordinate position (units of angle)
         :param y: y-coordinate position (units of angle)
-        :param sigma0: normalization parameter defined such that the deflection at projected RS leads to alpha = 2./3 * Rs * sigma0
+        :param sigma0: normalization parameter defined such that the deflection at projected RS leads to
+         alpha = 2./3 * Rs * sigma0
         :param Rs: Hernquist radius in units of angle
         :param center_x: x-center of the profile (units of angle)
         :param center_y: y-center of the profile (units of angle)
@@ -179,7 +183,8 @@ class Hernquist(LensProfileBase):
 
         :param x: x-coordinate position (units of angle)
         :param y: y-coordinate position (units of angle)
-        :param sigma0: normalization parameter defined such that the deflection at projected RS leads to alpha = 2./3 * Rs * sigma0
+        :param sigma0: normalization parameter defined such that the deflection at projected RS leads to
+         alpha = 2./3 * Rs * sigma0
         :param Rs: Hernquist radius in units of angle
         :param center_x: x-center of the profile (units of angle)
         :param center_y: y-center of the profile (units of angle)
@@ -191,7 +196,7 @@ class Hernquist(LensProfileBase):
         r = np.maximum(r, self._s)
         X = r/Rs
         if isinstance(r, int) or isinstance(r, float):
-        #f = (1 - self._F(X)) / (X ** 2 - 1)  # this expression is 1/3 for X=1
+            # f = (1 - self._F(X)) / (X ** 2 - 1)  # this expression is 1/3 for X=1
             if X == 1:
                 f = 1./3
             else:
@@ -212,7 +217,8 @@ class Hernquist(LensProfileBase):
 
         :param x: x-coordinate position (units of angle)
         :param y: y-coordinate position (units of angle)
-        :param sigma0: normalization parameter defined such that the deflection at projected RS leads to alpha = 2./3 * Rs * sigma0
+        :param sigma0: normalization parameter defined such that the deflection at projected RS leads to
+         alpha = 2./3 * Rs * sigma0
         :param Rs: Hernquist radius in units of angle
         :param center_x: x-center of the profile (units of angle)
         :param center_y: y-center of the profile (units of angle)
@@ -231,7 +237,8 @@ class Hernquist(LensProfileBase):
         f_yy = (alpha_dec_dy - alpha_dec_dy_) / diff
         return f_xx, f_xy, f_yx, f_yy
 
-    def rho2sigma(self, rho0, Rs):
+    @staticmethod
+    def rho2sigma(rho0, Rs):
         """
         converts 3d density into 2d projected density parameter
         :param rho0: 3d density normalization of Hernquist model
@@ -240,7 +247,8 @@ class Hernquist(LensProfileBase):
         """
         return rho0 * Rs
 
-    def sigma2rho(self, sigma0, Rs):
+    @staticmethod
+    def sigma2rho(sigma0, Rs):
         """
         converts projected density parameter (in units of deflection) into 3d density parameter
         :param sigma0: density defined quantity in projected units
@@ -258,7 +266,7 @@ class Hernquist(LensProfileBase):
         c = self._s
         if isinstance(X, int) or isinstance(X, float):
             X = max(X, c)
-            if X < 1 and X > 0:
+            if 0 < X < 1:
                 a = 1. / np.sqrt(1 - X ** 2) * np.arctanh(np.sqrt(1 - X**2))
             elif X == 1:
                 a = 1.
@@ -273,7 +281,7 @@ class Hernquist(LensProfileBase):
             x = X[X < 1]
             a[X < 1] = 1 / np.sqrt(1 - x ** 2) * np.arctanh(np.sqrt((1 - x**2)))
 
-            x = X[X == 1]
+            # x = X[X == 1]
             a[X == 1] = 1.
 
             x = X[X > 1]

--- a/lenstronomy/LensModel/Profiles/hernquist.py
+++ b/lenstronomy/LensModel/Profiles/hernquist.py
@@ -120,7 +120,8 @@ class Hernquist(LensProfileBase):
         mass_2d = alpha_r * r * np.pi
         return mass_2d
 
-    def mass_tot(self, rho0, Rs):
+    @staticmethod
+    def mass_tot(rho0, Rs):
         """
         total mass within the profile
         :param rho0: density normalization

--- a/test/test_Analysis/test_lens_profile.py
+++ b/test/test_Analysis/test_lens_profile.py
@@ -48,8 +48,8 @@ class TestLensProfileAnalysis(object):
         assert len(ret) == 2
         npt.assert_almost_equal(ret[0], 1., decimal=2)
         kwargs_lens_bad = [{'theta_E': 100, 'center_x': 0, 'center_y': 0}]
-        ret_nan = lensModel.effective_einstein_radius(kwargs_lens_bad,
-                                                      get_precision=True, verbose=True)
+        ret_nan, precision = lensModel.effective_einstein_radius(kwargs_lens_bad,
+                                                      get_precision=True)
         assert np.isnan(ret_nan)
 
         # test interpolated profile

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -5,6 +5,7 @@ import numpy.testing as npt
 import pytest
 
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
+from lenstronomy.Util  import util
 
 
 class TestLensCosmo(object):
@@ -117,6 +118,40 @@ class TestLensCosmo(object):
 
         m_star_out = self.lensCosmo.sersic_k_eff2m_star(k_eff, R_sersic, n_sersic)
         npt.assert_almost_equal(m_star_out, m_star, decimal=6)
+
+    def test_hernquist_angular2phys(self):
+        m_star = 10**10  # in M_sun
+        rs = 0.01  # in Mpc
+
+        # test bijective transformation
+        sigma0, rs_angle = self.lensCosmo.hernquist_phys2angular(mass=m_star, rs=rs)
+        m_star_new, rs_new = self.lensCosmo.hernquist_angular2phys(sigma0=sigma0, rs_angle=rs_angle)
+        npt.assert_almost_equal(m_star_new, m_star, decimal=1)
+        npt.assert_almost_equal(rs_new, rs, decimal=8)
+
+    def test_hernquist_mass_normalization(self):
+        m_star = 10 ** 10  # in M_sun
+        rs = 0.01  # in Mpc
+
+        # test bijective transformation
+        sigma0, rs_angle = self.lensCosmo.hernquist_phys2angular(mass=m_star, rs=rs)
+
+        # test mass integrals
+        # make large grid
+        delta_pix = rs_angle / 10
+        x, y = util.make_grid(numPix=100, deltapix=delta_pix)
+        # compute convergence
+        from lenstronomy.LensModel.lens_model import LensModel
+        lens_model = LensModel(lens_model_list=['HERNQUIST'])
+        kwargs = [{'sigma0': sigma0, 'Rs': rs_angle, 'center_x': 0, 'center_y': 0}]
+        kappa = lens_model.kappa(x, y, kwargs)
+        # sum up convergence
+        kappa_tot = np.sum(kappa) * delta_pix ** 2
+        # transform to mass
+        mass_tot = kappa_tot * self.lensCosmo.sigma_crit_angle
+
+        # compare
+        npt.assert_almost_equal(mass_tot, m_star, decimal=1)
 
 
 if __name__ == '__main__':

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -138,8 +138,8 @@ class TestLensCosmo(object):
 
         # test mass integrals
         # make large grid
-        delta_pix = rs_angle / 10
-        x, y = util.make_grid(numPix=100, deltapix=delta_pix)
+        delta_pix = rs_angle / 30.
+        x, y = util.make_grid(numPix=501, deltapix=delta_pix)
         # compute convergence
         from lenstronomy.LensModel.lens_model import LensModel
         lens_model = LensModel(lens_model_list=['HERNQUIST'])
@@ -151,7 +151,7 @@ class TestLensCosmo(object):
         mass_tot = kappa_tot * self.lensCosmo.sigma_crit_angle
 
         # compare
-        npt.assert_almost_equal(mass_tot, m_star, decimal=1)
+        npt.assert_almost_equal(mass_tot/ m_star, 1, decimal=1)
 
 
 if __name__ == '__main__':

--- a/test/test_LensModel/test_Profiles/test_hernquist.py
+++ b/test/test_LensModel/test_Profiles/test_hernquist.py
@@ -25,7 +25,7 @@ class TestHernquist(object):
         y = np.array([0])
         Rs = 1.
         sigma0 = 0.5
-        values = self.profile.function( x, y, sigma0, Rs)
+        values = self.profile.function(x, y, sigma0, Rs)
         npt.assert_almost_equal(values[0], 0, decimal=6)
 
         x = np.array([2,3,4])


### PR DESCRIPTION
this PR adds functionality to define a Hernquist profile in mass and then translates it to the profile parameter 'sigma0'.
Minor re-factoring in the einstein radius estimates and minor improvements in the Hernquist calculation included