### PR TITLE
check_additional_images() not requiring to model additional images

### DIFF
--- a/lenstronomy/GalKin/psf.py
+++ b/lenstronomy/GalKin/psf.py
@@ -77,6 +77,7 @@ class PSFGaussian(object):
         kernel = kernel_util.kernel_gaussian(num_pix, delta_pix, self._fwhm)
         return kernel
 
+
 @export
 class PSFMoffat(object):
     """
@@ -110,6 +111,6 @@ class PSFMoffat(object):
         :return: 2d numpy array of kernel
         """
 
-        kernel = kernel_util.kernel_moffat(num_pix=num_pix, delta_pix=delta_pix, moffat_beta=self._moffat_beta)
+        kernel = kernel_util.kernel_moffat(num_pix=num_pix, delta_pix=delta_pix, fwhm=self._fwhm,
+                                           moffat_beta=self._moffat_beta)
         return kernel
-

--- a/lenstronomy/LensModel/Profiles/chameleon.py
+++ b/lenstronomy/LensModel/Profiles/chameleon.py
@@ -537,6 +537,7 @@ class DoubleChameleonPointMass(LensProfileBase):
                  center_x=0, center_y=0):
         """
         #TODO chose better parameterization for combining point mass and Chameleon profiles
+
         :param x: ra-coordinate
         :param y: dec-coordinate
         :param alpha_1: deflection angle at 1 (arcseconds) from the center
@@ -552,7 +553,7 @@ class DoubleChameleonPointMass(LensProfileBase):
         :param e22: ellipticity parameter for second profile
         :param center_x: ra center
         :param center_y: dec center
-        :return:
+        :return: lensing potential
         """
         f_1 = self.pointMass.function(x, y, alpha_1 / (1. + 1. / ratio_pointmass), center_x, center_y)
         f_2 = self.chameleon.function(x, y, alpha_1 / (1. + ratio_pointmass), ratio_chameleon, w_c1, w_t1, e11, e21,

--- a/lenstronomy/PointSource/Types/base_ps.py
+++ b/lenstronomy/PointSource/Types/base_ps.py
@@ -8,13 +8,13 @@ class PSBase(object):
     """
     base point source type class
     """
-    def __init__(self, lens_model=None, fixed_magnification=False, additional_image=False):
+    def __init__(self, lens_model=None, fixed_magnification=False, additional_images=False):
         """
 
         :param lens_model: instance of the LensModel() class
         :param fixed_magnification: bool. If True, magnification
          ratio of point sources is fixed to the one given by the lens model
-        :param additional_image: bool. If True, search for additional images of the same source is conducted.
+        :param additional_images: bool. If True, search for additional images of the same source is conducted.
         """
         self._lens_model = lens_model
         if self._lens_model is None:
@@ -22,8 +22,8 @@ class PSBase(object):
         else:
             self._solver = LensEquationSolver(lens_model)
         self._fixed_magnification = fixed_magnification
-        self._additional_image = additional_image
-        if fixed_magnification is True and additional_image is True:
+        self.additional_images = additional_images
+        if fixed_magnification is True and additional_images is True:
             Warning('The combination of fixed_magnification=True and additional_image=True is not optimal for the '
                     'current computation. If you see this warning, please approach the developers.')
 

--- a/lenstronomy/PointSource/Types/lensed_position.py
+++ b/lenstronomy/PointSource/Types/lensed_position.py
@@ -16,7 +16,8 @@ class LensedPositions(PSBase):
     #    super(LensedPositions, self).__init__(lens_model=lens_model, fixed_magnification=fixed_magnification,
     #                                          additional_image=additional_image)
 
-    def image_position(self, kwargs_ps, kwargs_lens=None, magnification_limit=None, kwargs_lens_eqn_solver=None):
+    def image_position(self, kwargs_ps, kwargs_lens=None, magnification_limit=None, kwargs_lens_eqn_solver=None,
+                       additional_images=False):
         """
         on-sky image positions
 
@@ -27,9 +28,11 @@ class LensedPositions(PSBase):
          images will be computed that exceed the lensing magnification (absolute value) limit
         :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical settings for the lens equation solver
          see LensEquationSolver() class for details
+        :param additional_images: if True, solves the lens equation for additional images
+        :type additional_images: bool
         :return: image positions in x, y as arrays
         """
-        if self._additional_image is True:
+        if self.additional_images is True or additional_images:
             if kwargs_lens_eqn_solver is None:
                 kwargs_lens_eqn_solver = {}
             ra_source, dec_source = self.source_position(kwargs_ps, kwargs_lens)

--- a/lenstronomy/PointSource/Types/source_position.py
+++ b/lenstronomy/PointSource/Types/source_position.py
@@ -16,7 +16,8 @@ class SourcePositions(PSBase):
 
     """
 
-    def image_position(self, kwargs_ps, kwargs_lens=None, magnification_limit=None, kwargs_lens_eqn_solver=None):
+    def image_position(self, kwargs_ps, kwargs_lens=None, magnification_limit=None, kwargs_lens_eqn_solver=None,
+                       **kwargs):
         """
         on-sky image positions
 

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -53,7 +53,7 @@ class PointSource(object):
             elif model == 'LENSED_POSITION':
                 from lenstronomy.PointSource.Types.lensed_position import LensedPositions
                 self._point_source_list.append(PointSourceCached(LensedPositions(lensModel, fixed_magnification=fixed_magnification_list[i],
-                                                                 additional_image=additional_images_list[i]),
+                                                                                 additional_images=additional_images_list[i]),
                                                                  save_cache=save_cache))
             elif model == 'SOURCE_POSITION':
                 from lenstronomy.PointSource.Types.source_position import SourcePositions
@@ -150,7 +150,7 @@ class PointSource(object):
             y_source_list.append(y_source)
         return x_source_list, y_source_list
 
-    def image_position(self, kwargs_ps, kwargs_lens, k=None, original_position=False):
+    def image_position(self, kwargs_ps, kwargs_lens, k=None, original_position=False, additional_images=False):
         """
         image positions as observed on the sky of the point sources
 
@@ -160,6 +160,8 @@ class PointSource(object):
         :param original_position: boolean (only applies to 'LENSED_POSITION' models), returns the image positions in
          the model parameters and does not re-compute images (which might be differently ordered) in case of the lens
          equation solver
+        :param additional_images: if True, solves the lens equation for additional images
+        :type additional_images: bool
         :return: list of: list of image positions per point source model component
         """
         x_image_list = []
@@ -169,7 +171,8 @@ class PointSource(object):
                 kwargs = kwargs_ps[i]
                 x_image, y_image = model.image_position(kwargs, kwargs_lens,
                                                         magnification_limit=self._magnification_limit,
-                                                        kwargs_lens_eqn_solver=self._kwargs_lens_eqn_solver)
+                                                        kwargs_lens_eqn_solver=self._kwargs_lens_eqn_solver,
+                                                        additional_images=additional_images)
                 if original_position is True and self.point_source_type_list[i] == 'LENSED_POSITION':
                     x_o, y_o = kwargs['ra_image'], kwargs['dec_image']
                     x_image, y_image = _sort_position_by_original(x_o, y_o, x_image, y_image)

--- a/lenstronomy/PointSource/point_source_cached.py
+++ b/lenstronomy/PointSource/point_source_cached.py
@@ -52,9 +52,9 @@ class PointSourceCached(object):
             # ignore cached parts if additional images
             if not self._save_cache or not hasattr(self, '_x_image_add') or not hasattr(self, '_y_image_add'):
                 self._x_image_add, self._y_image_add = self._model.image_position(kwargs_ps, kwargs_lens=kwargs_lens,
-                                              magnification_limit=magnification_limit,
-                                              kwargs_lens_eqn_solver=kwargs_lens_eqn_solver,
-                                              additional_images=additional_images)
+                                                                                  magnification_limit=magnification_limit,
+                                                                                  kwargs_lens_eqn_solver=kwargs_lens_eqn_solver,
+                                                                                  additional_images=additional_images)
             return self._x_image_add, self._y_image_add
         if not self._save_cache or not hasattr(self, '_x_image') or not hasattr(self, '_y_image'):
             self._x_image, self._y_image = self._model.image_position(kwargs_ps, kwargs_lens=kwargs_lens,

--- a/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
@@ -15,7 +15,7 @@ class FluxRatioLikelihood(object):
 
         :param lens_model_class: LensModel class instance
         :param flux_ratios: ratio of fluxes of the multiple images (relative to the first appearing)
-        :param flux_ratio_errors: errors in the flux ratios (relative to the first appearing. Alternatively 
+        :param flux_ratio_errors: errors in the flux ratios (relative to the first appearing). Alternatively
         a log-normal covariance matrix. Note: in the case of a the covariance matrix, the errors are are assumed
         to be log-normal, i.e. the logarithms of the flux ratios, ln(F[i]/F[0]) are assumed to have a multivariate 
         Gaussian distribution, with the given covariance matrix.

--- a/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
@@ -34,17 +34,17 @@ class FluxRatioLikelihood(object):
         self._polar_grid = polar_grid
         self._aspect_ratio = aspect_ratio
 
-    def logL(self, x_pos, y_pos, kwargs_lens, kwargs_cosmo):
+    def logL(self, x_pos, y_pos, kwargs_lens, kwargs_special):
         """
 
-        :param kwargs_lens:
-        :param kwargs_cosmo:
+        :param kwargs_lens: lens model keyword argument list
+        :param kwargs_special: dictionary of 'special' keyword parameters
         :return: log likelihood of the measured flux ratios given a model
         """
         if self._source_type == 'INF':
             mag = np.abs(self._lens_model_class.magnification(x_pos, y_pos, kwargs_lens))
         else:
-            source_sigma = kwargs_cosmo['source_size']
+            source_sigma = kwargs_special['source_size']
             mag = self._lens_model_extensions.magnification_finite(x_pos, y_pos, kwargs_lens, source_sigma=source_sigma,
                                                                    window_size=self._window_size,
                                                                    grid_number=self._gird_number,

--- a/lenstronomy/Util/magnification_finite_util.py
+++ b/lenstronomy/Util/magnification_finite_util.py
@@ -17,6 +17,7 @@ def auto_raytracing_grid_size(source_fwhm_parcsec, grid_size_scale=0.005, power=
     grid_radius_arcsec = grid_size_scale * source_fwhm_parcsec ** power
     return grid_radius_arcsec
 
+
 def auto_raytracing_grid_resolution(source_fwhm_parcsec, grid_resolution_scale=0.0002, ref=10., power=1.):
 
     """

--- a/test/test_PointSource/test_Types/test_lensed_position.py
+++ b/test/test_PointSource/test_Types/test_lensed_position.py
@@ -11,7 +11,7 @@ class TestLensedPosition(object):
         self.kwargs_lens = [{'theta_E': 1, 'center_x': 0, 'center_y': 0}]
         self.ps_mag = LensedPositions(lens_model=lens_model, fixed_magnification=True)
         self.ps = LensedPositions(lens_model=lens_model, fixed_magnification=False)
-        self.ps_add = LensedPositions(lens_model=lens_model, fixed_magnification=[False], additional_image=True)
+        self.ps_add = LensedPositions(lens_model=lens_model, fixed_magnification=[False], additional_images=True)
         self.kwargs = {'point_amp': [2, 1], 'ra_image': [0, 1.2], 'dec_image': [0, 0]}
         self.kwargs_mag = {'source_amp': 2, 'ra_image': [0, 1.2], 'dec_image': [0, 0]}
 

--- a/test/test_PointSource/test_Types/test_ps_base.py
+++ b/test/test_PointSource/test_Types/test_ps_base.py
@@ -8,8 +8,8 @@ from lenstronomy.LensModel.lens_model import LensModel
 class TestPSBase(object):
 
     def setup_method(self):
-        self.base = PSBase(lens_model=LensModel(lens_model_list=[]), fixed_magnification=False, additional_image=False)
-        PSBase(fixed_magnification=True, additional_image=True)
+        self.base = PSBase(lens_model=LensModel(lens_model_list=[]), fixed_magnification=False, additional_images=False)
+        PSBase(fixed_magnification=True, additional_images=True)
 
     def test_update_lens_model(self):
         self.base.update_lens_model(lens_model_class=None)
@@ -18,7 +18,7 @@ class TestPSBase(object):
         base = PSBase()
         base.update_lens_model(lens_model_class=LensModel(lens_model_list=['SIS']))
         assert base._solver is not None
-        PSBase(fixed_magnification=True, additional_image=True)
+        PSBase(fixed_magnification=True, additional_images=True)
 
 
 class TestUtil(object):

--- a/test/test_Sampling/test_Likelihoods/test_flux_ratio_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_flux_ratio_likelihood.py
@@ -51,7 +51,7 @@ class TestFluxRatioLikelihood(object):
         self.kwargs_lens = kwargs_lens
 
     def test_logL(self):
-        logL = self.flux_likelihood.logL(self.x_img, self.y_img, self.kwargs_lens, kwargs_cosmo=self.kwargs_cosmo)
+        logL = self.flux_likelihood.logL(self.x_img, self.y_img, self.kwargs_lens, kwargs_special=self.kwargs_cosmo)
         assert logL == 0
 
         logL_inf = self.flux_likelihood_inf.logL(self.x_img, self.y_img, self.kwargs_lens, {})
@@ -76,12 +76,12 @@ class TestFluxRatioLikelihood(object):
 
     def test_numimgs(self):
         # Test with a different number of images
-        logL = self.flux_likelihood.logL(self.x_img[:-1], self.y_img[:-1], self.kwargs_lens, kwargs_cosmo=self.kwargs_cosmo)
+        logL = self.flux_likelihood.logL(self.x_img[:-1], self.y_img[:-1], self.kwargs_lens, kwargs_special=self.kwargs_cosmo)
         assert logL == -10**15
 
     def test_covmatrix(self):
         # Test with a different number of images
-        logL = self.flux_likelihood_inf_cov.logL(self.x_img, self.y_img, self.kwargs_lens, kwargs_cosmo=self.kwargs_cosmo)
+        logL = self.flux_likelihood_inf_cov.logL(self.x_img, self.y_img, self.kwargs_lens, kwargs_special=self.kwargs_cosmo)
         npt.assert_almost_equal(logL, 0, decimal=8)
 
 


### PR DESCRIPTION
up to now, to check whether there are additional images appearing from a point source, additional images have to be set to be modeled, otherwise this check would not raise errors. This PR improves the behavior and especially works for catalogue modeling