### PR TITLE
Enforce parameter limits in SpecialParam class

### DIFF
--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -205,11 +205,9 @@ class SingleParam(ModelParamGroup):
                 else:
                     out[name] = args[i]
                     if kwargs_lower is not None:
-                        if out[name] < kwargs_lower[name]:
-                            out[name] = kwargs_lower[name]
-                    elif kwargs_upper is not None:
-                        if out[name] > kwargs_upper[name]:
-                            out[name] = kwargs_upper[name]
+                        out = np.maximum(out, kwargs_lower[name])
+                    if kwargs_upper is not None:
+                        out = np.minimum(out, kwargs_upper[name])
                     i += 1
         return out, i
 

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -7,6 +7,8 @@ new parameters you can safely ignore this.
 __author__ = 'jhodonnell'
 __all__ = ['ModelParamGroup', 'SingleParam', 'ArrayParam']
 
+import numpy as np
+
 
 class ModelParamGroup:
     '''
@@ -181,7 +183,7 @@ class SingleParam(ModelParamGroup):
             return output
         return []
 
-    def get_params(self, args, i, kwargs_fixed):
+    def get_params(self, args, i, kwargs_fixed, kwargs_upper=None, kwargs_lower=None):
         '''
         Converts a flattened array of parameters back into a lenstronomy dictionary,
         starting at index i.
@@ -202,6 +204,12 @@ class SingleParam(ModelParamGroup):
                     out[name] = kwargs_fixed[name]
                 else:
                     out[name] = args[i]
+                    if kwargs_lower is not None:
+                        if out[name] < kwargs_lower[name]:
+                            out[name] = kwargs_lower[name]
+                    elif kwargs_upper is not None:
+                        if out[name] > kwargs_upper[name]:
+                            out[name] = kwargs_upper[name]
                     i += 1
         return out, i
 
@@ -288,7 +296,7 @@ class ArrayParam(ModelParamGroup):
                 args.extend(kwargs[name])
         return args
 
-    def get_params(self, args, i, kwargs_fixed):
+    def get_params(self, args, i, kwargs_fixed, kwargs_lower=None, kwargs_upper=None):
         '''
         Converts a flattened array of parameters back into a lenstronomy dictionary,
         starting at index i.
@@ -299,7 +307,10 @@ class ArrayParam(ModelParamGroup):
         :type i: int
         :param kwargs_fixed: Dictionary of fixed arguments
         :type kwargs_fixed: dict
-
+        :param kwargs_lower: Dictionary of lower bounds
+        :type kwargs_lower: dict
+        :param kwargs_upper: Dictionary of upper bounds
+        :type kwargs_upper: dict
         :returns: dictionary of parameters
         '''
         if not self.on:
@@ -309,6 +320,17 @@ class ArrayParam(ModelParamGroup):
         for name, count in self.param_names.items():
             if name not in kwargs_fixed:
                 params[name] = args[i:i + count]
+
+                if kwargs_lower is not None:
+                    for j in range(len(params[name])):
+                        if params[name][j] < kwargs_lower[name][j]:
+                            params[name][j] = kwargs_lower[name][j]
+
+                if kwargs_upper is not None:
+                    for j in range(len(params[name])):
+                        if params[name][j] > kwargs_upper[name][j]:
+                            params[name][j] = kwargs_upper[name][j]
+
                 i += count
             else:
                 params[name] = kwargs_fixed[name]

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -205,9 +205,9 @@ class SingleParam(ModelParamGroup):
                 else:
                     out[name] = args[i]
                     if kwargs_lower is not None:
-                        out = np.maximum(out, kwargs_lower[name])
+                        out[name] = np.maximum(out[name], kwargs_lower[name])
                     if kwargs_upper is not None:
-                        out = np.minimum(out, kwargs_upper[name])
+                        out[name] = np.minimum(out[name], kwargs_upper[name])
                     i += 1
         return out, i
 

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -372,7 +372,7 @@ class Param(object):
         kwargs_source, i = self.sourceParams.get_params(args, i)
         kwargs_lens_light, i = self.lensLightParams.get_params(args, i)
         kwargs_ps, i = self.pointSourceParams.get_params(args, i)
-        kwargs_special, i = self.specialParams.get_params(args, i)
+        kwargs_special, i = self.specialParams.get_params(args, i, impose_bound=True)
         kwargs_extinction, i = self.extinctionParams.get_params(args, i)
         self._update_lens_model(kwargs_special)
         # update lens_light joint parameters

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -192,16 +192,23 @@ class SpecialParam(object):
         self.lower_limit = kwargs_lower
         self.upper_limit = kwargs_upper
 
-    def get_params(self, args, i):
+    def get_params(self, args, i, impose_bound=False):
         """
 
         :param args: argument list
         :param i: integer, list index to start the read out for this class
+        :param impose_bound: bool, if True, imposes the lower and upper limits on the sampled parameters
         :return: keyword arguments related to args, index after reading out arguments of this class
         """
-        result = ModelParamGroup.compose_get_params(
-            self._param_groups, args, i, kwargs_fixed=self._kwargs_fixed
-        )
+        if impose_bound:
+            result = ModelParamGroup.compose_get_params(
+                self._param_groups, args, i, kwargs_fixed=self._kwargs_fixed,
+                kwargs_lower=self.lower_limit, kwargs_upper=self.upper_limit
+            )
+        else:
+            result = ModelParamGroup.compose_get_params(
+                self._param_groups, args, i, kwargs_fixed=self._kwargs_fixed
+            )
         return result
 
     def set_params(self, kwargs_special):

--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -309,11 +309,6 @@ class FittingSequence(object):
         lower_start = np.array(init_pos) - np.array(sigma_start) * sigma_scale
         upper_start = np.array(init_pos) + np.array(sigma_start) * sigma_scale
 
-        lower_limit, upper_limit = param_class.param_limits()
-
-        lower_start = np.maximum(lower_start, lower_limit)
-        upper_start = np.minimum(upper_start, upper_limit)
-
         num_param, param_list = param_class.num_param()
         # run PSO
         sampler = Sampler(likelihoodModule=self.likelihoodModule)

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -10,7 +10,10 @@ class TestParam(object):
 
     def setup_method(self):
         self.param = SpecialParam(Ddt_sampling=True, kwargs_fixed=None, point_source_offset=True, num_images=2,
-                                  source_size=True, num_tau0=2, num_z_sampling=3, source_grid_offset=True)
+                                  source_size=True, num_tau0=2, num_z_sampling=3, source_grid_offset=True,
+                                  kwargs_lower={'z_sampling': [0.05, 0.1, 0.5]},
+                                  kwargs_upper={'z_sampling': [0.2, 1., 1.]}
+                                  )
         self.kwargs = {'D_dt': 1988, 'delta_x_image': [0, 0], 'delta_y_image': [0, 0], 'source_size': 0.1,
                        'tau0_list': [0, 1], 'z_sampling': np.array([0.1, 0.5, 2]),
                        'delta_x_source_grid': 0, 'delta_y_source_grid': 0}
@@ -26,6 +29,12 @@ class TestParam(object):
                                    source_size=True, num_z_sampling=3, num_tau0=2)
         kwargs_new, i = param_fixed.get_params(args=[], i=0)
         kwargs_new['D_dt'] = self.kwargs['D_dt']
+
+        special_param = SpecialParam(num_z_sampling=1, kwargs_lower={'z_sampling': [0.1]},
+                                     kwargs_upper={'z_sampling': [0.2]})
+
+        kwargs_test, i = special_param.get_params(args=[0.3], i=0, impose_bound=True)
+        assert kwargs_test['z_sampling'] == [0.2]
 
     def test_num_params(self):
         num, list = self.param.num_param()


### PR DESCRIPTION
This PR:
- reverts enforcing initial parameter limits within the `FittingSequence` class, since it is already being done by the `Sampler.pso()` method.
- directly imposes the user-defined bound through `SpecialParam.get_params()` to avoid error thrown when a lens-plane redshift is sampled higher than the reference source-plane redshift in the multi-plane mode, as parameters outside the user-defined bounds can be sampled by `ParticleSwarmOptimizer`.