### PR TITLE
Single band multi model re-factoring

### DIFF
--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -102,7 +102,7 @@ class MultiBandImageReconstruction(object):
 class ModelBand(object):
     """
     class to plot a single band given the full modeling results
-    This class has it's specific role when the linear inference is performed on the joint band level and/or when only
+    This class has its specific role when the linear inference is performed on the joint band level and/or when only
     a subset of model components get used for this specific band in the modeling.
 
     """
@@ -128,7 +128,7 @@ class ModelBand(object):
                                                likelihood_mask_list=image_likelihood_mask_list, band_index=band_index)
         self._kwargs_special_partial = kwargs_params.get('kwargs_special', None)
         kwarks_lens_partial, kwargs_source_partial, kwargs_lens_light_partial, kwargs_ps_partial, self._kwargs_extinction_partial = self._bandmodel.select_kwargs(**kwargs_params)
-        self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial, self._kwargs_ps_partial = self._bandmodel.update_linear_kwargs(param, kwarks_lens_partial, kwargs_source_partial, kwargs_lens_light_partial, kwargs_ps_partial)
+        self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial, self._kwargs_ps_partial = self._bandmodel._update_linear_kwargs(param, kwarks_lens_partial, kwargs_source_partial, kwargs_lens_light_partial, kwargs_ps_partial)
         # this is an (out-commented) example of how to re-create the model in this band
         # model_new = self.bandmodel.image(self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial, self._kwargs_ps_partial, self._kwargs_special_partial, self._kwargs_extinction_partial)
 

--- a/lenstronomy/Analysis/light_profile.py
+++ b/lenstronomy/Analysis/light_profile.py
@@ -3,7 +3,6 @@ import numpy as np
 import lenstronomy.Util.util as util
 import lenstronomy.Util.analysis_util as analysis_util
 import lenstronomy.Util.multi_gauss_expansion as mge
-from lenstronomy.Util import mask_util
 
 __all__ = ['LightProfileAnalysis']
 

--- a/lenstronomy/Analysis/multi_patch_reconstruction.py
+++ b/lenstronomy/Analysis/multi_patch_reconstruction.py
@@ -42,6 +42,7 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
             self._pixel_grid_joint = PixelGrid(**kwargs_pixel_grid)
         else:
             self._pixel_grid_joint = self._joint_pixel_grid(multi_band_list)
+        self._kwargs_params = kwargs_params
 
     @property
     def pixel_grid_joint(self):
@@ -107,8 +108,8 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
         for model_band in self.model_band_list:
             if model_band is not None:
                 image_model = model_band.image_model_class
-                kwargs_params = model_band.kwargs_model
-                model = image_model.image(**kwargs_params)
+                # kwargs_params = model_band.kwargs_model
+                model = image_model.image(**self._kwargs_params)
                 data_class_i = image_model.Data
                 # evaluate pixel of zero point with the base coordinate system
                 ra0, dec0 = data_class_i.radec_at_xy_0
@@ -178,9 +179,8 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
         x_grid_source += center_x
         y_grid_source += center_y
 
-        pixel_grid = PixelGrid(nx=num_pix, ny=num_pix,transform_pix2angle=Mpix2coord,
-                                    ra_at_xy_0=ra_at_xy_0 + center_x,
-                                    dec_at_xy_0=dec_at_xy_0 + center_y)
+        pixel_grid = PixelGrid(nx=num_pix, ny=num_pix,transform_pix2angle=Mpix2coord, ra_at_xy_0=ra_at_xy_0 + center_x,
+                               dec_at_xy_0=dec_at_xy_0 + center_y)
 
         source = image_model.SourceModel.surface_brightness(x_grid_source, y_grid_source, kwargs_source)
         source = util.array2image(source) * delta_pix ** 2

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -17,7 +17,7 @@ class SingleBandMultiModel(ImageLinearFit):
     These arguments should be lists of length the number of imaging bands available and each entry in the list
     is a list of integers specifying the model components being evaluated for the specific band.
 
-    E.g. there are two bands and you want to different light profiles being modeled.
+    E.g. there are two bands, and you want to different light profiles being modeled.
     - you define two different light profiles lens_light_model_list = ['SERSIC', 'SERSIC']
     - set index_lens_light_model_list = [[0], [1]]
     - (optional) for now all the parameters between the two light profiles are independent in the model. You have

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -320,19 +320,19 @@ class SingleBandMultiModel(ImageLinearFit):
         :param kwargs_ps:
         :return:
         """
-        if self._index_lens_model is None:
+        if self._index_lens_model is None or kwargs_lens is None:
             kwargs_lens_i = kwargs_lens
         else:
             kwargs_lens_i = [kwargs_lens[k] for k in self._index_lens_model]
-        if self._index_source is None:
+        if self._index_source is None or kwargs_source is None:
             kwargs_source_i = kwargs_source
         else:
             kwargs_source_i = [kwargs_source[k] for k in self._index_source]
-        if self._index_lens_light is None:
+        if self._index_lens_light is None or kwargs_lens_light is None:
             kwargs_lens_light_i = kwargs_lens_light
         else:
             kwargs_lens_light_i = [kwargs_lens_light[k] for k in self._index_lens_light]
-        if self._index_point_source is None:
+        if self._index_point_source is None or kwargs_ps is None:
             kwargs_ps_i = kwargs_ps
         else:
             kwargs_ps_i = [kwargs_ps[k] for k in self._index_point_source]

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -59,12 +59,102 @@ class SingleBandMultiModel(ImageLinearFit):
         index_optical_depth = kwargs_model.get('index_optical_depth_model_list',
                                                    [None for i in range(len(multi_band_list))])
         self._index_optical_depth = index_optical_depth[band_index]
-        self._linear_solver = linear_solver
 
         super(SingleBandMultiModel, self).__init__(data_i, psf_i, lens_model_class, source_model_class,
                                                    lens_light_model_class, point_source_class, extinction_class,
                                                    kwargs_numerics=kwargs_numerics, likelihood_mask=likelihood_mask_list[band_index],
-                                                   kwargs_pixelbased=kwargs_pixelbased)
+                                                   kwargs_pixelbased=kwargs_pixelbased, linear_solver=linear_solver)
+
+    def image(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
+              kwargs_extinction=None, kwargs_special=None, unconvolved=False, source_add=True, lens_light_add=True,
+              point_source_add=True):
+        """
+
+        make an image with a realisation of linear parameter values "param"
+
+        :param kwargs_lens: list of keyword arguments corresponding to the superposition of different lens profiles
+        :param kwargs_source: list of keyword arguments corresponding to the superposition of different source light profiles
+        :param kwargs_lens_light: list of keyword arguments corresponding to different lens light surface brightness profiles
+        :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as external shear and point source image positions
+        :param unconvolved: if True: returns the unconvolved light distribution (prefect seeing)
+        :param source_add: if True, compute source, otherwise without
+        :param lens_light_add: if True, compute lens light, otherwise without
+        :param point_source_add: if True, add point sources, otherwise without
+        :return: 2d array of surface brightness pixels of the simulation
+        """
+        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
+            kwargs_extinction)
+        return self._image(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i,
+                                            kwargs_extinction_i, kwargs_special=kwargs_special, unconvolved=unconvolved,
+                                            source_add=source_add, lens_light_add=lens_light_add,
+                                            point_source_add=point_source_add)
+
+    def source_surface_brightness(self, kwargs_source, kwargs_lens=None, kwargs_extinction=None, kwargs_special=None,
+                                  unconvolved=False, de_lensed=False, k=None, update_pixelbased_mapping=True):
+        """
+
+        computes the source surface brightness distribution
+
+        :param kwargs_source: list of keyword arguments corresponding to the superposition of different source light profiles
+        :param kwargs_lens: list of keyword arguments corresponding to the superposition of different lens profiles
+        :param kwargs_extinction: list of keyword arguments of extinction model
+        :param unconvolved: if True: returns the unconvolved light distribution (prefect seeing)
+        :param de_lensed: if True: returns the un-lensed source surface brightness profile, otherwise the lensed.
+        :param k: integer, if set, will only return the model of the specific index
+        :return: 2d array of surface brightness pixels
+        """
+        kwargs_lens_i, kwargs_source_i, _, _, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light=None,
+            kwargs_ps=None,
+            kwargs_extinction=kwargs_extinction)
+        return self._source_surface_brightness(kwargs_source_i, kwargs_lens_i, kwargs_extinction=kwargs_extinction_i,
+                                               kwargs_special=kwargs_special, unconvolved=unconvolved,
+                                               de_lensed=de_lensed, k=k,
+                                               update_pixelbased_mapping=update_pixelbased_mapping)
+
+    def lens_surface_brightness(self, kwargs_lens_light, unconvolved=False, k=None):
+        """
+
+        computes the lens surface brightness distribution
+
+        :param kwargs_lens_light: list of keyword arguments corresponding to different lens light surface brightness profiles
+        :param unconvolved: if True, returns unconvolved surface brightness (perfect seeing), otherwise convolved with PSF kernel
+        :return: 2d array of surface brightness pixels
+        """
+        _, _, kwargs_lens_light_i, kwargs_ps_i, _ = self.select_kwargs(
+            kwargs_lens=None,
+            kwargs_source=None,
+            kwargs_lens_light=kwargs_lens_light,
+            kwargs_ps=None,
+            kwargs_extinction=None)
+        return self._lens_surface_brightness(kwargs_lens_light_i, unconvolved=unconvolved, k=k)
+
+    def point_source(self, kwargs_ps, kwargs_lens=None, kwargs_special=None, unconvolved=False, k=None):
+        """
+
+        computes the point source positions and paints PSF convolutions on them
+
+        :param kwargs_ps:
+        :param kwargs_lens:
+        :param kwargs_special:
+        :param unconvolved:
+        :param k:
+        :return:
+        """
+        kwargs_lens_i, _, _, kwargs_ps_i, _ = self.select_kwargs(
+            kwargs_lens=kwargs_lens,
+            kwargs_source=None,
+            kwargs_lens_light=None,
+            kwargs_ps=kwargs_ps,
+            kwargs_extinction=None)
+        return self._point_source(kwargs_ps=kwargs_ps_i, kwargs_lens=kwargs_lens_i, kwargs_special=kwargs_special,
+                                  unconvolved=unconvolved, k=k)
 
     def image_linear_solve(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                            kwargs_extinction=None, kwargs_special=None, inv_bool=False):
@@ -78,23 +168,18 @@ class SingleBandMultiModel(ImageLinearFit):
         :param inv_bool: if True, invert the full linear solver Matrix Ax = y for the purpose of the covariance matrix.
         :return: 1d array of surface brightness pixels of the optimal solution of the linear parameters to match the data
         """
-        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(kwargs_lens,
-                                                                                              kwargs_source,
-                                                                                              kwargs_lens_light,
-                                                                                              kwargs_ps,
-                                                                                              kwargs_extinction)
-        wls_model, error_map, cov_param, param = self._image_linear_solve(kwargs_lens_i, kwargs_source_i,
-                                                                          kwargs_lens_light_i, kwargs_ps_i,
-                                                                          kwargs_extinction_i, kwargs_special, inv_bool=inv_bool)
-        # For the interfometric likelihood method, 
-        # return the array2 of [array1, array2] of the model output of _image_linear_solver.
-        if self.Data.likelihood_method() == "interferometry_natwt":
-            wls_model = wls_model[1]
-        return wls_model, error_map, cov_param, param
+        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
+            kwargs_extinction)
+        return self._image_linear_solve(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i,kwargs_ps_i,
+                                        kwargs_extinction_i, kwargs_special, inv_bool=inv_bool)
 
     def likelihood_data_given_model(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                                     kwargs_extinction=None, kwargs_special=None, source_marg=False, linear_prior=None,
-                                    check_positive_flux=False):
+                                    check_positive_flux=False, linear_solver=True):
         """
         computes the likelihood of the data given a model
         This is specified with the non-linear parameters and a linear inversion and prior marginalisation.
@@ -108,16 +193,17 @@ class SingleBandMultiModel(ImageLinearFit):
         :return: log likelihood (natural logarithm) (sum of the log likelihoods of the individual images)
         """
         # generate image
-        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(kwargs_lens,
-                                                                                              kwargs_source,
-                                                                                              kwargs_lens_light,
-                                                                                              kwargs_ps,
-                                                                                              kwargs_extinction)
-        logL = self._likelihood_data_given_model(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i,
-                                                 kwargs_extinction_i, kwargs_special, source_marg=source_marg,
-                                                 linear_prior=linear_prior, check_positive_flux=check_positive_flux,
-                                                 linear_solver=self._linear_solver)
-        return logL
+        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
+            kwargs_extinction)
+        return self._likelihood_data_given_model(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i,
+                                                                  kwargs_ps_i, kwargs_extinction_i, kwargs_special,
+                                                                  source_marg=source_marg, linear_prior=linear_prior,
+                                                                  check_positive_flux=check_positive_flux,
+                                                                  linear_solver=self._linear_solver)
 
     def num_param_linear(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None):
         """
@@ -141,11 +227,8 @@ class SingleBandMultiModel(ImageLinearFit):
         :param kwargs_ps:
         :return:
         """
-        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(kwargs_lens,
-                                                                                              kwargs_source,
-                                                                                              kwargs_lens_light,
-                                                                                              kwargs_ps,
-                                                                                              kwargs_extinction)
+        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction)
         A = self._linear_response_matrix(kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i,
                                          kwargs_extinction_i, kwargs_special)
         return A
@@ -169,6 +252,62 @@ class SingleBandMultiModel(ImageLinearFit):
         else:
             kwargs_source_i = [kwargs_source[k] for k in self._index_source]
         return self._error_map_source(kwargs_source_i, x_grid, y_grid, cov_param)
+
+    def error_response(self, kwargs_lens, kwargs_ps, kwargs_special):
+        """
+        returns the 1d array of the error estimate corresponding to the data response
+
+        :return: 1d numpy array of response, 2d array of additional errors (e.g. point source uncertainties)
+        """
+        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens,
+            kwargs_source=None,
+            kwargs_lens_light=None,
+            kwargs_ps=kwargs_ps,
+            kwargs_extinction=None)
+        return self._error_response(kwargs_lens_i, kwargs_ps_i, kwargs_special=kwargs_special)
+
+    def update_linear_kwargs(self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps):
+        """
+
+        links linear parameters to kwargs arguments
+        ATTENTION: this function requires input dictionary lists to be already contracted to the ones applied to the
+        specific band
+
+        :param param: linear parameter vector corresponding to the response matrix
+        :return: updated list of kwargs with linear parameter values
+        """
+        kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, kwargs_extinction_i = self.select_kwargs(
+            kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction=None)
+        return self._update_linear_kwargs(param, kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i)
+
+    def extinction_map(self, kwargs_extinction=None, kwargs_special=None):
+        """
+        differential extinction per pixel
+
+        :param kwargs_extinction: list of keyword arguments corresponding to the optical depth models tau, such that extinction is exp(-tau)
+        :param kwargs_special: keyword arguments, additional parameter to the extinction
+        :return: 2d array of size of the image
+        """
+        _, _, _, _, kwargs_extinction_i = self.select_kwargs(kwargs_extinction=kwargs_extinction)
+        return self._extinction_map(kwargs_extinction_i, kwargs_special)
+
+    def linear_param_from_kwargs(self, kwargs_source, kwargs_lens_light, kwargs_ps):
+        """
+        inverse function of update_linear() returning the linear amplitude list for the keyword argument list
+
+        :param kwargs_source:
+        :param kwargs_lens_light:
+        :param kwargs_ps:
+        :return: list of linear coefficients
+        """
+        _, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, _ = self.select_kwargs(
+            kwargs_lens=None,
+            kwargs_source=kwargs_source,
+            kwargs_lens_light=kwargs_lens_light,
+            kwargs_ps=kwargs_ps,
+            kwargs_extinction=None)
+        return self._linear_param_from_kwargs(kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i)
 
     def select_kwargs(self, kwargs_lens=None, kwargs_source=None, kwargs_lens_light=None, kwargs_ps=None,
                       kwargs_extinction=None, kwargs_special=None):

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -380,8 +380,9 @@ class ImageModel(object):
         ra_grid, dec_grid = self.ImageNumerics.coordinates_evaluate
         extinction = self._extinction.extinction(ra_grid, dec_grid, kwargs_extinction=kwargs_extinction,
                                                  kwargs_special=kwargs_special)
+        print(extinction, 'test extinction')
         extinction_array = np.ones_like(ra_grid) * extinction
-        extinction = self.ImageNumerics.re_size_convolve(extinction_array, unconvolved=True)
+        extinction = self.ImageNumerics.re_size_convolve(extinction_array, unconvolved=True) / self.ImageNumerics.grid_class.pixel_width ** 2
         return extinction
 
     @staticmethod

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -377,7 +377,7 @@ class ModelBandPlot(ModelBand):
         y_grid_source += y_center
         coords_source = Coordinates(self._coords.transform_pix2angle * deltaPix_source / self._deltaPix, ra_at_xy_0=x_grid_source[0],
                                     dec_at_xy_0=y_grid_source[0])
-        error_map_source = self._bandmodel._error_map_source(self._kwargs_source_partial, x_grid_source, y_grid_source,
+        error_map_source = self._bandmodel.error_map_source(self._kwargs_source_partial, x_grid_source, y_grid_source,
                                                             self._cov_param, model_index_select=False)
         error_map_source = util.array2image(error_map_source)
         d_s = numPix * deltaPix_source

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -356,7 +356,8 @@ class ModelBandPlot(ModelBand):
         """
         plots the uncertainty in the surface brightness in the source from the linear inversion by taking the diagonal
         elements of the covariance matrix of the inversion of the basis set to be propagated to the source plane.
-        #TODO illustration of the uncertainties in real space with the full covariance matrix is subtle. The best way is probably to draw realizations from the covariance matrix.
+        #TODO illustration of the uncertainties in real space with the full covariance matrix is subtle.
+        # The best way is probably to draw realizations from the covariance matrix.
 
         :param ax: matplotlib axis instance
         :param numPix: number of pixels in plot per axis
@@ -376,7 +377,7 @@ class ModelBandPlot(ModelBand):
         y_grid_source += y_center
         coords_source = Coordinates(self._coords.transform_pix2angle * deltaPix_source / self._deltaPix, ra_at_xy_0=x_grid_source[0],
                                     dec_at_xy_0=y_grid_source[0])
-        error_map_source = self._bandmodel.error_map_source(self._kwargs_source_partial, x_grid_source, y_grid_source,
+        error_map_source = self._bandmodel._error_map_source(self._kwargs_source_partial, x_grid_source, y_grid_source,
                                                             self._cov_param, model_index_select=False)
         error_map_source = util.array2image(error_map_source)
         d_s = numPix * deltaPix_source
@@ -495,7 +496,7 @@ class ModelBandPlot(ModelBand):
         :param kwargs: kwargs to send matplotlib.pyplot.matshow()
         :return:
         """
-        model = self._bandmodel.image(self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial,
+        model = self._bandmodel._image(self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial,
                                       self._kwargs_ps_partial, unconvolved=unconvolved, source_add=source_add,
                                       lens_light_add=lens_light_add, point_source_add=point_source_add)
         if v_min is None:
@@ -524,7 +525,7 @@ class ModelBandPlot(ModelBand):
                                 source_add=False, lens_light_add=False,
                                 font_size=15
                                 ):
-        model = self._bandmodel.image(self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial,
+        model = self._bandmodel._image(self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial,
                                       self._kwargs_ps_partial, unconvolved=False, source_add=source_add,
                                       lens_light_add=lens_light_add, point_source_add=point_source_add)
         if v_min is None:
@@ -612,7 +613,7 @@ class ModelBandPlot(ModelBand):
         :param v_max:
         :return:
         """
-        model = self._bandmodel.extinction_map(self._kwargs_extinction_partial, self._kwargs_special_partial)
+        model = self._bandmodel._extinction_map(self._kwargs_extinction_partial, self._kwargs_special_partial)
         if v_min is None:
             v_min = 0
         if v_max is None:

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -173,7 +173,9 @@ class PointSource(object):
                                                         magnification_limit=self._magnification_limit,
                                                         kwargs_lens_eqn_solver=self._kwargs_lens_eqn_solver,
                                                         additional_images=additional_images)
-                if original_position is True and self.point_source_type_list[i] == 'LENSED_POSITION':
+                # this takes action when new images are computed not necessary in order
+                if original_position is True and additional_images is True and\
+                        self.point_source_type_list[i] == 'LENSED_POSITION':
                     x_o, y_o = kwargs['ra_image'], kwargs['dec_image']
                     x_image, y_image = _sort_position_by_original(x_o, y_o, x_image, y_image)
 

--- a/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/flux_ratio_likelihood.py
@@ -14,15 +14,16 @@ class FluxRatioLikelihood(object):
         """
 
         :param lens_model_class: LensModel class instance
-        :param flux_ratios: ratio of fluxes of the multiple images (relative to the first appearing)
+        :param flux_ratios: ratio of fluxes of the multiple images (relative to the first appearing in
+         same order as the images)
         :param flux_ratio_errors: errors in the flux ratios (relative to the first appearing). Alternatively
-        a log-normal covariance matrix. Note: in the case of a the covariance matrix, the errors are are assumed
-        to be log-normal, i.e. the logarithms of the flux ratios, ln(F[i]/F[0]) are assumed to have a multivariate 
-        Gaussian distribution, with the given covariance matrix.
+         a log-normal covariance matrix. Note: in the case of a covariance matrix, the errors are assumed
+         to be log-normal, i.e. the logarithms of the flux ratios, ln(F[i]/F[0]) are assumed to have a multivariate
+         Gaussian distribution, with the given covariance matrix.
         :param source_type: string, type of source, 'INF' specifies a point source, while 'GAUSSIAN' specifies a
-        finite-size source modeled as a Gaussian
+         finite-size source modeled as a Gaussian
         :param window_size: size of window to compute the finite flux
-        :param grid_number: number of grid cells per axis in the window to numerically comute the flux
+        :param grid_number: number of grid cells per axis in the window to numerically compute the flux
         """
         self._lens_model_class = lens_model_class
         self._flux_ratios = np.array(flux_ratios)

--- a/lenstronomy/Workflow/fitting_sequence.py
+++ b/lenstronomy/Workflow/fitting_sequence.py
@@ -53,6 +53,7 @@ class FittingSequence(object):
                                                      num_bands=len(self.multi_band_list))
         self._mcmc_init_samples = None
 
+    @property
     def kwargs_fixed(self):
         """
         returns the updated kwargs_fixed from the update Manager

--- a/test/test_ImSim/test_image_linear_solve.py
+++ b/test/test_ImSim/test_image_linear_solve.py
@@ -1,5 +1,7 @@
 __author__ = 'sibirrer'
 
+import numpy as np
+
 from lenstronomy.ImSim.image_linear_solve import ImageLinearFit
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.lens_model import LensModel
@@ -8,6 +10,7 @@ from lenstronomy.PointSource.point_source import PointSource
 import lenstronomy.Util.simulation_util as sim_util
 from lenstronomy.Data.imaging_data import ImageData
 from lenstronomy.Data.psf import PSF
+import numpy.testing as npt
 
 
 class TestImageLinearFit(object):
@@ -58,3 +61,17 @@ class TestImageLinearFit(object):
         assert param[0] == self.kwargs_source[0]['amp']
         assert param[1] == self.kwargs_lens_light[0]['amp']
         assert param[2] == self.kwargs_ps[0]['source_amp']
+
+    def test_update_linear_kwargs(self):
+        num = self.imageModel.num_param_linear(self.kwargs_lens, self.kwargs_source, self.kwargs_lens_light,
+                                               self.kwargs_ps)
+        param = np.ones(num) * 10
+        kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps = self.imageModel.update_linear_kwargs(param,
+            kwargs_lens=self.kwargs_lens,
+            kwargs_source=self.kwargs_source, kwargs_lens_light=self.kwargs_lens_light, kwargs_ps=self.kwargs_ps)
+        assert kwargs_source[0]['amp'] == 10
+
+    def test_error_response(self):
+        C_D_response, model_error = self.imageModel.error_response(kwargs_lens=self.kwargs_lens,
+                                                                   kwargs_ps=self.kwargs_ps, kwargs_special=None)
+        npt.assert_almost_equal(model_error, 0)

--- a/test/test_LensModel/test_Profiles/test_sersic_lens.py
+++ b/test/test_LensModel/test_Profiles/test_sersic_lens.py
@@ -36,8 +36,8 @@ class TestSersic(object):
         values = self.sersic.function(x, y, n_sersic, R_sersic, k_eff)
         npt.assert_almost_equal(values[0], 0., decimal=9)
 
-        x = np.array([2,3,4])
-        y = np.array([1,1,1])
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
         values = self.sersic.function(x, y, n_sersic, R_sersic, k_eff)
 
         npt.assert_almost_equal(values[0], 1.0272982586319199, decimal=10)
@@ -53,8 +53,8 @@ class TestSersic(object):
         f_x, f_y = self.sersic.derivatives(x, y, n_sersic, R_sersic, k_eff)
         f_x2, f_y2 = self.sersic_2.derivatives(x, y, n_sersic, R_sersic, k_eff, 0, 0.00000001)
 
-        assert f_x[0] == 0.16556078301997193
-        assert f_y[0] == 0.33112156603994386
+        npt.assert_almost_equal(f_x[0], 0.16556078301997193, decimal=9)
+        npt.assert_almost_equal(f_y[0], 0.33112156603994386, decimal=9)
         npt.assert_almost_equal(f_x2[0], f_x[0])
         npt.assert_almost_equal(f_y2[0], f_y[0])
 
@@ -67,14 +67,14 @@ class TestSersic(object):
         npt.assert_almost_equal(f_x2[0], f_x[0])
         npt.assert_almost_equal(f_y2[0], f_y[0])
 
-        x = np.array([1,3,4])
-        y = np.array([2,1,1])
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
         values = self.sersic.derivatives(x, y, n_sersic, R_sersic, k_eff)
         values2 = self.sersic_2.derivatives(x, y, n_sersic, R_sersic, k_eff, 0, 0.00000001)
-        assert values[0][0] == 0.16556078301997193
-        assert values[1][0] == 0.33112156603994386
-        assert values[0][1] == 0.2772992378623737
-        assert values[1][1] == 0.092433079287457892
+        npt.assert_almost_equal(values[0][0], 0.16556078301997193, decimal=9)
+        npt.assert_almost_equal(values[1][0], 0.33112156603994386, decimal=9)
+        npt.assert_almost_equal(values[0][1], 0.2772992378623737, decimal=9)
+        npt.assert_almost_equal(values[1][1], 0.092433079287457892, decimal=9)
         npt.assert_almost_equal(values2[0][0], values[0][0])
         npt.assert_almost_equal(values2[1][0], values[1][0])
         npt.assert_almost_equal(values2[0][1], values[0][1])
@@ -113,16 +113,16 @@ class TestSersic(object):
         R_sersic = 1.
         k_eff = 0.2
         f_xx, f_xy, f_yx, f_yy = self.sersic.hessian(x, y, n_sersic, R_sersic, k_eff)
-        assert f_xx[0] == 0.1123170666045793
+        npt.assert_almost_equal(f_xx[0], 0.1123170666045793, decimal=10)
         npt.assert_almost_equal(f_yy[0], -0.047414082641598576, decimal=10)
-        npt.assert_almost_equal(f_xy[0], -0.10648743283078525 , decimal=10)
+        npt.assert_almost_equal(f_xy[0], -0.10648743283078525, decimal=10)
         npt.assert_almost_equal(f_xy, f_yx, decimal=5)
-        x = np.array([1,3,4])
-        y = np.array([2,1,1])
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
         values = self.sersic.hessian(x, y, n_sersic, R_sersic, k_eff)
-        assert values[0][0] == 0.1123170666045793
+        npt.assert_almost_equal(values[0][0], 0.1123170666045793, decimal=10)
         npt.assert_almost_equal(values[3][0], -0.047414082641598576, decimal=10)
-        npt.assert_almost_equal(values[1][0], -0.10648743283078525 , decimal=10)
+        npt.assert_almost_equal(values[1][0], -0.10648743283078525, decimal=10)
         npt.assert_almost_equal(values[0][1], -0.053273787681591328, decimal=10)
         npt.assert_almost_equal(values[3][1], 0.076243427402007985, decimal=10)
         npt.assert_almost_equal(values[1][1], -0.048568955656349749, decimal=10)

--- a/test/test_LensModel/test_Profiles/test_sis.py
+++ b/test/test_LensModel/test_Profiles/test_sis.py
@@ -20,7 +20,7 @@ class TestSIS(object):
         y = np.array([2])
         phi_E = 1.
         values = self.SIS.function(x, y, phi_E)
-        assert values[0] == 2.2360679774997898
+        npt.assert_almost_equal(values[0], 2.2360679774997898, decimal=9)
         x = np.array([0])
         y = np.array([0])
         phi_E = 1.
@@ -30,17 +30,17 @@ class TestSIS(object):
         x = np.array([2,3,4])
         y = np.array([1,1,1])
         values = self.SIS.function( x, y, phi_E)
-        assert values[0] == 2.2360679774997898
-        assert values[1] == 3.1622776601683795
-        assert values[2] == 4.1231056256176606
+        npt.assert_almost_equal(values[0], 2.2360679774997898, decimal=9)
+        npt.assert_almost_equal(values[1], 3.1622776601683795, decimal=9)
+        npt.assert_almost_equal(values[2], 4.1231056256176606, decimal=9)
 
     def test_derivatives(self):
         x = np.array([1])
         y = np.array([2])
         phi_E = 1.
         f_x, f_y = self.SIS.derivatives( x, y, phi_E)
-        assert f_x[0] == 0.44721359549995793
-        assert f_y[0] == 0.89442719099991586
+        npt.assert_almost_equal(f_x[0], 0.44721359549995793, decimal=9)
+        npt.assert_almost_equal(f_y[0], 0.89442719099991586, decimal=9)
         x = np.array([0])
         y = np.array([0])
         f_x, f_y = self.SIS.derivatives( x, y, phi_E)
@@ -60,19 +60,19 @@ class TestSIS(object):
         y = np.array([2])
         phi_E = 1.
         f_xx, f_xy, f_yx, f_yy = self.SIS.hessian( x, y, phi_E)
-        assert f_xx[0] == 0.35777087639996635
-        assert f_yy[0] == 0.089442719099991588
-        assert f_xy[0] == -0.17888543819998318
+        npt.assert_almost_equal(f_xx[0], 0.35777087639996635, decimal=9)
+        npt.assert_almost_equal(f_yy[0], 0.089442719099991588, decimal=9)
+        npt.assert_almost_equal(f_xy[0], -0.17888543819998318, decimal=9)
         npt.assert_almost_equal(f_xy, f_yx, decimal=8)
         x = np.array([1,3,4])
         y = np.array([2,1,1])
         values = self.SIS.hessian( x, y, phi_E)
-        assert values[0][0] == 0.35777087639996635
-        assert values[3][0] == 0.089442719099991588
-        assert values[1][0] == -0.17888543819998318
-        assert values[0][1] == 0.031622776601683791
-        assert values[3][1] == 0.28460498941515411
-        assert values[1][1] == -0.094868329805051374
+        npt.assert_almost_equal(values[0][0], 0.35777087639996635, decimal=9)
+        npt.assert_almost_equal(values[3][0], 0.089442719099991588, decimal=9)
+        npt.assert_almost_equal(values[1][0], -0.17888543819998318, decimal=9)
+        npt.assert_almost_equal(values[0][1], 0.031622776601683791, decimal=9)
+        npt.assert_almost_equal(values[3][1], 0.28460498941515411, decimal=9)
+        npt.assert_almost_equal(values[1][1], -0.094868329805051374, decimal=9)
 
     def test_theta2rho(self):
         theta_E = 2.

--- a/test/test_LensModel/test_Profiles/test_sis_truncate.py
+++ b/test/test_LensModel/test_Profiles/test_sis_truncate.py
@@ -30,8 +30,8 @@ class TestSIS_truncate(object):
         x = np.array([2,3,4])
         y = np.array([1,1,1])
         values = self.SIS.function(x, y, phi_E, r_trunc)
-        assert values[0] == 2.2221359549995796
-        assert values[1] == 2.8245553203367586
+        npt.assert_almost_equal(values[0], 2.2221359549995796, decimal=9)
+        npt.assert_almost_equal(values[1], 2.8245553203367586, decimal=9)
         assert values[2] == 3
 
     def test_derivatives(self):
@@ -40,8 +40,8 @@ class TestSIS_truncate(object):
         phi_E = 1.
         r_trunc = 2
         f_x, f_y = self.SIS.derivatives(x, y, phi_E, r_trunc)
-        assert f_x == 0.39442719099991586
-        assert f_y == 0.78885438199983171
+        npt.assert_almost_equal(f_x, 0.39442719099991586, decimal=9)
+        npt.assert_almost_equal(f_y, 0.78885438199983171, decimal=9)
         x = np.array([0])
         y = np.array([0])
         f_x, f_y = self.SIS.derivatives(x, y, phi_E, r_trunc)
@@ -51,10 +51,10 @@ class TestSIS_truncate(object):
         x = np.array([1,3,4])
         y = np.array([2,1,1])
         values = self.SIS.derivatives(x, y, phi_E, r_trunc)
-        assert values[0][0] == 0.39442719099991586
-        assert values[1][0] == 0.78885438199983171
-        assert values[0][1] == 0.39736659610102748
-        assert values[1][1] == 0.13245553203367583
+        npt.assert_almost_equal(values[0][0], 0.39442719099991586, decimal=9)
+        npt.assert_almost_equal(values[1][0], 0.78885438199983171, decimal=9)
+        npt.assert_almost_equal(values[0][1], 0.39736659610102748, decimal=9)
+        npt.assert_almost_equal(values[1][1], 0.13245553203367583, decimal=9)
 
     def test_hessian(self):
         x = 1
@@ -69,12 +69,12 @@ class TestSIS_truncate(object):
         x = np.array([1,3,4])
         y = np.array([2,1,1])
         values = self.SIS.hessian(x, y, phi_E, r_trunc)
-        assert values[0][0] == 0.21554175279993265
-        assert values[3][0] == -0.3211145618000168
-        assert values[1][0] == -0.3577708763999663
-        assert values[0][1] == -0.43675444679663239
-        assert values[3][1] == 0.06920997883030823
-        assert values[1][1] == -0.18973665961010272
+        npt.assert_almost_equal(values[0][0], 0.21554175279993265, decimal=9)
+        npt.assert_almost_equal(values[3][0], -0.3211145618000168, decimal=9)
+        npt.assert_almost_equal(values[1][0], -0.3577708763999663, decimal=9)
+        npt.assert_almost_equal(values[0][1], -0.43675444679663239, decimal=9)
+        npt.assert_almost_equal(values[3][1], 0.06920997883030823, decimal=9)
+        npt.assert_almost_equal(values[1][1], -0.18973665961010272, decimal=9)
 
 
 if __name__ == '__main__':

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -297,7 +297,6 @@ class TestRaise(unittest.TestCase):
                                  kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
                                  arrow_size=0.02, cmap_string="gist_heat", linear_solver=False)
 
-
 def test_interferometry_natwt_Model_Plot_linear_solver():
     # Test no errors are raised in the Model Plot linear solver for 'interferometry_natwt' likelihood function.
     try:
@@ -311,7 +310,8 @@ def test_interferometry_natwt_Model_Plot_linear_solver():
                              kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
                              arrow_size=0.02, cmap_string="gist_heat", linear_solver=True)
     except:
-        pytest.fail("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
+        Warning("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
+        #pytest.fail("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
 
 
 if __name__ == '__main__':

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -310,8 +310,7 @@ def test_interferometry_natwt_Model_Plot_linear_solver():
                              kwargs_model=kwargs_model, kwargs_params=kwargs_params, bands_compute=[True],
                              arrow_size=0.02, cmap_string="gist_heat", linear_solver=True)
     except:
-        Warning("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
-        #pytest.fail("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
+        pytest.fail("Errors are raised in the Model Plot linear solver for the 'interferometric_natwt' likelihood method, which is not expected.")
 
 
 if __name__ == '__main__':

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -32,6 +32,13 @@ class TestPointSource(object):
         npt.assert_almost_equal(x_image_list[1], 1, decimal=8)
         npt.assert_almost_equal(x_image_list[2][0], self.x_pos[0], decimal=8)
 
+        x_image_list, y_image_list = self.PointSource.image_position(kwargs_ps=self.kwargs_ps,
+                                                                     kwargs_lens=self.kwargs_lens,
+                                                                     original_position=True, additional_images=True)
+        npt.assert_almost_equal(x_image_list[0][0], self.x_pos[0], decimal=8)
+        npt.assert_almost_equal(x_image_list[1], 1, decimal=8)
+        npt.assert_almost_equal(x_image_list[2][0], self.x_pos[0], decimal=8)
+
     def test_source_position(self):
         x_source_list, y_source_list = self.PointSource.source_position(kwargs_ps=self.kwargs_ps, kwargs_lens=self.kwargs_lens)
         npt.assert_almost_equal(x_source_list[0], self.sourcePos_x, decimal=8)


### PR DESCRIPTION
This PR is aimed at removing ambiguities when dealing with the SingleBandMultiModel() class that down-selects the input models and the keyword argument lists for specific bands. In particular, the definitions in the inherited ImageModel() class were expected to have as inputs the down-selected dictionary lists. With this PR, this is being changed.