### PR TITLE
point source positions with multi-frames enabled

### DIFF
--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -127,6 +127,7 @@ class ModelBand(object):
         self._bandmodel = SingleBandMultiModel(multi_band_list, kwargs_model,
                                                likelihood_mask_list=image_likelihood_mask_list, band_index=band_index)
         self._kwargs_special_partial = kwargs_params.get('kwargs_special', None)
+        self._kwargs_lens = kwargs_params.get('kwargs_lens', None)
         kwarks_lens_partial, kwargs_source_partial, kwargs_lens_light_partial, kwargs_ps_partial, self._kwargs_extinction_partial = self._bandmodel.select_kwargs(**kwargs_params)
         self._kwargs_lens_partial, self._kwargs_source_partial, self._kwargs_lens_light_partial, self._kwargs_ps_partial = self._bandmodel._update_linear_kwargs(param, kwarks_lens_partial, kwargs_source_partial, kwargs_lens_light_partial, kwargs_ps_partial)
         # this is an (out-commented) example of how to re-create the model in this band

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -50,7 +50,8 @@ class ImageModel(object):
         if point_source_class is None:
             point_source_class = PointSource(point_source_type_list=[])
         self.PointSource = point_source_class
-        self.PointSource.update_lens_model(lens_model_class=lens_model_class)
+        if self.PointSource._lensModel is None:
+            self.PointSource.update_lens_model(lens_model_class=lens_model_class)
         x_center, y_center = self.Data.center
         self.PointSource.update_search_window(search_window=np.max(self.Data.width), x_center=x_center,
                                               y_center=y_center, min_distance=self.Data.pixel_width,

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -24,7 +24,6 @@ class SinglePlane(ProfileListBase):
         """
 
         dx, dy = self.alpha(x, y, kwargs, k=k)
-
         return x - dx, y - dy
 
     def fermat_potential(self, x_image, y_image, kwargs_lens, x_source=None, y_source=None, k=None):

--- a/lenstronomy/LightModel/Profiles/shapelets.py
+++ b/lenstronomy/LightModel/Profiles/shapelets.py
@@ -165,8 +165,8 @@ class Shapelets(object):
         x_ = x - center_x
         y_ = y - center_y
         n = len(np.atleast_1d(x))
-        H_x = np.empty((n_order+1, n))
-        H_y = np.empty((n_order+1, n))
+        H_x = np.empty((n_order + 1, n))
+        H_y = np.empty((n_order + 1, n))
         exp_x = np.exp(-(x_ / beta) ** 2 / 2.)
         exp_y = np.exp(-(y_ / beta) ** 2 / 2.)
         if n_order > 170:

--- a/lenstronomy/LightModel/light_param.py
+++ b/lenstronomy/LightModel/light_param.py
@@ -39,7 +39,12 @@ class LightParam(object):
                 kwargs_upper.append(func.upper_limit_default)
         self.lower_limit = kwargs_lower
         self.upper_limit = kwargs_upper
-    
+        # check that n_max is fixed
+        for k, model in enumerate(self.model_list):
+            if model in ['SHAPELETS', 'SHAPELETS_POLAR', 'SHAPELETS_POLAR_EXP']:
+                if 'n_max' not in self.kwargs_fixed[k]:
+                    Warning('n_max needs to be fixed in %s.' % model)
+
     @property
     def param_name_list(self):
         return self._param_name_list

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -348,7 +348,7 @@ class ModelBandPlot(ModelBand):
             plot_util.text_description(ax, d_s, text=text, color="w", backgroundcolor='k',
                          flipped=False, font_size=font_size)
         if point_source_position is True:
-            ra_source, dec_source = self._bandmodel.PointSource.source_position(self._kwargs_ps_partial, self._kwargs_lens_partial)
+            ra_source, dec_source = self._bandmodel.PointSource.source_position(self._kwargs_ps_partial, self._kwargs_lens)
             plot_util.source_position_plot(ax, coords_source, ra_source, dec_source)
         return ax
 
@@ -400,7 +400,7 @@ class ModelBandPlot(ModelBand):
         plot_util.text_description(ax, d_s, text="Error map in source", color="w", backgroundcolor='k', flipped=False,
                                    font_size=font_size)
         if point_source_position is True:
-            ra_source, dec_source = self._bandmodel.PointSource.source_position(self._kwargs_ps_partial, self._kwargs_lens_partial)
+            ra_source, dec_source = self._bandmodel.PointSource.source_position(self._kwargs_ps_partial, self._kwargs_lens)
             plot_util.source_position_plot(ax, coords_source, ra_source, dec_source)
         return ax
 

--- a/lenstronomy/PointSource/Types/base_ps.py
+++ b/lenstronomy/PointSource/Types/base_ps.py
@@ -8,15 +8,29 @@ class PSBase(object):
     """
     base point source type class
     """
-    def __init__(self, lens_model=None, fixed_magnification=False, additional_images=False):
+    def __init__(self, lens_model=None, fixed_magnification=False, additional_images=False, index_lens_model_list=None,
+                 point_source_frame_list=None):
         """
 
         :param lens_model: instance of the LensModel() class
         :param fixed_magnification: bool. If True, magnification
          ratio of point sources is fixed to the one given by the lens model
         :param additional_images: bool. If True, search for additional images of the same source is conducted.
+        :param index_lens_model_list: list (length of different patches/bands) of integer lists, e.g., [[0, 1], [2, 3]];
+         evaluating a subset of the lens models per individual bands. If this keyword is set, the image positions need
+         to have a specified band/frame assigned to it
+        :param point_source_frame_list: list of lists mirroring the structure of the image positions.
+         Integers correspond to the i'th list entry of index_lens_model_list indicating in which frame/band the image is
+         appearing
         """
         self._lens_model = lens_model
+        if index_lens_model_list is not None:
+            k_list = []
+            for point_source_frame in point_source_frame_list:
+                k_list.append(index_lens_model_list[point_source_frame])
+            self.k_list = k_list
+        else:
+            self.k_list = None
         if self._lens_model is None:
             self._solver = None
         else:

--- a/lenstronomy/PointSource/Types/lensed_position.py
+++ b/lenstronomy/PointSource/Types/lensed_position.py
@@ -6,7 +6,7 @@ __all__ = ['LensedPositions']
 
 class LensedPositions(PSBase):
     """
-    class of a a lensed point source parameterized as the (multiple) observed image positions
+    class of a lensed point source parameterized as the (multiple) observed image positions
     Name within the PointSource module: 'LENSED_POSITION'
     parameters: ra_image, dec_image, point_amp
     If fixed_magnification=True, than 'source_amp' is a parameter instead of 'point_amp'
@@ -36,6 +36,7 @@ class LensedPositions(PSBase):
             if kwargs_lens_eqn_solver is None:
                 kwargs_lens_eqn_solver = {}
             ra_source, dec_source = self.source_position(kwargs_ps, kwargs_lens)
+            # TODO: this solver does not distinguish between different frames/bands with partial lens models
             ra_image, dec_image = self._solver.image_position_from_source(ra_source, dec_source, kwargs_lens,
                                                                           magnification_limit=magnification_limit,
                                                                           **kwargs_lens_eqn_solver)
@@ -54,7 +55,15 @@ class LensedPositions(PSBase):
         """
         ra_image = kwargs_ps['ra_image']
         dec_image = kwargs_ps['dec_image']
-        x_source, y_source = self._lens_model.ray_shooting(ra_image, dec_image, kwargs_lens)
+
+        if self.k_list is None:
+            x_source, y_source = self._lens_model.ray_shooting(ra_image, dec_image, kwargs_lens)
+        else:
+            x_source, y_source = [], []
+            for i in range(len(ra_image)):
+                x, y = self._lens_model.ray_shooting(ra_image[i], dec_image[i], kwargs_lens, k=self.k_list[i])
+                x_source.append(x)
+                y_source.append(y)
         x_source = np.mean(x_source)
         y_source = np.mean(y_source)
         return np.array(x_source), np.array(y_source)
@@ -82,7 +91,13 @@ class LensedPositions(PSBase):
                 ra_image, dec_image = self.image_position(kwargs_ps, kwargs_lens,
                                                           magnification_limit=magnification_limit,
                                                           kwargs_lens_eqn_solver=kwargs_lens_eqn_solver)
-            mag = self._lens_model.magnification(ra_image, dec_image, kwargs_lens)
+
+            if self.k_list is None:
+                mag = self._lens_model.magnification(ra_image, dec_image, kwargs_lens)
+            else:
+                mag = []
+                for i in range(len(ra_image)):
+                    mag.append(self._lens_model.magnification(ra_image, dec_image, kwargs_lens, k=self.k_list[i]))
             point_amp = kwargs_ps['source_amp'] * np.abs(mag)
         else:
             point_amp = kwargs_ps['point_amp']
@@ -105,7 +120,12 @@ class LensedPositions(PSBase):
             source_amp = kwargs_ps['source_amp']
         else:
             ra_image, dec_image = kwargs_ps['ra_image'], kwargs_ps['dec_image']
-            mag = self._lens_model.magnification(ra_image, dec_image, kwargs_lens)
+            if self.k_list is None:
+                mag = self._lens_model.magnification(ra_image, dec_image, kwargs_lens)
+            else:
+                mag = []
+                for i in range(len(ra_image)):
+                    mag.append(self._lens_model.magnification(ra_image, dec_image, kwargs_lens, k=self.k_list[i]))
             point_amp = kwargs_ps['point_amp']
             source_amp = np.mean(np.array(point_amp) / np.array(np.abs(mag)))
         return np.array(source_amp)

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -11,7 +11,8 @@ class PointSource(object):
 
     def __init__(self, point_source_type_list, lensModel=None, fixed_magnification_list=None,
                  additional_images_list=None, flux_from_point_source_list=None, magnification_limit=None,
-                 save_cache=False, kwargs_lens_eqn_solver=None):
+                 save_cache=False, kwargs_lens_eqn_solver=None, index_lens_model_list=None,
+                 point_source_frame_list=None):
         """
 
         :param point_source_type_list: list of point source types
@@ -32,9 +33,23 @@ class PointSource(object):
          equation is conducted with the lens model parameters provided. This can increase the speed as multiple times
          the image positions are requested for the same lens model. Attention in usage!
         :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical settings for the lens equation solver
-         see LensEquationSolver() class for details ,such as:
+         see LensEquationSolver() class for details, such as:
          min_distance=0.01, search_window=5, precision_limit=10**(-10), num_iter_max=100
+        :param index_lens_model_list: list (length of different patches/bands) of integer lists, e.g., [[0, 1], [2, 3]];
+         evaluating a subset of the lens models per individual bands. If this keyword is set, the image positions need
+         to have a specified band/frame assigned to it
+        :param point_source_frame_list: list of lists mirroring the structure of the image positions.
+         Integers correspond to the i'th list entry of index_lens_model_list indicating in which frame/band the image is
+         appearing
         """
+        if len(point_source_type_list) > 0:
+            if index_lens_model_list is not None and point_source_frame_list is None:
+                raise ValueError('with specified index_lens_model_list a specified point_source_frame_list argument is '
+                                 'required')
+            if index_lens_model_list is None:
+                point_source_frame_list = [None] * len(point_source_type_list)
+        self._index_lens_model_list = index_lens_model_list
+        self._point_source_frame_list = point_source_frame_list
         self._lensModel = lensModel
         self.point_source_type_list = point_source_type_list
         self._point_source_list = []
@@ -52,9 +67,12 @@ class PointSource(object):
                 self._point_source_list.append(PointSourceCached(Unlensed(), save_cache=save_cache))
             elif model == 'LENSED_POSITION':
                 from lenstronomy.PointSource.Types.lensed_position import LensedPositions
-                self._point_source_list.append(PointSourceCached(LensedPositions(lensModel, fixed_magnification=fixed_magnification_list[i],
-                                                                                 additional_images=additional_images_list[i]),
-                                                                 save_cache=save_cache))
+                self._point_source_list.append(PointSourceCached(LensedPositions(lensModel,
+                    fixed_magnification=fixed_magnification_list[i],
+                     additional_images=additional_images_list[i],
+                     index_lens_model_list=index_lens_model_list,
+                     point_source_frame_list=point_source_frame_list[i]),
+                                                save_cache=save_cache))
             elif model == 'SOURCE_POSITION':
                 from lenstronomy.PointSource.Types.source_position import SourcePositions
                 self._point_source_list.append(PointSourceCached(SourcePositions(lensModel,
@@ -132,6 +150,20 @@ class PointSource(object):
         """
         for model in self._point_source_list:
             model.set_save_cache(save_cache)
+
+    def k_list(self, k):
+        """
+
+        :param k: index of point source model
+        :return: list of lengths of images with corresponding lens models in the frame (or None if not multi-frame)
+        """
+        if self._index_lens_model_list is not None:
+            k_list = []
+            for point_source_frame in self._point_source_frame_list[k]:
+                k_list.append(self._index_lens_model_list[point_source_frame])
+        else:
+            k_list = None
+        return k_list
 
     def source_position(self, kwargs_ps, kwargs_lens):
         """
@@ -355,7 +387,7 @@ class PointSource(object):
 
         :param kwargs_ps: point source keyword argument list
         :param kwargs_lens: lens model keyword argument list
-        :param tolerance: Eucledian distance between the source positions ray-traced backwards to be tolerated
+        :param tolerance: Euclidian distance between the source positions ray-traced backwards to be tolerated
         :return: bool: True, if requirement on tolerance is fulfilled, False if not.
         """
         x_image_list, y_image_list = self.image_position(kwargs_ps, kwargs_lens)

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -134,7 +134,7 @@ class LikelihoodModule(object):
         """
 
         # TODO: in case lens model or point source models are only applied on partial images, then this current class
-        # has ambiguities when it comes to time-delay likelihood and flux ratio likelihood
+        # has ambiguities when it comes to position likelihood, time-delay likelihood and flux ratio likelihood
         lens_model_class, _, _, point_source_class, _ = class_creator.create_class_instances(all_models=True,
                                                                                              **kwargs_model)
         self.PointSource = point_source_class

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -15,7 +15,7 @@ def create_class_instances(lens_model_list=None, z_lens=None, z_source=None, z_s
                            lens_redshift_list=None, kwargs_interp=None,
                            multi_plane=False, observed_convention_index=None, source_light_model_list=None,
                            lens_light_model_list=None, point_source_model_list=None, fixed_magnification_list=None,
-                           flux_from_point_source_list=None,
+                           flux_from_point_source_list=None, point_source_frame_list=None,
                            additional_images_list=None, kwargs_lens_eqn_solver=None,
                            source_deflection_scaling_list=None, source_redshift_list=None, cosmo=None,
                            index_lens_model_list=None, index_source_light_model_list=None,
@@ -42,6 +42,9 @@ def create_class_instances(lens_model_list=None, z_lens=None, z_source=None, z_s
     :param fixed_magnification_list:
     :param flux_from_point_source_list: list of bools (optional), if set, will only return image positions
          (for imaging modeling) for the subset of the point source lists that =True. This option enables to model
+    :param point_source_frame_list: list of lists mirroring the structure of the image positions.
+     Integers correspond to the i'th list entry of index_lens_model_list indicating in which frame/band the image is
+     appearing
     :param additional_images_list:
     :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical settings for the lens equation solver
          see LensEquationSolver() class for details
@@ -105,6 +108,12 @@ def create_class_instances(lens_model_list=None, z_lens=None, z_source=None, z_s
                                  observed_convention_index=observed_convention_index_i, kwargs_interp=kwargs_interp,
                                  numerical_alpha_class=tabulated_deflection_angles)
 
+    lens_model_class_all = LensModel(lens_model_list=lens_model_list, z_lens=z_lens, z_source=z_source,
+                                     z_source_convention=z_source_convention, lens_redshift_list=lens_redshift_list,
+                                     multi_plane=multi_plane, cosmo=cosmo,
+                                     observed_convention_index=observed_convention_index, kwargs_interp=kwargs_interp,
+                                     numerical_alpha_class=tabulated_deflection_angles)
+
     if index_source_light_model_list is None or all_models is True:
         source_light_model_list_i = source_light_model_list
         source_deflection_scaling_list_i = source_deflection_scaling_list
@@ -134,6 +143,7 @@ def create_class_instances(lens_model_list=None, z_lens=None, z_source=None, z_s
     point_source_model_list_i = point_source_model_list
     fixed_magnification_list_i = fixed_magnification_list
     additional_images_list_i = additional_images_list
+    point_source_frame_list_i = point_source_frame_list
 
     if index_point_source_model_list is not None and not all_models:
         point_source_model_list_i = [point_source_model_list[k] for k in index_point_source_model_list[band_index]]
@@ -141,12 +151,16 @@ def create_class_instances(lens_model_list=None, z_lens=None, z_source=None, z_s
             fixed_magnification_list_i = [fixed_magnification_list[k] for k in index_point_source_model_list[band_index]]
         if additional_images_list is not None:
             additional_images_list_i = [additional_images_list[k] for k in index_point_source_model_list[band_index]]
-    point_source_class = PointSource(point_source_type_list=point_source_model_list_i, lensModel=lens_model_class,
+        if point_source_frame_list is not None:
+            point_source_frame_list_i = [point_source_frame_list[k] for k in index_point_source_model_list[band_index]]
+    point_source_class = PointSource(point_source_type_list=point_source_model_list_i, lensModel=lens_model_class_all,
                                      fixed_magnification_list=fixed_magnification_list_i,
                                      flux_from_point_source_list=flux_from_point_source_list,
                                      additional_images_list=additional_images_list_i,
                                      magnification_limit=point_source_magnification_limit,
-                                     kwargs_lens_eqn_solver=kwargs_lens_eqn_solver)
+                                     kwargs_lens_eqn_solver=kwargs_lens_eqn_solver,
+                                     point_source_frame_list=point_source_frame_list_i,
+                                     index_lens_model_list=index_lens_model_list)
     if tau0_index_list is None:
         tau0_index = 0
     else:

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -666,7 +666,7 @@ def convert_bool_list(n, k=None):
     if k is a list of int, e.g. [0, 3, 5], returns a bool list with True's in the integers listed and False elsewhere
     if k is a boolean list, checks for size to match the numbers of models and returns it
 
-    :param n: integer, total lenght of output boolean list
+    :param n: integer, total length of output boolean list
     :param k: None, int, or list of ints
     :return: bool list
     """
@@ -691,7 +691,7 @@ def convert_bool_list(n, k=None):
                 if k_i < n:
                     bool_list[k_i] = True
                 else:
-                    raise ValueError("k as set by %s is not convertable in a bool string!" % k)
+                    raise ValueError("k as set by %s is not convertable in a bool string of length %s !" % (k, n))
     else:
         raise ValueError('input list k as %s not compatible' % k)
     return bool_list

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -72,6 +72,7 @@ class TestSingleBandMultiModel(object):
                         'index_lens_light_model_list': [[0]],
                         'index_source_light_model_list': [[0]],
                         'index_point_source_model_list': [[0]],
+                        'point_source_frame_list': [[0]]
                         }
 
         self.kwargs_params = {'kwargs_lens': kwargs_lens, 'kwargs_source': kwargs_source,

--- a/test/test_PointSource/test_Types/test_lensed_position.py
+++ b/test/test_PointSource/test_Types/test_lensed_position.py
@@ -9,7 +9,8 @@ class TestLensedPosition(object):
     def setup_method(self):
         lens_model = LensModel(lens_model_list=['SIS'])
         self.kwargs_lens = [{'theta_E': 1, 'center_x': 0, 'center_y': 0}]
-        self.ps_mag = LensedPositions(lens_model=lens_model, fixed_magnification=True)
+        self.ps_mag = LensedPositions(lens_model=lens_model, fixed_magnification=True, point_source_frame_list=[0, 0],
+                                      index_lens_model_list=[[0]])
         self.ps = LensedPositions(lens_model=lens_model, fixed_magnification=False)
         self.ps_add = LensedPositions(lens_model=lens_model, fixed_magnification=[False], additional_images=True)
         self.kwargs = {'point_amp': [2, 1], 'ra_image': [0, 1.2], 'dec_image': [0, 0]}

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -21,7 +21,8 @@ class TestPointSource(object):
                                                                    sourcePos_y=self.sourcePos_y, kwargs_lens=self.kwargs_lens)
         self.PointSource = PointSource(point_source_type_list=['LENSED_POSITION', 'UNLENSED', 'SOURCE_POSITION'],
                                        lensModel=lensModel, fixed_magnification_list=[False]*3,
-                                       additional_images_list=[False]*4, flux_from_point_source_list=[True, True, True])
+                                       additional_images_list=[False]*4, flux_from_point_source_list=[True, True, True],
+                                       index_lens_model_list=[[0]], point_source_frame_list=[[0] * len(self.x_pos), [0], [0]])
         self.kwargs_ps = [{'ra_image': self.x_pos, 'dec_image': self.y_pos, 'point_amp': np.ones_like(self.x_pos) * 2},
                           {'ra_image': [1.], 'dec_image': [1.], 'point_amp': [10]},
                           {'ra_source': self.sourcePos_x, 'dec_source': self.sourcePos_y, 'point_amp': np.ones_like(self.x_pos)}, {}]

--- a/test/test_Sampling/test_Likelihoods/test_position_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_position_likelihood.py
@@ -24,6 +24,15 @@ class TestPositionLikelihood(object):
                                              image_position_likelihood=True, ra_image_list=[x_pos], dec_image_list=[y_pos],
                                              source_position_likelihood=True, check_matched_source_position=False, source_position_tolerance=0.001, force_no_add_image=False,
                                              restrict_image_number=False, max_num_images=None)
+
+        self.likelihood_all = PositionLikelihood(point_source_class, image_position_uncertainty=0.005,
+                                             astrometric_likelihood=True,
+                                             image_position_likelihood=True, ra_image_list=[x_pos],
+                                             dec_image_list=[y_pos],
+                                             source_position_likelihood=True, check_matched_source_position=True,
+                                             source_position_tolerance=0.001, force_no_add_image=True,
+                                             restrict_image_number=True, max_num_images=5)
+
         self._x_pos, self._y_pos = x_pos, y_pos
 
     def test_image_position_likelihood(self):
@@ -33,6 +42,9 @@ class TestPositionLikelihood(object):
 
         kwargs_ps = [{'ra_image': self._x_pos + 0.01, 'dec_image': self._y_pos}]
         logL = self.likelihood.image_position_likelihood(kwargs_ps, self._kwargs_lens, sigma=0.01)
+        npt.assert_almost_equal(logL, -2, decimal=8)
+
+        self.likelihood_all.image_position_likelihood(kwargs_ps, self._kwargs_lens, sigma=0.01)
         npt.assert_almost_equal(logL, -2, decimal=8)
 
     def test_astrometric_likelihood(self):

--- a/test/test_Util/coolest_template_update_pyAPI.json
+++ b/test/test_Util/coolest_template_update_pyAPI.json
@@ -36,14 +36,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.08028784240848165
+                    "value": 0.11323541200353929
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.0834314686288201,
-                    "median": 0.08360405849427985,
-                    "percentile_16th": 0.08257035022266043,
-                    "percentile_84th": 0.08447758889470816
+                    "mean": 0.10700454790889738,
+                    "median": 0.10696497421217538,
+                    "percentile_16th": 0.1057738342044547,
+                    "percentile_84th": 0.1084737203064561
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -65,14 +65,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": -88.6461686344104
+                    "value": -7.217168075548159
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": -87.74138975488273,
-                    "median": -87.70905162431639,
-                    "percentile_16th": -88.11359089640823,
-                    "percentile_84th": -87.34816955268884
+                    "mean": -5.689304722762927,
+                    "median": -5.696855790656741,
+                    "percentile_16th": -5.9821921311601045,
+                    "percentile_84th": -5.377357579219279
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -114,14 +114,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.2698550382002391
+                    "value": 0.15232902469275142
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.2848512499860762,
-                    "median": 0.28391919074644295,
-                    "percentile_16th": 0.27723525686769923,
-                    "percentile_84th": 0.2912362857991146
+                    "mean": 0.17723806287870145,
+                    "median": 0.1828712450587679,
+                    "percentile_16th": 0.1516099609960561,
+                    "percentile_84th": 0.20475338496071827
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -143,14 +143,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.8456295909157578
+                    "value": 0.49510117182628705
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.867778869655172,
-                    "median": 0.8675683101304902,
-                    "percentile_16th": 0.8634646141855524,
-                    "percentile_84th": 0.8723194469220661
+                    "mean": 0.5072922109571728,
+                    "median": 0.5064828966438408,
+                    "percentile_16th": 0.5032238911010215,
+                    "percentile_84th": 0.5121671282696961
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -172,14 +172,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 35.86034360188829
+                    "value": 26.88108322772576
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 34.93042094049908,
-                    "median": 34.81129080819228,
-                    "percentile_16th": 34.12942295826212,
-                    "percentile_84th": 35.829885230551945
+                    "mean": 28.963184640708977,
+                    "median": 28.99200570525403,
+                    "percentile_16th": 28.621436458054735,
+                    "percentile_84th": 29.2931656496119
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -201,14 +201,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": -0.14192002413502444
+                    "value": -0.25973870945725974
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": -0.14108142386201725,
-                    "median": -0.1417887723375098,
-                    "percentile_16th": -0.13877318648155423,
-                    "percentile_84th": -0.14473350973338134
+                    "mean": -0.2114896792337598,
+                    "median": -0.2112944469505482,
+                    "percentile_16th": -0.20433758102542826,
+                    "percentile_84th": -0.21965440523497048
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -230,14 +230,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.012451021050170687
+                    "value": 1.3628788042135738
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.0336070783588442,
-                    "median": 0.034764130022613686,
-                    "percentile_16th": 0.025869266857929615,
-                    "percentile_84th": 0.039640196438159206
+                    "mean": 1.3714800142270784,
+                    "median": 1.3732762858558771,
+                    "percentile_16th": 1.365867124656035,
+                    "percentile_84th": 1.3785638006317762
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -303,14 +303,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.043032320820713524
+                    "value": 0.014766053302357057
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.0608861312764143,
-                    "median": 0.06373564730711578,
-                    "percentile_16th": 0.0525717489105345,
-                    "percentile_84th": 0.07058833814316429
+                    "mean": 0.06028511449852797,
+                    "median": 0.06368167866989334,
+                    "percentile_16th": 0.04535750706731953,
+                    "percentile_84th": 0.0723740157029311
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -332,14 +332,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 1.4056738052248503
+                    "value": 3.2174153088555575
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 1.3653901628398548,
-                    "median": 1.3633294155209843,
-                    "percentile_16th": 1.3458475813339812,
-                    "percentile_84th": 1.3829220342417692
+                    "mean": 3.204860410765481,
+                    "median": 3.2012824758634086,
+                    "percentile_16th": 3.1701338298426758,
+                    "percentile_84th": 3.235601264951213
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -361,14 +361,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 6.3846194078019005
+                    "value": 5.812772236981448
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 6.331472336677272,
-                    "median": 6.325768904388582,
-                    "percentile_16th": 6.309999901552871,
-                    "percentile_84th": 6.355624456773335
+                    "mean": 5.862992034915482,
+                    "median": 5.864950885651041,
+                    "percentile_16th": 5.839302061841325,
+                    "percentile_84th": 5.885516620757836
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -390,14 +390,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.805177916032711
+                    "value": 0.6698542528489305
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.8149072395475689,
-                    "median": 0.8143875399726024,
-                    "percentile_16th": 0.8121094982157592,
-                    "percentile_84th": 0.8176425870562799
+                    "mean": 0.6840832550599724,
+                    "median": 0.6846573885670876,
+                    "percentile_16th": 0.6778883518518963,
+                    "percentile_84th": 0.6900100310115358
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -419,14 +419,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 75.30463313467948
+                    "value": 79.34657094131052
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 74.62485231606139,
-                    "median": 74.61747234160111,
-                    "percentile_16th": 74.07556764956524,
-                    "percentile_84th": 75.14802889376142
+                    "mean": 80.01932014062103,
+                    "median": 79.97216922233574,
+                    "percentile_16th": 79.52213509459251,
+                    "percentile_84th": 80.48786569029356
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -448,14 +448,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.2289476873695148
+                    "value": 0.5618538016737871
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.20868566308330602,
-                    "median": 0.20778149980106572,
-                    "percentile_16th": 0.21364466351740044,
-                    "percentile_84th": 0.20382009162162373
+                    "mean": 0.5210006518405856,
+                    "median": 0.5215580725644668,
+                    "percentile_16th": 0.5310274365457294,
+                    "percentile_84th": 0.512719608582333
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -477,14 +477,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": -1.3371361055417084
+                    "value": 0.5532746469706314
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": -1.3715206235004056,
-                    "median": -1.3722856802348302,
-                    "percentile_16th": -1.3780834382218279,
-                    "percentile_84th": -1.3656885504515224
+                    "mean": 0.5565682208821388,
+                    "median": 0.557762369775528,
+                    "percentile_16th": 0.5498715268577485,
+                    "percentile_84th": 0.5630789003317176
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -514,14 +514,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 4.927822562542158
+                    "value": 1.4338463496240004
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 5.101023481557856,
-                    "median": 5.078020130568445,
-                    "percentile_16th": 4.758982014560028,
-                    "percentile_84th": 5.3919649808423324
+                    "mean": 0.7957334154826202,
+                    "median": 0.7619308953427045,
+                    "percentile_16th": 0.5945086709874743,
+                    "percentile_84th": 0.8860049005404672
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -543,14 +543,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.8300723176394926
+                    "value": 0.051614146563019575
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.6722740252439011,
-                    "median": 0.6673429038883207,
-                    "percentile_16th": 0.6521483150364589,
-                    "percentile_84th": 0.694747535748473
+                    "mean": 0.19304398650658028,
+                    "median": 0.18884002092945112,
+                    "percentile_16th": 0.16735928296804378,
+                    "percentile_84th": 0.22207032472197136
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -572,14 +572,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 4.396481133588683
+                    "value": 2.898529689865732
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 4.529856843342577,
-                    "median": 4.532358513493419,
-                    "percentile_16th": 4.513819555840464,
-                    "percentile_84th": 4.550226926374958
+                    "mean": 3.006901804857708,
+                    "median": 3.0054609468221627,
+                    "percentile_16th": 2.987602973604724,
+                    "percentile_84th": 3.0242058777009078
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -601,14 +601,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.8456295909157578
+                    "value": 0.49510117182628705
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.867778869655172,
-                    "median": 0.8675683101304902,
-                    "percentile_16th": 0.8634646141855524,
-                    "percentile_84th": 0.8723194469220661
+                    "mean": 0.5072922109571728,
+                    "median": 0.5064828966438408,
+                    "percentile_16th": 0.5032238911010215,
+                    "percentile_84th": 0.5121671282696961
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -630,14 +630,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 35.86034360188829
+                    "value": 26.88108322772576
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 34.93042094049908,
-                    "median": 34.81129080819228,
-                    "percentile_16th": 34.12942295826212,
-                    "percentile_84th": 35.829885230551945
+                    "mean": 28.963184640708977,
+                    "median": 28.99200570525403,
+                    "percentile_16th": 28.621436458054735,
+                    "percentile_84th": 29.2931656496119
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -659,14 +659,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": -0.14192002413502444
+                    "value": -0.25973870945725974
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": -0.14108142386201725,
-                    "median": -0.1417887723375098,
-                    "percentile_16th": -0.13877318648155423,
-                    "percentile_84th": -0.14473350973338134
+                    "mean": -0.2114896792337598,
+                    "median": -0.2112944469505482,
+                    "percentile_16th": -0.20433758102542826,
+                    "percentile_84th": -0.21965440523497048
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -688,14 +688,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.012451021050170687
+                    "value": 1.3628788042135738
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.0336070783588442,
-                    "median": 0.034764130022613686,
-                    "percentile_16th": 0.025869266857929615,
-                    "percentile_84th": 0.039640196438159206
+                    "mean": 1.3714800142270784,
+                    "median": 1.3732762858558771,
+                    "percentile_16th": 1.365867124656035,
+                    "percentile_84th": 1.3785638006317762
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -741,14 +741,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 5.416863154114772
+                    "value": 0.15103891585827595
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 4.394688074589356,
-                    "median": 4.459869031376075,
-                    "percentile_16th": 4.005331642838988,
-                    "percentile_84th": 4.773793305145151
+                    "mean": 0.1412227600176803,
+                    "median": 0.14159337551923612,
+                    "percentile_16th": 0.13899369314138466,
+                    "percentile_84th": 0.14398821724751196
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -770,14 +770,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.3640249282548136
+                    "value": 5.380286643911373
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.4660548399594208,
-                    "median": 0.46578502946298783,
-                    "percentile_16th": 0.4505897410052205,
-                    "percentile_84th": 0.48481836286629654
+                    "mean": 5.4716011397153395,
+                    "median": 5.468358392965,
+                    "percentile_16th": 5.439702205747826,
+                    "percentile_84th": 5.49970372282661
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -799,14 +799,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 4.396774282267133
+                    "value": 2.0295759788690724
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 4.386012064519258,
-                    "median": 4.386145401420407,
-                    "percentile_16th": 4.371488891989945,
-                    "percentile_84th": 4.401903273354358
+                    "mean": 2.0977953959427684,
+                    "median": 2.1008596179379584,
+                    "percentile_16th": 2.075275493217439,
+                    "percentile_84th": 2.1220473753486906
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -828,14 +828,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.8031289693097592
+                    "value": 0.38384530803139644
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.8047540447511803,
-                    "median": 0.803908138631314,
-                    "percentile_16th": 0.8008270849522741,
-                    "percentile_84th": 0.8089010199822535
+                    "mean": 0.38832547991064625,
+                    "median": 0.38784124142148724,
+                    "percentile_16th": 0.3847927787108162,
+                    "percentile_84th": 0.39163257860494616
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -857,14 +857,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 57.66472491375059
+                    "value": 32.244310589791006
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 57.49967705679063,
-                    "median": 57.42618922675578,
-                    "percentile_16th": 57.032675826908395,
-                    "percentile_84th": 57.94911782908431
+                    "mean": 33.12090945756981,
+                    "median": 33.09867078496377,
+                    "percentile_16th": 32.86454575215035,
+                    "percentile_84th": 33.34601054453545
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -886,14 +886,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": -0.1768323470448125
+                    "value": 0.11847599075168405
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": -0.16122753959112418,
-                    "median": -0.16021984738423553,
-                    "percentile_16th": -0.157291581491518,
-                    "percentile_84th": -0.1661538519644343
+                    "mean": 0.14137311610236794,
+                    "median": 0.14211732426215162,
+                    "percentile_16th": 0.15044069264220827,
+                    "percentile_84th": 0.1328648202224173
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -915,14 +915,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.38821361884269345
+                    "value": -0.5497963365895576
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.3728880221693646,
-                    "median": 0.3736937544404638,
-                    "percentile_16th": 0.3690298145480581,
-                    "percentile_84th": 0.37771047240572
+                    "mean": -0.5346163456786575,
+                    "median": -0.5319822843493355,
+                    "percentile_16th": -0.5433761993442665,
+                    "percentile_84th": -0.5263268937920943
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -981,14 +981,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.2343713567761273
+                    "value": 0.3396474977385784
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.2326051826420254,
-                    "median": 0.23251038415982542,
-                    "percentile_16th": 0.22901648563771657,
-                    "percentile_84th": 0.23675609569514788
+                    "mean": 0.30775208891564454,
+                    "median": 0.306328363630647,
+                    "percentile_16th": 0.2976632559294203,
+                    "percentile_84th": 0.31796031596001334
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -1011,67 +1011,67 @@
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
                     "value": [
-                      103.02872390855208,
-                      24.072032514468916,
-                      -6.531676868079238,
-                      26.17850850498505,
-                      1.352441118264391,
-                      38.27489245560879,
-                      -35.68274064024738,
-                      -0.7192522188334625,
-                      0.2821377903166482,
-                      9.272189557118068
+                      147.09545601850246,
+                      64.01170985714734,
+                      70.36863082976858,
+                      64.20628110174447,
+                      15.99780828228129,
+                      50.68591604215086,
+                      6.2411771784129755,
+                      11.345334972593172,
+                      2.418620993852393,
+                      20.45144733844489
                     ]
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
                     "mean": [
-                      107.60842187671525,
-                      16.062093145623404,
-                      -12.236190656279433,
-                      19.605019062497714,
-                      1.7751176135487357,
-                      34.393546447087374,
-                      -34.07775756045019,
-                      -1.6643964488192187,
-                      -2.6248198359028305,
-                      2.977551977425948
+                      157.21498523555644,
+                      62.33712664781889,
+                      82.47745298074156,
+                      65.21737426713425,
+                      18.03050544843368,
+                      67.71705731945491,
+                      0.406676976334394,
+                      8.438080921246065,
+                      1.7798102642642757,
+                      28.076298019984108
                     ],
                     "median": [
-                      107.90011415408006,
-                      16.11385553594195,
-                      -12.578730033516313,
-                      19.270965947087554,
-                      1.9669876055504063,
-                      33.664663624225255,
-                      -34.11053630385361,
-                      -1.5551887382022846,
-                      -2.4799805745426884,
-                      2.4403645168469157
+                      157.80196930529974,
+                      62.840661089658106,
+                      84.076759758122,
+                      65.92120503790197,
+                      19.31676006733334,
+                      68.819086391823,
+                      0.6448403605413204,
+                      8.46385293892219,
+                      2.5074829791904083,
+                      28.74148400755328
                     ],
                     "percentile_16th": [
-                      104.77808219392992,
-                      18.801747843074164,
-                      -13.967120550388742,
-                      17.97354026117791,
-                      3.010220798763585,
-                      31.64932649576819,
-                      -33.27220763487294,
-                      -2.8417561506377975,
-                      -0.9748910376459043,
-                      0.7268355721384798
+                      151.6645591997067,
+                      64.93995295217127,
+                      78.02428071636282,
+                      60.689411424053084,
+                      23.42514371878739,
+                      61.72273932197934,
+                      2.1601673081897745,
+                      5.17973465183442,
+                      5.399336944933137,
+                      25.077826830928863
                     ],
                     "percentile_84th": [
-                      110.52000737903913,
-                      13.088886958004093,
-                      -10.63249290274204,
-                      21.171614280958526,
-                      0.7410444586763394,
-                      36.79191436796804,
-                      -34.891567419239045,
-                      -0.4780764242642298,
-                      -4.231732413401309,
-                      4.7964143672102235
+                      161.99253941511859,
+                      59.08832225107962,
+                      86.82609876213289,
+                      69.17441537502772,
+                      12.43491436015556,
+                      73.3452788836545,
+                      -1.4625726244519324,
+                      12.463366771128651,
+                      -1.8273325683095765,
+                      30.901973678821218
                     ]
                   },
                   "prior": {
@@ -1094,14 +1094,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": 0.007847550026012905
+                    "value": -0.2170149897037723
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": 0.027844576750958815,
-                    "median": 0.0289335849883565,
-                    "percentile_16th": 0.03339681708459946,
-                    "percentile_84th": 0.021996618862619277
+                    "mean": -0.15481234862162535,
+                    "median": -0.15312161808267444,
+                    "percentile_16th": -0.1457844309500328,
+                    "percentile_84th": -0.16266969416424837
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -1123,14 +1123,14 @@
                   "fixed": false,
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
-                    "value": -0.07103672300452858
+                    "value": -0.10915353011463692
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
-                    "mean": -0.05878851129661986,
-                    "median": -0.0591168234995821,
-                    "percentile_16th": -0.06408194133974537,
-                    "percentile_84th": -0.052970167845146084
+                    "mean": -0.12085648712635493,
+                    "median": -0.12174024168748655,
+                    "percentile_16th": -0.1293687354754372,
+                    "percentile_84th": -0.11324668938487728
                   },
                   "prior": {
                     "py/object": "coolest.template.classes.probabilities.Prior",
@@ -1161,22 +1161,22 @@
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
                     "value": [
-                      0.7709158326830448
+                      -0.22823014668079958
                     ]
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
                     "mean": [
-                      0.7065125215878153
+                      -0.20126102596464981
                     ],
                     "median": [
-                      0.7045051147003569
+                      -0.20438681483892235
                     ],
                     "percentile_16th": [
-                      0.7172075255874433
+                      -0.18602025460935503
                     ],
                     "percentile_84th": [
-                      0.6947856437736474
+                      -0.2148702039387553
                     ]
                   },
                   "prior": {
@@ -1200,22 +1200,22 @@
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
                     "value": [
-                      -0.6976306953932367
+                      0.611784770393207
                     ]
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
                     "mean": [
-                      -0.6997585006607466
+                      0.6072202330904442
                     ],
                     "median": [
-                      -0.6988734896832836
+                      0.6090687686142733
                     ],
                     "percentile_16th": [
-                      -0.7080832955985319
+                      0.5960050159769176
                     ],
                     "percentile_84th": [
-                      -0.6896635925586312
+                      0.6175411196040832
                     ]
                   },
                   "prior": {
@@ -1239,22 +1239,22 @@
                   "point_estimate": {
                     "py/object": "coolest.template.classes.parameter.PointEstimate",
                     "value": [
-                      0.028828994280635834
+                      5.844396472584384
                     ]
                   },
                   "posterior_stats": {
                     "py/object": "coolest.template.classes.probabilities.PosteriorStatistics",
                     "mean": [
-                      0.01880928403392135
+                      7.063817983265634
                     ],
                     "median": [
-                      0.017135052262383463
+                      7.330553800291534
                     ],
                     "percentile_16th": [
-                      0.005968817434649664
+                      5.9337939119293095
                     ],
                     "percentile_84th": [
-                      0.032212972598745046
+                      8.015623687574701
                     ]
                   },
                   "prior": {

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -16,18 +16,22 @@ class TestClassCreator(object):
                              'index_lens_light_model_list': [[0]], 'index_point_source_model_list': [[0]],
                              'band_index': 0, 'source_deflection_scaling_list': [1], 'source_redshift_list': [1],
                              'fixed_magnification_list': [True], 'additional_images_list': [False],
-                             'lens_redshift_list': [0.5]}
+                             'lens_redshift_list': [0.5],
+                             'point_source_frame_list': [[0]]}
         self.kwargs_model_2 = {'lens_model_list': ['SIS'], 'source_light_model_list': ['SERSIC'],
                              'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION'],
                              }
         self.kwargs_model_3 = {'lens_model_list': ['SIS'], 'source_light_model_list': ['SERSIC'],
-                             'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION'],
-                             'index_lens_model_list': [[0]], 'index_source_light_model_list': [[0]],
-                             'index_lens_light_model_list': [[0]], 'index_point_source_model_list': [[0]],
+                               'lens_light_model_list': ['SERSIC'], 'point_source_model_list': ['LENSED_POSITION'],
+                               'index_lens_model_list': [[0]], 'index_source_light_model_list': [[0]],
+                               'index_lens_light_model_list': [[0]], 'index_point_source_model_list': [[0]],
+                               'point_source_frame_list': [[0]]
                              }
         self.kwargs_model_4 = {'lens_model_list': ['SIS', 'SIS'], 'lens_redshift_list': [0.3, 0.4], 'multi_plane': True,
                                'observed_convention_index': [0], 'index_lens_model_list': [[0]], 'z_source': 1,
-                               'optical_depth_model_list': ['UNIFORM'], 'index_optical_depth_model_list': [[0]], 'tau0_index_list': [0]}
+                               'optical_depth_model_list': ['UNIFORM'], 'index_optical_depth_model_list': [[0]],
+                               'tau0_index_list': [0],
+                               'point_source_frame_list': [[0]]}
 
 
         self.kwargs_psf = {'psf_type': 'NONE'}

--- a/test/test_Workflow/test_fitting_sequence.py
+++ b/test/test_Workflow/test_fitting_sequence.py
@@ -76,7 +76,8 @@ class TestFittingSequence(object):
                              'lens_light_model_list': lens_light_model_list,
                              'point_source_model_list': point_source_list,
                              'fixed_magnification_list': [False],
-                             'index_lens_model_list': [[0, 1]]
+                             'index_lens_model_list': [[0, 1]],
+                             'point_source_frame_list': [[0]]
                              }
         self.kwargs_numerics = kwargs_numerics
 


### PR DESCRIPTION
Positional constraints on multiple images appearing in different sub-frames (disjoint cutout regions with separate lens models) was not supported. This PR adds this functionality.
It was not straightforward to implement. All tests pass.
Some tests need to be improved