### PR TITLE
Implement cored and truncated nfw profile 

### DIFF
--- a/lenstronomy/Analysis/multi_patch_reconstruction.py
+++ b/lenstronomy/Analysis/multi_patch_reconstruction.py
@@ -82,9 +82,10 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
             # evaluate pixel of zero point with the base coordinate system
             ra0, dec0 = data_class_i.radec_at_xy_0
             x_min, y_min = pixel_grid.map_coord2pix(ra0, dec0)
+            y_min = int(y_min)
+            x_min = int(x_min)
             nx_i, ny_i = data_class_i.num_pixel_axes
             nx, ny = _update_frame_size(nx, ny, x_min, y_min, nx_i, ny_i)
-
             # select minimum in x- and y-axis
             # transform back in RA/DEC and make this the new zero point of the base coordinate system
             ra_at_xy_0_new, dec_at_xy_0_new = pixel_grid.map_pix2coord(np.minimum(x_min, 0), np.minimum(y_min, 0))
@@ -114,6 +115,8 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
                 # evaluate pixel of zero point with the base coordinate system
                 ra0, dec0 = data_class_i.radec_at_xy_0
                 x_min, y_min = self._pixel_grid_joint.map_coord2pix(ra0, dec0)
+                y_min = int(y_min)
+                x_min = int(x_min)
                 nx_i, ny_i = data_class_i.num_pixel_axes
                 image_joint[int(y_min):int(y_min + ny_i), int(x_min):int(x_min + nx_i)] = data_class_i.data
                 model_joint[int(y_min):int(y_min + ny_i), int(x_min):int(x_min + nx_i)] = model
@@ -145,6 +148,8 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
                 # evaluate pixel of zero point with the base coordinate system
                 ra0, dec0 = data_class_i.radec_at_xy_0
                 x_min, y_min = self._pixel_grid_joint.map_coord2pix(ra0, dec0)
+                y_min = int(y_min)
+                x_min = int(x_min)
                 nx_i, ny_i = data_class_i.num_pixel_axes
                 kappa_joint[int(y_min):int(y_min + ny_i), int(x_min):int(x_min + nx_i)] = kappa
                 magnification_joint[int(y_min):int(y_min + ny_i), int(x_min):int(x_min + nx_i)] = magnification

--- a/lenstronomy/LensModel/Profiles/cnfw.py
+++ b/lenstronomy/LensModel/Profiles/cnfw.py
@@ -145,7 +145,6 @@ class CNFW(LensProfileBase):
         b = r_core * Rs ** -1
         x = R * Rs ** -1
         Fx = self._F(x, b)
-
         return 2 * rho0 * Rs * Fx
 
     def mass_3d(self, R, Rs, rho0, r_core):

--- a/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
+++ b/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
@@ -19,7 +19,7 @@ class TNFWC(LensProfileBase):
 
     When the core radius goes to zero and the truncation radius approaches infinity this profile reduces to an NFW profile
     with the squared term inside the parentheses.
-    
+
     TODO: add the gravitational potential for this profile
     TODO: add analytic solution for 3D mass
     """
@@ -71,7 +71,7 @@ class TNFWC(LensProfileBase):
         R = np.sqrt(x_ ** 2 + y_ ** 2)
         R = np.maximum(R, 0.00000001)
         kappa = self.density_2d(R, 0, Rs, rho0_input, r_core, r_trunc)
-        gamma1, gamma2 = self.nfwGamma(R, Rs, rho0_input, r_core, r_trunc, x_, y_)
+        gamma1, gamma2 = self.nfw_gamma(R, Rs, rho0_input, r_core, r_trunc, x_, y_)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -207,7 +207,7 @@ class TNFWC(LensProfileBase):
         a = 4 * rho0 * Rs * R * gx / x ** 2 / R
         return a * ax_x, a * ax_y
 
-    def nfwGamma(self, R, Rs, rho0, r_core, r_trunc, ax_x, ax_y):
+    def nfw_gamma(self, R, Rs, rho0, r_core, r_trunc, ax_x, ax_y):
         """
 
         shear gamma of NFW profile (times Sigma_crit) along the projection to coordinate 'axis'

--- a/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
+++ b/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
@@ -15,11 +15,11 @@ class TNFWC(LensProfileBase):
     This class contains an pseudo NFW profile with a core radius and a truncation radius. The density in 3D is given by
 
     .. math::
-        \\rho(r) = \\frac{\\rho_0 r_s^\3}{\left(r^2+r_c^2\right)^{1/2} \left(r_s^2+r^2\right)} \left(\frac{r_t^2}{r^2+r_t^2}\right)
+        \\rho(r) = \\frac{\\rho_0 r_s^3}{\\left(r^2+r_c^2\\right)^{1/2} \\left(r_s^2+r^2\\right)} \\left(\\frac{r_t^2}{r^2+r_t^2}\\right)
 
-    For For :math:\\r_c \\rightarrow 0 and :math:\\r_t \\rightarrow \infty this profile reduce to something like an NFW 
-    profile with the squared term in the denominator appearing inside the parenthesis, i.e. .. math:: \\left(1 + r^2/r_s^2)\right)
-
+    When the core radius goes to zero and the truncation radius approaches infinity this profile reduces to an NFW profile
+    with the squared term inside the parentheses.
+    
     TODO: add the gravitational potential for this profile
     TODO: add analytic solution for 3D mass
     """

--- a/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
+++ b/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
@@ -8,6 +8,7 @@ from scipy.integrate import quad
 
 __all__ = ['TNFWC']
 
+
 class TNFWC(LensProfileBase):
     """
 
@@ -16,8 +17,13 @@ class TNFWC(LensProfileBase):
     .. math::
         \\rho(r) = \\frac{\\rho_0 r_s^\3}{\left(r^2+r_c^2\right)^{1/2} \left(r_s^2+r^2\right)} \left(\frac{r_t^2}{r^2+r_t^2}\right)
 
-    For r_c -> 0 and r_t -> infinity, this profile reduce to something like an NFW profile with the squared term in
-    the denominator appearing inside the parenthesis (i.e. (1 + r^2/r_s^2) instead of (1 + r/r_s)^2).
+    For
+    .. math::
+        \r_c \rightarrow 0
+        r_t -> infinity
+    this profile reduce to something like an NFW profile with the squared term in the denominator appearing inside the
+    parenthesis, i.e. .. math::
+        \\left(1 + r^2/r_s^2)\right)
 
     TODO: implement the gravitational potential for this profile
     TODO: implement analytic solution for 3D mass
@@ -48,7 +54,7 @@ class TNFWC(LensProfileBase):
         x_ = x - center_x
         y_ = y - center_y
         R = np.sqrt(x_ ** 2 + y_ ** 2)
-        f_x, f_y = self.nfwAlpha(R, Rs, rho0_input, r_core, r_trunc, x_, y_)
+        f_x, f_y = self.nfw_alpha(R, Rs, rho0_input, r_core, r_trunc, x_, y_)
         return f_x, f_y
 
     def hessian(self, x, y, Rs, alpha_Rs, r_core, r_trunc, center_x=0, center_y=0):
@@ -184,10 +190,10 @@ class TNFWC(LensProfileBase):
         m_2d = 4 * rho0 * Rs * R ** 2 * gx / x ** 2 * np.pi
         return m_2d
 
-    def nfwAlpha(self, R, Rs, rho0, r_core, r_trunc, ax_x, ax_y):
+    def nfw_alpha(self, R, Rs, rho0, r_core, r_trunc, ax_x, ax_y):
         """
 
-        deflection angel of NFW profile (times Sigma_crit D_OL) along the projection to coordinate 'axis'
+        deflection angle of the profile (times Sigma_crit D_OL) along the projection to coordinate 'axis'
 
         :param R: 3d radius
         :param Rs: scale radius
@@ -234,8 +240,8 @@ class TNFWC(LensProfileBase):
 
         :param X: R/Rs
         :type X: float >0
-        :param r_core: core radius [arcsec]
-        :param r_trunc: truncation radius [arcsec]
+        :param b: core radius divided by the scale radius
+        :param t: truncation radius divided by the scale radius
         :return: solution to the projection integral
         """
         prefactor = t ** 2 / (t ** 2 - 1)
@@ -247,8 +253,8 @@ class TNFWC(LensProfileBase):
 
         :param X: R/Rs
         :type X: float >0
-        :param r_core: core radius [arcsec]
-        :param r_trunc: truncation radius [arcsec]
+        :param b: core radius divided by the scale radius
+        :param t: truncation radius divided by the scale radius
         :return: solution of the integral over projected mass
         """
         if b == t:
@@ -260,8 +266,8 @@ class TNFWC(LensProfileBase):
     def _u1(x, b, t):
         """
         :param x: R/Rs
-        :param b: r_core/Rs
-        :param t: r_trunc/Rs
+        :param b: core radius divided by the scale radius
+        :param t: truncation radius divided by the scale radius
 
         """
         t2x2 = t ** 2 + x ** 2
@@ -278,8 +284,8 @@ class TNFWC(LensProfileBase):
     def _u2(self, x, b, t):
         """
         :param x: R/Rs
-        :param b: r_core/Rs
-        :param t: r_trunc/Rs
+        :param b: core radius divided by the scale radius
+        :param t: truncation radius divided by the scale radius
 
         """
         return (t ** 2 + x ** 2) * self._u1(x, b, t)
@@ -313,4 +319,4 @@ class TNFWC(LensProfileBase):
         :param r_trunc: truncation radius [arcsec]
         :return: deflection angle at RS
         """
-        return self.nfwAlpha(Rs, Rs, rho0, r_core, r_trunc, Rs, 0.0)[0]
+        return self.nfw_alpha(Rs, Rs, rho0, r_core, r_trunc, Rs, 0.0)[0]

--- a/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
+++ b/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
@@ -1,0 +1,316 @@
+__author__ = 'dgilman'
+
+# this file contains a class to compute lensing proprerties of a pseudo Navaro-Frenk-White profile with a core and truncation
+# radius
+import numpy as np
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from scipy.integrate import quad
+
+__all__ = ['TNFWC']
+
+class TNFWC(LensProfileBase):
+    """
+
+    This class contains an pseudo NFW profile with a core radius and a truncation radius. The density in 3D is given by
+
+    .. math::
+        \\rho(r) = \\frac{\\rho_0 r_s^\3}{\left(r^2+r_c^2\right)^{1/2} \left(r_s^2+r^2\right)} \left(\frac{r_t^2}{r^2+r_t^2}\right)
+
+    For r_c -> 0 and r_t -> infinity, this profile reduce to something like an NFW profile with the squared term in
+    the denominator appearing inside the parenthesis (i.e. (1 + r^2/r_s^2) instead of (1 + r/r_s)^2).
+
+    TODO: implement the gravitational potential for this profile
+    TODO: implement analytic solution for 3D mass
+    """
+    profile_name = 'TNFWC'
+    param_names = ['Rs', 'alpha_Rs', 'center_x', 'center_y', 'r_trunc', 'r_core']
+    lower_limit_default = {'Rs': 0, 'alpha_Rs': 0, 'center_x': -100, 'center_y': -100, 'r_trunc': 0.001,
+                           'r_core': 0.00001}
+    upper_limit_default = {'Rs': 100, 'alpha_Rs': 10, 'center_x': 100, 'center_y': 100, 'r_trunc': 1000.0,
+                           'r_core': 1000.0}
+
+    def derivatives(self, x, y, Rs, alpha_Rs, r_core, r_trunc, center_x=0, center_y=0):
+        """
+        returns df/dx and df/dy of the function which are the deflection angles
+
+        :param x: angular position (normally in units of arc seconds)
+        :param y: angular position (normally in units of arc seconds)
+        :param Rs: turn over point in the slope of the NFW profile in angular unit
+        :param alpha_Rs: deflection (angular units) at projected Rs
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :param center_x: center of halo (in angular units)
+        :param center_y: center of halo (in angular units)
+        :return: deflection angle in x, deflection angle in y
+        """
+        rho0_input = self.alpha2rho0(alpha_Rs, Rs, r_core, r_trunc)
+        Rs = np.maximum(Rs, 0.00000001)
+        x_ = x - center_x
+        y_ = y - center_y
+        R = np.sqrt(x_ ** 2 + y_ ** 2)
+        f_x, f_y = self.nfwAlpha(R, Rs, rho0_input, r_core, r_trunc, x_, y_)
+        return f_x, f_y
+
+    def hessian(self, x, y, Rs, alpha_Rs, r_core, r_trunc, center_x=0, center_y=0):
+        """
+
+        :param x: angular position (normally in units of arc seconds)
+        :param y: angular position (normally in units of arc seconds)
+        :param Rs: turn over point in the slope of the NFW profile in angular unit
+        :param alpha_Rs: deflection (angular units) at projected Rs
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :param center_x: center of halo (in angular units)
+        :param center_y: center of halo (in angular units)
+        :return: Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx, d^f/dy^2
+        """
+        rho0_input = self.alpha2rho0(alpha_Rs, Rs, r_core, r_trunc)
+        x_ = x - center_x
+        y_ = y - center_y
+        R = np.sqrt(x_ ** 2 + y_ ** 2)
+        R = np.maximum(R, 0.00000001)
+        kappa = self.density_2d(R, 0, Rs, rho0_input, r_core, r_trunc)
+        gamma1, gamma2 = self.nfwGamma(R, Rs, rho0_input, r_core, r_trunc, x_, y_)
+        f_xx = kappa + gamma1
+        f_yy = kappa - gamma1
+        f_xy = gamma2
+        return f_xx, f_xy, f_xy, f_yy
+
+    @staticmethod
+    def density(R, Rs, rho0, r_core, r_trunc):
+        """
+        3D density profile
+
+        :param R: radius of interest
+        :type Rs: scale radius
+        :param rho0: central density normalization
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: rho(R) density
+        """
+        x = R / Rs
+        beta = r_core / Rs
+        tau = r_trunc / Rs
+        denom_core = (beta ** 2 + x ** 2) ** 0.5
+        denom_nfw = (1 + x ** 2)
+        denom_trunc = (x ** 2 + tau ** 2) / tau ** 2
+        denom = denom_core * denom_nfw * denom_trunc
+        return rho0 / denom
+
+    def density_lens(self, r, Rs, alpha_Rs, r_core, r_trunc):
+        """
+        computes the density at 3d radius r given lens model parameterization.
+        The integral in the LOS projection of this quantity results in the convergence quantity.
+
+        :param r: 3d radios
+        :param Rs: scale radius
+        :param alpha_Rs: deflection at Rs
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: density rho(r)
+        """
+        rho0 = self.alpha2rho0(alpha_Rs, Rs, r_core, r_trunc)
+        return self.density(r, Rs, rho0, r_core, r_trunc)
+
+    def density_2d(self, x, y, Rs, rho0, r_core, r_trunc, center_x=0, center_y=0):
+        """
+        2D (projected) density profile
+
+        :param x: angular position (normally in units of arc seconds)
+        :param y: angular position (normally in units of arc seconds)
+        :param Rs: turn over point in the slope of the NFW profile in angular unit
+        :param rho0: density normalization at Rs
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :param center_x: profile center (same units as x)
+        :param center_y: profile center (same units as x)
+        :return: Epsilon(R) projected density at radius R
+        """
+        x_ = x - center_x
+        y_ = y - center_y
+        R = np.sqrt(x_ ** 2 + y_ ** 2)
+        x = R / Rs
+        beta = r_core / Rs
+        tau = r_trunc / Rs
+        Fx = self._f(x, beta, tau)
+        return 2 * rho0 * Rs * Fx
+
+    def mass_3d(self, r, Rs, rho0, r_core, r_trunc):
+        """
+        mass enclosed a 3d sphere or radius r
+
+        :param r: 3d radius
+        :param Rs: scale radius
+        :param rho0: density normalization
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: M(<r)
+        """
+        integrand = lambda x: x ** 2 * self.density(x, Rs, rho0, r_core, r_trunc)
+        return 4 * np.pi * quad(integrand, 0, r)[0]
+
+    def mass_3d_lens(self, r, Rs, alpha_Rs, r_core, r_trunc):
+        """
+        mass enclosed a 3d sphere or radius r.
+        This function takes as input the lensing parameterization.
+
+        :param r: 3d radius
+        :param Rs: scale radius
+        :param alpha_Rs: deflection angle at Rs
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: M(<r)
+        """
+        rho0 = self.alpha2rho0(alpha_Rs, Rs, r_core, r_trunc)
+        m_3d = self.mass_3d(r, Rs, rho0, r_core, r_trunc)
+        return m_3d
+
+    def mass_2d(self, R, Rs, rho0, r_core, r_trunc):
+        """
+        mass enclosed a 2d cylinder or projected radius R
+
+        :param R: 3d radius
+        :param Rs: scale radius
+        :param rho0: central density normalization
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: mass in cylinder
+        """
+        R = np.maximum(R, 0.00000001)
+        x = R / Rs
+        beta = r_core / Rs
+        tau = r_trunc / Rs
+        gx = self._g(x, beta, tau)
+        m_2d = 4 * rho0 * Rs * R ** 2 * gx / x ** 2 * np.pi
+        return m_2d
+
+    def nfwAlpha(self, R, Rs, rho0, r_core, r_trunc, ax_x, ax_y):
+        """
+
+        deflection angel of NFW profile (times Sigma_crit D_OL) along the projection to coordinate 'axis'
+
+        :param R: 3d radius
+        :param Rs: scale radius
+        :param rho0: central density normalization
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :param ax_x: x coordinate relative to center
+        :param ax_y: y coordinate relative to center
+        :return: Epsilon(R) projected density at radius R
+        """
+        R = np.maximum(R, 0.00000001)
+        x = R / Rs
+        beta = r_core / Rs
+        tau = r_trunc / Rs
+        gx = self._g(x, beta, tau)
+        a = 4 * rho0 * Rs * R * gx / x ** 2 / R
+        return a * ax_x, a * ax_y
+
+    def nfwGamma(self, R, Rs, rho0, r_core, r_trunc, ax_x, ax_y):
+        """
+
+        shear gamma of NFW profile (times Sigma_crit) along the projection to coordinate 'axis'
+
+        :param R: 3d radius
+        :param Rs: scale radius
+        :param rho0: central density normalization
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :param ax_x: x coordinate relative to center
+        :param ax_y: y coordinate relative to center
+        :return: Epsilon(R) projected density at radius R
+        """
+        R = np.maximum(R, 0.00000001)
+        x = R / Rs
+        beta, tau = r_core / Rs, r_trunc / Rs
+        gx = self._g(x, beta, tau)
+        Fx = self._f(x, beta, tau)
+        a = 2 * rho0 * Rs * (2 * gx / x ** 2 - Fx)  # /x #2*rho0*Rs*(2*gx/x**2 - Fx)*axis/x
+        return a * (ax_y ** 2 - ax_x ** 2) / R ** 2, -a * 2 * (ax_x * ax_y) / R ** 2
+
+    def _f(self, x, b, t):
+        """
+        analytic solution of the projection integral
+
+        :param X: R/Rs
+        :type X: float >0
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: solution to the projection integral
+        """
+        prefactor = t ** 2 / (t ** 2 - 1)
+        return prefactor * (self._u1(x, b, 1.0) - self._u1(x, b, t))
+
+    def _g(self, x, b, t):
+        """
+        analytic solution of integral for NFW profile to compute deflection angle and gamma
+
+        :param X: R/Rs
+        :type X: float >0
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: solution of the integral over projected mass
+        """
+        if b == t:
+            t += 1e-3
+        prefactor = abs(t ** 2 / (t ** 2 - 1))
+        return prefactor * (-self._u2(x, b, t) + self._u2(0.0, b, t) + self._u2(x, b, 1.0) - self._u2(0.0, b, 1.0))
+
+    @staticmethod
+    def _u1(x, b, t):
+        """
+        :param x: R/Rs
+        :param b: r_core/Rs
+        :param t: r_trunc/Rs
+
+        """
+        t2x2 = t ** 2 + x ** 2
+        b2x2 = b ** 2 + x ** 2
+        b2mt2 = b ** 2 - t ** 2
+        if t > b:
+            func = np.arccosh
+            b2mt2 *= -1
+        else:
+            func = np.arccos
+        arg = np.sqrt(t2x2 / b2x2)
+        return func(arg) / np.sqrt(t2x2 * b2mt2)
+
+    def _u2(self, x, b, t):
+        """
+        :param x: R/Rs
+        :param b: r_core/Rs
+        :param t: r_trunc/Rs
+
+        """
+        return (t ** 2 + x ** 2) * self._u1(x, b, t)
+
+    def alpha2rho0(self, alpha_Rs, Rs, r_core, r_trunc):
+
+        """
+        convert angle at Rs into rho0
+
+        :param alpha_Rs: deflection angle at RS
+        :param Rs: scale radius
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: density normalization
+        """
+        # alpha_Rs = 4 * rho0 * Rs * R * gx
+        beta = r_core / Rs
+        tau = r_trunc / Rs
+        gx = self._g(1.0, beta, tau)
+        rho0 = alpha_Rs / (4 * Rs ** 2 * gx)
+        return rho0
+
+    def rho02alpha(self, rho0, Rs, r_core, r_trunc):
+
+        """
+        convert rho0 to angle at Rs
+
+        :param rho0: density normalization
+        :param Rs: scale radius
+        :param r_core: core radius [arcsec]
+        :param r_trunc: truncation radius [arcsec]
+        :return: deflection angle at RS
+        """
+        return self.nfwAlpha(Rs, Rs, rho0, r_core, r_trunc, Rs, 0.0)[0]

--- a/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
+++ b/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
@@ -17,16 +17,11 @@ class TNFWC(LensProfileBase):
     .. math::
         \\rho(r) = \\frac{\\rho_0 r_s^\3}{\left(r^2+r_c^2\right)^{1/2} \left(r_s^2+r^2\right)} \left(\frac{r_t^2}{r^2+r_t^2}\right)
 
-    For
-    .. math::
-        \r_c \rightarrow 0
-        r_t -> infinity
-    this profile reduce to something like an NFW profile with the squared term in the denominator appearing inside the
-    parenthesis, i.e. .. math::
-        \\left(1 + r^2/r_s^2)\right)
+    For For :math:\\r_c \\rightarrow 0 and :math:\\r_t \\rightarrow \infty this profile reduce to something like an NFW 
+    profile with the squared term in the denominator appearing inside the parenthesis, i.e. .. math:: \\left(1 + r^2/r_s^2)\right)
 
-    TODO: implement the gravitational potential for this profile
-    TODO: implement analytic solution for 3D mass
+    TODO: add the gravitational potential for this profile
+    TODO: add analytic solution for 3D mass
     """
     profile_name = 'TNFWC'
     param_names = ['Rs', 'alpha_Rs', 'center_x', 'center_y', 'r_trunc', 'r_core']

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -18,7 +18,7 @@ _SUPPORTED_MODELS = ['SHIFT', 'NIE_POTENTIAL', 'CONST_MAG', 'SHEAR', 'SHEAR_GAMM
                      'CORED_DENSITY', 'CORED_DENSITY_2', 'CORED_DENSITY_MST', 'CORED_DENSITY_2_MST', 'CORED_DENSITY_EXP',
                      'CORED_DENSITY_EXP_MST', 'TABULATED_DEFLECTIONS', 'MULTIPOLE', 'HESSIAN', 'ElliSLICE', 'ULDM','CORED_DENSITY_ULDM_MST',
                      'LOS', 'LOS_MINIMAL' , 'SYNTHESIS',
-                     'GNFW','CSE']
+                     'GNFW','CSE', 'TNFWC']
 
 
 class ProfileListBase(object):
@@ -330,6 +330,9 @@ class ProfileListBase(object):
         elif lens_type == 'SYNTHESIS':
             from lenstronomy.LensModel.Profiles.synthesis import SynthesisProfile
             return SynthesisProfile(**kwargs_synthesis)
+        elif lens_type == 'TNFWC':
+            from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC
+            return TNFWC()
         else:
             raise ValueError('%s is not a valid lens model. Supported are: %s.' % (lens_type, _SUPPORTED_MODELS))
 

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -257,18 +257,21 @@ class ModelBandPlot(ModelBand):
             plot_util.text_description(ax, self._frame_size, text=text,
                                        color="k", backgroundcolor='w', flipped=False,
                                        font_size=font_size)
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes("right", size="5%", pad=0.05)
-        cb = plt.colorbar(im, cax=cax)
-        cb.set_label(colorbar_label, fontsize=font_size)
-        ra_image, dec_image = self._bandmodel.PointSource.image_position(self._kwargs_ps_partial,
-                                                                         self._kwargs_lens_partial)
-        plot_util.image_position_plot(ax, self._coords, ra_image, dec_image, color='k', image_name_list=image_name_list)
 
         if with_critical_curves is True:
             ra_crit_list, dec_crit_list = self._critical_curves()
             plot_util.plot_line_set(ax, self._coords, ra_crit_list, dec_crit_list, color=crit_curve_color,
                                     points_only=self._caustic_points_only)
+
+        ra_image, dec_image = self._bandmodel.PointSource.image_position(self._kwargs_ps_partial,
+                                                                         self._kwargs_lens_partial)
+        plot_util.image_position_plot(ax, self._coords, ra_image, dec_image, color='k', image_name_list=image_name_list,
+                                      plot_out_of_image=False)
+
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="5%", pad=0.05)
+        cb = plt.colorbar(im, cax=cax)
+        cb.set_label(colorbar_label, fontsize=font_size)
 
         return ax
 

--- a/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
+++ b/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
@@ -58,5 +58,16 @@ class TestTNFWC(object):
         m2 = self.tnfwc.mass_3d_lens(2.0, **kwargs_lens)
         npt.assert_almost_equal(m1, m2)
 
+    def test_g(self):
+        x = 1.2
+        b = 1.5
+        t = 1.5
+        out1 = self.tnfwc._g(x, b, t)
+        b = 1.5001
+        out2 = self.tnfwc._g(x, b, t)
+        out3 = self.tnfwc._g(x, b, t+0.001)
+        npt.assert_almost_equal(out1, out2, 4)
+        npt.assert_almost_equal(out1, out3, 4)
+
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
+++ b/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
@@ -1,0 +1,53 @@
+__author__ = 'dgilman'
+
+import unittest
+from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC
+from lenstronomy.LensModel.Profiles.general_nfw import GNFW
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestTNFWC(object):
+
+    def setup_method(self):
+        self.tnfwc = TNFWC()
+        self.gnfw = GNFW()
+
+    def test_alphaRs(self):
+
+        kwargs_lens = {'alpha_Rs': 2.1, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0, 'center_x': 0.04, 'center_y': -1.0}
+        alpha_rs = self.tnfwc.derivatives(kwargs_lens['Rs'], 0.0, kwargs_lens['Rs'], kwargs_lens['alpha_Rs'],
+                                         kwargs_lens['r_core'], kwargs_lens['r_trunc'])[0]
+        npt.assert_almost_equal(alpha_rs, kwargs_lens['alpha_Rs'], 8)
+
+    def test_alphaRs_rho0_conversion(self):
+
+        kwargs_lens = {'alpha_Rs': 2.1, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0, 'center_x': 0.04, 'center_y': -1.0}
+        rho0 = self.tnfwc.alpha2rho0(kwargs_lens['alpha_Rs'], kwargs_lens['Rs'],
+                                    kwargs_lens['r_core'], kwargs_lens['r_trunc'])
+        alpha_Rs = self.tnfwc.rho02alpha(rho0, kwargs_lens['Rs'], kwargs_lens['r_core'],
+                                        kwargs_lens['r_trunc'])
+        npt.assert_almost_equal(alpha_Rs, kwargs_lens['alpha_Rs'], 5)
+
+    def test_gnfw_match(self):
+
+        # profile reduces to GNFW with gamma_inner = 1.0, gamma_outer = 3.0 when core -> 0 and truncation -> inf
+        alpha_Rs = 2.5
+        Rs = 1.5
+        R = np.logspace(-1, 1, 100) * Rs
+        r_core = 0.001 * Rs
+        r_trunc = 1000 * Rs
+
+        alpha_tnfwc = self.tnfwc.derivatives(R, 0.0, Rs, alpha_Rs, r_core, r_trunc)
+        alpha_gnfw = self.gnfw.derivatives(R, 0.0, Rs, alpha_Rs, 1.0, 3.0)
+        npt.assert_almost_equal(alpha_gnfw, alpha_tnfwc, 3.0)
+
+        rho0 = self.tnfwc.alpha2rho0(alpha_Rs, Rs, r_core, r_trunc)
+        density_2d_tnfwc = self.tnfwc.density_2d(R, 0.0, Rs, rho0, r_core, r_trunc)
+        rho0 = self.gnfw.alpha2rho0(alpha_Rs, Rs, 1.0, 3.0)
+        density_2d_gnfw = self.gnfw.density_2d(R, 0.0, Rs, rho0, 1.0, 3.0)
+        npt.assert_almost_equal(density_2d_tnfwc, density_2d_gnfw, 3.)
+
+if __name__ == '__main__':
+    pytest.main()

--- a/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
+++ b/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
@@ -49,19 +49,14 @@ class TestTNFWC(object):
         density_2d_gnfw = self.gnfw.density_2d(R, 0.0, Rs, rho0, 1.0, 3.0)
         npt.assert_almost_equal(density_2d_tnfwc, density_2d_gnfw, 3.)
 
-    def test_mass(self):
+    def test_mass3d(self):
 
-        kwargs_lens = {'alpha_Rs': 2.1, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0, 'center_x': 0.04, 'center_y': -1.0}
+        kwargs_lens = {'alpha_Rs': 2.1, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0}
         rho0 = self.tnfwc.alpha2rho0(kwargs_lens['alpha_Rs'], kwargs_lens['Rs'], kwargs_lens['r_core'], kwargs_lens['r_trunc'])
-        kwargs_lens_rho0 = {'rho0': rho0, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0, 'center_x': 0.04, 'center_y': -1.0}
+        kwargs_lens_rho0 = {'rho0': rho0, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0}
         m1 = self.tnfwc.mass_3d(2.0, **kwargs_lens_rho0)
         m2 = self.tnfwc.mass_3d_lens(2.0, **kwargs_lens)
         npt.assert_almost_equal(m1, m2)
-
-        m1 = self.tnfwc.mass_2d(2.0, **kwargs_lens_rho0)
-        m2 = self.tnfwc.mass_2d_lens(2.0, **kwargs_lens)
-        npt.assert_almost_equal(m1, m2)
-
 
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
+++ b/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
@@ -49,5 +49,19 @@ class TestTNFWC(object):
         density_2d_gnfw = self.gnfw.density_2d(R, 0.0, Rs, rho0, 1.0, 3.0)
         npt.assert_almost_equal(density_2d_tnfwc, density_2d_gnfw, 3.)
 
+    def test_mass(self):
+
+        kwargs_lens = {'alpha_Rs': 2.1, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0, 'center_x': 0.04, 'center_y': -1.0}
+        rho0 = self.tnfwc.alpha2rho0(kwargs_lens['alpha_Rs'], kwargs_lens['Rs'], kwargs_lens['r_core'], kwargs_lens['r_trunc'])
+        kwargs_lens_rho0 = {'rho0': rho0, 'Rs': 1.5, 'r_core': 1.2, 'r_trunc': 3.0, 'center_x': 0.04, 'center_y': -1.0}
+        m1 = self.tnfwc.mass_3d(2.0, **kwargs_lens_rho0)
+        m2 = self.tnfwc.mass_3d_lens(2.0, **kwargs_lens)
+        npt.assert_almost_equal(m1, m2)
+
+        m1 = self.tnfwc.mass_2d(2.0, **kwargs_lens_rho0)
+        m2 = self.tnfwc.mass_2d_lens(2.0, **kwargs_lens)
+        npt.assert_almost_equal(m1, m2)
+
+
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_LensModel/test_convergence_integrals.py
+++ b/test/test_LensModel/test_convergence_integrals.py
@@ -145,5 +145,31 @@ class TestConvergenceIntegrals(object):
         x1, y1 = 500, 550
         npt.assert_almost_equal(f_x[x1, y1], f_x_num[x1, y1], decimal=2)
 
+    def test_tnfwc(self):
+
+        from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC
+        tnfwc = TNFWC()
+        deltaPix = 0.005
+        numPix = 2000
+        x_grid, y_grid = util.make_grid(numPix=numPix, deltapix=deltaPix)
+
+        kwargs_lens = {'alpha_Rs': 1.2, 'Rs': 0.8, 'r_trunc': 3.5, 'r_core': 0.45}
+        f_xx, _, _, f_yy = tnfwc.hessian(x_grid, y_grid, **kwargs_lens)
+        f_x, f_y = tnfwc.derivatives(x_grid, y_grid, **kwargs_lens)
+        f_x = util.array2image(f_x)
+        kappa = util.array2image((f_xx + f_yy) / 2.)
+        f_x_num, f_y_num = convergence_integrals.deflection_from_kappa_grid(kappa, deltaPix)
+        x1, y1 = 500, 550
+        npt.assert_almost_equal(f_x[x1, y1], f_x_num[x1, y1], decimal=2)
+
+        kwargs_lens = {'alpha_Rs': 1.2, 'Rs': 0.8, 'r_trunc': 300.5, 'r_core': 0.45}
+        f_xx, _, _, f_yy = tnfwc.hessian(x_grid, y_grid, **kwargs_lens)
+        f_x, f_y = tnfwc.derivatives(x_grid, y_grid, **kwargs_lens)
+        f_x = util.array2image(f_x)
+        kappa = util.array2image((f_xx + f_yy) / 2.)
+        f_x_num, f_y_num = convergence_integrals.deflection_from_kappa_grid(kappa, deltaPix)
+        x1, y1 = 500, 550
+        npt.assert_almost_equal(f_x[x1, y1], f_x_num[x1, y1], decimal=2)
+
 if __name__ == '__main__':
     pytest.main()

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -486,5 +486,28 @@ class TestNumericsProfile(object):
         lens_model = ['HERNQUIST_ELLIPSE_CSE']
         self.assert_differentials(lens_model, kwargs, potential=True)
 
+    def test_TNFWC(self):
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 0.1, 'r_trunc': 200.0}
+        lens_model = ['TNFWC']
+        self.assert_differentials(lens_model, kwargs, potential=False)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 0.1, 'r_trunc': 5.0}
+        lens_model = ['TNFWC']
+        self.assert_differentials(lens_model, kwargs, potential=False)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 0.9, 'r_trunc': 5.0}
+        lens_model = ['TNFWC']
+        self.assert_differentials(lens_model, kwargs, potential=False)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 2.1, 'r_trunc': 5.0}
+        lens_model = ['TNFWC']
+        self.assert_differentials(lens_model, kwargs, potential=False)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 12.1, 'r_trunc': 5.0}
+        lens_model = ['TNFWC']
+        self.assert_differentials(lens_model, kwargs, potential=False)
+
+
 if __name__ == '__main__':
     pytest.main("-k TestLensModel")

--- a/test/test_LensModel/test_profile_integrals.py
+++ b/test/test_LensModel/test_profile_integrals.py
@@ -386,6 +386,23 @@ class TestNumerics(object):
         kwargs = {'alpha_Rs': 0.7, 'Rs': 0.3, 'gamma_inner': 0.5, 'gamma_outer': 2.6}
         self.assert_lens_integrals(Model, kwargs)
 
+    def test_tnfwc(self):
+
+        from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC as Model
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 0.1, 'r_trunc': 200.0}
+        self.assert_lens_integrals(Model, kwargs)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 2.0, 'r_core': 1.1, 'r_trunc': 100.0}
+        self.assert_lens_integrals(Model, kwargs)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 0.5, 'r_core': 0.1, 'r_trunc': 3.0}
+        self.assert_lens_integrals(Model, kwargs)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 0.5, 'r_core': 0.4, 'r_trunc': 3.0}
+        self.assert_lens_integrals(Model, kwargs)
+
+        kwargs = {'alpha_Rs': 4.0, 'Rs': 0.5, 'r_core': 0.9, 'r_trunc': 3.0}
+        self.assert_lens_integrals(Model, kwargs)
 
     """
     def test_sis(self):

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -81,6 +81,12 @@ class TestOutputPlots(object):
         data_class.update_data(image_sim)
         self.kwargs_data['image_data'] = image_sim
         self.kwargs_model = {'lens_model_list': lens_model_list,
+                                        'source_light_model_list': source_model_list,
+                                        'lens_light_model_list': lens_light_model_list,
+                                        'point_source_model_list': point_source_list,
+                                        'fixed_magnification_list': [False],
+                                        }
+        self.kwargs_model_multiplane = {'lens_model_list': lens_model_list,
                              'lens_redshift_list': [0.5, 0.5],
                              'multi_plane': True,
                              'z_source': 2.0,
@@ -97,6 +103,11 @@ class TestOutputPlots(object):
     def test_lensModelPlot(self):
         multi_band_list = [[self.kwargs_data, self.kwargs_psf, self.kwargs_numerics]]
         lensPlot = ModelPlot(multi_band_list, self.kwargs_model, self.kwargs_params, arrow_size=0.02, cmap_string="gist_heat",
+                             multi_band_type='single-band')
+
+        multi_band_list_multiplane = [[self.kwargs_data, self.kwargs_psf, self.kwargs_numerics]]
+        lensPlot_multiplane = ModelPlot(multi_band_list_multiplane, self.kwargs_model_multiplane, self.kwargs_params, arrow_size=0.02,
+                             cmap_string="gist_heat",
                              multi_band_type='single-band')
 
         lensPlot.plot_main(with_caustics=True)
@@ -139,9 +150,15 @@ class TestOutputPlots(object):
         kwargs_plot = {'index_macromodel': [0]}
         lensPlot.substructure_plot(ax=ax, **kwargs_plot)
         plt.close()
+
         f, ax = plt.subplots(1, 1, figsize=(4, 4))
         kwargs_plot = {'index_macromodel': [0], 'with_critical_curves': True}
         lensPlot.substructure_plot(ax=ax, **kwargs_plot)
+        plt.close()
+
+        f, ax = plt.subplots(1, 1, figsize=(4, 4))
+        kwargs_plot = {'index_macromodel': [0], 'with_critical_curves': True}
+        lensPlot_multiplane.substructure_plot(ax=ax, **kwargs_plot)
         plt.close()
 
     def test_source_plot(self):


### PR DESCRIPTION
I add an NFW-like mass profile with a core radius and a truncation radius. I got analytic expressions for the projected mass and the integral of the projected mass by moving the square inside the parenthesis in the denominator, i.e. (1+x^2) instead of (1+x)^2. The core is implemented through a term (r_c^2 + r^2)^1/2, and the profile drops like 1/r^5 outside the truncation radius. 