### PR TITLE
Implementation of `hessian_z1z2` in `LensModel.lens_model`

### DIFF
--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -516,3 +516,29 @@ class LensModel(object):
         f_yy = (alpha_dec_pp - alpha_dec_pn + alpha_dec_np - alpha_dec_nn) / diff / 2
 
         return f_xx, f_xy, f_yx, f_yy
+
+    def hessian_z1z2(self, z1, z2, theta_x, theta_y, kwargs_lens, diff=0.00000001):
+        """Computes Hessian matrix when Observed at z1 with rays going to z2 with z1 <
+        z2 for multi_plane.
+
+        :param z1: Observer redshift
+        :param z2: source redshift
+        :param theta_x: angular position and direction of the ray
+        :param theta_y: angular position and direction of the ray
+        :param kwargs_lens: list of keyword arguments of lens model parameters matching
+            the lens model classes
+        :param diff: numerical differential step (float)
+        :return: f_xx, f_xy, f_yx, f_yy
+        """
+        if diff is None:
+            raise ValueError(
+                "diff needs to be set to compute the numerical differential"
+            )
+        if self.multi_plane is False:
+            raise ValueError("Hessian z1z2 need to be compute in multi-plane mode")
+        if z1 >= z2:
+            raise ValueError("z1 needs to be smaller than z2")
+
+        f_xx, f_xy, f_yx, f_yy = self.lens_model.hessian_z1z2(z1, z2, theta_x, theta_y, kwargs_lens, diff=diff)
+
+        return f_xx, f_xy, f_yx, f_yy

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -539,6 +539,8 @@ class LensModel(object):
         if z1 >= z2:
             raise ValueError("z1 needs to be smaller than z2")
 
-        f_xx, f_xy, f_yx, f_yy = self.lens_model.hessian_z1z2(z1, z2, theta_x, theta_y, kwargs_lens, diff=diff)
+        f_xx, f_xy, f_yx, f_yy = self.lens_model.hessian_z1z2(
+            z1, z2, theta_x, theta_y, kwargs_lens, diff=diff
+        )
 
         return f_xx, f_xy, f_yx, f_yy

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -530,10 +530,6 @@ class LensModel(object):
         :param diff: numerical differential step (float)
         :return: f_xx, f_xy, f_yx, f_yy
         """
-        if diff is None:
-            raise ValueError(
-                "diff needs to be set to compute the numerical differential"
-            )
         if self.multi_plane is False:
             raise ValueError("Hessian z1z2 need to be compute in multi-plane mode")
         if z1 >= z2:

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -241,11 +241,7 @@ class TestLensModel(object):
             f_yx_expected,
             f_yy_expected,
         ) = multi_plane.hessian_z1z2(
-            z1=z1,
-            z2=z2,
-            theta_x=theta_x,
-            theta_y=theta_y,
-            kwargs_lens=kwargs_lens
+            z1=z1, z2=z2, theta_x=theta_x, theta_y=theta_y, kwargs_lens=kwargs_lens
         )
         npt.assert_almost_equal(f_xx, f_xx_expected, decimal=5)
         npt.assert_almost_equal(f_xy, f_xy_expected, decimal=5)

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -223,10 +223,9 @@ class TestLensModel(object):
         theta_x, theta_y = np.linspace(start=-1, stop=1, num=10), np.linspace(
             start=-1, stop=1, num=10
         )
-        diff = 0.0000001
 
         f_xx, f_xy, f_yx, f_yy = lensModel.hessian_z1z2(
-            z1, z2, theta_x, theta_y, kwargs_lens, diff=diff
+            z1, z2, theta_x, theta_y, kwargs_lens
         )
         # Use the method in multi_plane.hessian_z1z2 as a comparison
         multi_plane = MultiPlane(
@@ -246,8 +245,7 @@ class TestLensModel(object):
             z2=z2,
             theta_x=theta_x,
             theta_y=theta_y,
-            kwargs_lens=kwargs_lens,
-            diff=diff,
+            kwargs_lens=kwargs_lens
         )
         npt.assert_almost_equal(f_xx, f_xx_expected, decimal=5)
         npt.assert_almost_equal(f_xy, f_xy_expected, decimal=5)
@@ -306,10 +304,6 @@ class TestRaise(unittest.TestCase):
             z_source=2,
         )
         kwargs = [{"theta_E": 1, "center_x": 0, "center_y": 0}]
-
-        # Test when diff is None
-        with self.assertRaises(ValueError):
-            lensModel.hessian_z1z2(0.5, 1.5, 1, 1, kwargs, diff=None)
 
         # Test when the model is not in multi-plane mode
         lensModel_non_multi = LensModel(

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -213,17 +213,21 @@ class TestLensModel(object):
         lens_model_list = ["SIS"]
         kwargs_lens = [{"theta_E": 1}]
         redshift_list = [0.5]
-        lensModel = LensModel(lens_model_list=lens_model_list,
-                              multi_plane=True,
-                              lens_redshift_list=redshift_list,
-                              z_source=z_source)
+        lensModel = LensModel(
+            lens_model_list=lens_model_list,
+            multi_plane=True,
+            lens_redshift_list=redshift_list,
+            z_source=z_source,
+        )
         z1, z2 = 0.5, 1.5
         theta_x, theta_y = np.linspace(start=-1, stop=1, num=10), np.linspace(
             start=-1, stop=1, num=10
         )
         diff = 0.0000001
 
-        f_xx, f_xy, f_yx, f_yy = lensModel.hessian_z1z2(z1, z2, theta_x, theta_y, kwargs_lens, diff=diff)
+        f_xx, f_xy, f_yx, f_yy = lensModel.hessian_z1z2(
+            z1, z2, theta_x, theta_y, kwargs_lens, diff=diff
+        )
         # Use the method in multi_plane.hessian_z1z2 as a comparison
         multi_plane = MultiPlane(
             z_source=1.5,
@@ -232,12 +236,19 @@ class TestLensModel(object):
             z_interp_stop=3,
             cosmo_interp=False,
         )
-        f_xx_expected, f_xy_expected, f_yx_expected, f_yy_expected = multi_plane.hessian_z1z2(z1=z1,
-                                                                                              z2=z2,
-                                                                                              theta_x=theta_x,
-                                                                                              theta_y=theta_y,
-                                                                                              kwargs_lens=kwargs_lens,
-                                                                                              diff=diff)
+        (
+            f_xx_expected,
+            f_xy_expected,
+            f_yx_expected,
+            f_yy_expected,
+        ) = multi_plane.hessian_z1z2(
+            z1=z1,
+            z2=z2,
+            theta_x=theta_x,
+            theta_y=theta_y,
+            kwargs_lens=kwargs_lens,
+            diff=diff,
+        )
         npt.assert_almost_equal(f_xx, f_xx_expected, decimal=5)
         npt.assert_almost_equal(f_xy, f_xy_expected, decimal=5)
         npt.assert_almost_equal(f_yx, f_yx_expected, decimal=5)
@@ -315,6 +326,7 @@ class TestRaise(unittest.TestCase):
             lensModel.hessian_z1z2(1.5, 1.5, 1, 1, kwargs)
         with self.assertRaises(ValueError):
             lensModel.hessian_z1z2(2.0, 1.5, 1, 1, kwargs)
+
 
 if __name__ == "__main__":
     pytest.main("-k TestLensModel")

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from lenstronomy.LensModel.lens_model import LensModel
+from lenstronomy.LensModel.MultiPlane.multi_plane import MultiPlane
 from lenstronomy.LensModel.Profiles.nfw import NFW
 from lenstronomy.Util.util import make_grid
 import unittest
@@ -207,6 +208,41 @@ class TestLensModel(object):
         npt.assert_almost_equal(f_yx_sq, f_yx, decimal=5)
         npt.assert_almost_equal(f_yy_sq, f_yy, decimal=5)
 
+    def test_hessian_z1z2(self):
+        z_source = 1.5
+        lens_model_list = ["SIS"]
+        kwargs_lens = [{"theta_E": 1}]
+        redshift_list = [0.5]
+        lensModel = LensModel(lens_model_list=lens_model_list,
+                              multi_plane=True,
+                              lens_redshift_list=redshift_list,
+                              z_source=z_source)
+        z1, z2 = 0.5, 1.5
+        theta_x, theta_y = np.linspace(start=-1, stop=1, num=10), np.linspace(
+            start=-1, stop=1, num=10
+        )
+        diff = 0.0000001
+
+        f_xx, f_xy, f_yx, f_yy = lensModel.hessian_z1z2(z1, z2, theta_x, theta_y, kwargs_lens, diff=diff)
+        # Use the method in multi_plane.hessian_z1z2 as a comparison
+        multi_plane = MultiPlane(
+            z_source=1.5,
+            lens_model_list=lens_model_list,
+            lens_redshift_list=redshift_list,
+            z_interp_stop=3,
+            cosmo_interp=False,
+        )
+        f_xx_expected, f_xy_expected, f_yx_expected, f_yy_expected = multi_plane.hessian_z1z2(z1=z1,
+                                                                                              z2=z2,
+                                                                                              theta_x=theta_x,
+                                                                                              theta_y=theta_y,
+                                                                                              kwargs_lens=kwargs_lens,
+                                                                                              diff=diff)
+        npt.assert_almost_equal(f_xx, f_xx_expected, decimal=5)
+        npt.assert_almost_equal(f_xy, f_xy_expected, decimal=5)
+        npt.assert_almost_equal(f_yx, f_yx_expected, decimal=5)
+        npt.assert_almost_equal(f_yy, f_yy_expected, decimal=5)
+
 
 class TestRaise(unittest.TestCase):
     def test_raise(self):
@@ -251,6 +287,34 @@ class TestRaise(unittest.TestCase):
                 z_source=1.0,
             )
 
+    def test_hessian_z1z2_raise(self):
+        lensModel = LensModel(
+            lens_model_list=["SIS"],
+            multi_plane=True,
+            lens_redshift_list=[1],
+            z_source=2,
+        )
+        kwargs = [{"theta_E": 1, "center_x": 0, "center_y": 0}]
+
+        # Test when diff is None
+        with self.assertRaises(ValueError):
+            lensModel.hessian_z1z2(0.5, 1.5, 1, 1, kwargs, diff=None)
+
+        # Test when the model is not in multi-plane mode
+        lensModel_non_multi = LensModel(
+            lens_model_list=["SIS"],
+            multi_plane=False,
+            lens_redshift_list=[1],
+            z_source=2,
+        )
+        with self.assertRaises(ValueError):
+            lensModel_non_multi.hessian_z1z2(0.5, 1.5, 1, 1, kwargs)
+
+        # Test when z1 >= z2
+        with self.assertRaises(ValueError):
+            lensModel.hessian_z1z2(1.5, 1.5, 1, 1, kwargs)
+        with self.assertRaises(ValueError):
+            lensModel.hessian_z1z2(2.0, 1.5, 1, 1, kwargs)
 
 if __name__ == "__main__":
     pytest.main("-k TestLensModel")


### PR DESCRIPTION
 **Implementation of `hessian_z1z2` in `LensModel`**
Added a method to handle the Hessian calculation in multi-plane for arbitrary redshifts of the lens and source in `LensModel.lens_model`. This builds upon the core function from `multi_plane.hessian_z1z2`.