### PR TITLE
Debug findOverlap parantheses of image_util.py

### DIFF
--- a/lenstronomy/Util/image_util.py
+++ b/lenstronomy/Util/image_util.py
@@ -179,9 +179,8 @@ def findOverlap(x_mins, y_mins, min_distance):
         else:
             for j in range(0, i):
                 if abs(
-                    x_mins[i] - x_mins[j] < min_distance
-                    and abs(y_mins[i] - y_mins[j]) < min_distance
-                ):
+                    x_mins[i] - x_mins[j]) < min_distance
+                    and abs(y_mins[i] - y_mins[j]) < min_distance :
                     idex.append(i)
                     break
     x_mins = np.delete(x_mins, idex, axis=0)

--- a/lenstronomy/Util/image_util.py
+++ b/lenstronomy/Util/image_util.py
@@ -178,7 +178,10 @@ def findOverlap(x_mins, y_mins, min_distance):
             pass
         else:
             for j in range(0, i):
-                if abs(x_mins[i] - x_mins[j]) < min_distance and abs(y_mins[i] - y_mins[j]) < min_distance :
+                if (
+                    abs(x_mins[i] - x_mins[j]) < min_distance
+                    and abs(y_mins[i] - y_mins[j]) < min_distance
+                ):
                     idex.append(i)
                     break
     x_mins = np.delete(x_mins, idex, axis=0)

--- a/lenstronomy/Util/image_util.py
+++ b/lenstronomy/Util/image_util.py
@@ -178,9 +178,7 @@ def findOverlap(x_mins, y_mins, min_distance):
             pass
         else:
             for j in range(0, i):
-                if abs(
-                    x_mins[i] - x_mins[j]) < min_distance
-                    and abs(y_mins[i] - y_mins[j]) < min_distance :
+                if abs(x_mins[i] - x_mins[j]) < min_distance and abs(y_mins[i] - y_mins[j]) < min_distance :
                     idex.append(i)
                     break
     x_mins = np.delete(x_mins, idex, axis=0)


### PR DESCRIPTION
Previously, the parentheses of abs() in findOverlap was wrongly placed. It is a crucial typo but somehow it wasn't fixed earlier.

For example, with the previous code, if you give 
findOverlap([1, 0, 2, 3], [0, 0, 2, 3], 0.1) 

then the output comes out as (array([1, 2, 3]), array([0, 2, 3])), deleting the second coordinate even though it does not overlap in 0.1 distance.

After correcting the debug, now it works okay.