### PR TITLE
improved plotting of point sources and caustics on top of pixelated images

### DIFF
--- a/lenstronomy/Plots/lens_plot.py
+++ b/lenstronomy/Plots/lens_plot.py
@@ -62,7 +62,7 @@ def lens_model_plot(
     :param fast_caustic: boolean, if True, uses faster but less precise caustic
         calculation (might have troubles for the outer caustic (inner critical curve)
     :param with_convergence: boolean, if True, plots the convergence of the deflector
-    :return:
+    :return: matplotlib axis instance with plot
     """
     kwargs_data = sim_util.data_configure_simple(
         numPix,
@@ -76,9 +76,13 @@ def lens_model_plot(
     _frame_size = numPix * deltaPix
 
     ra0, dec0 = data.radec_at_xy_0
+    # shift half a pixel such that pixel is in the center
+    dec0 -= deltaPix / 2
     if coord_inverse:
+        ra0 += deltaPix / 2
         extent = [ra0, ra0 - _frame_size, dec0, dec0 + _frame_size]
     else:
+        ra0 -= deltaPix / 2
         extent = [ra0, ra0 + _frame_size, dec0, dec0 + _frame_size]
 
     if with_convergence:
@@ -100,7 +104,7 @@ def lens_model_plot(
             kwargs_lens=kwargs_lens,
             fast_caustic=fast_caustic,
             coord_inverse=coord_inverse,
-            pixel_offset=True,
+            pixel_offset=False,
             **kwargs_caustics
         )
     if point_source:
@@ -319,16 +323,16 @@ def point_source_plot(
     if name_list is None:
         name_list = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"]
     for i in range(len(x_image)):
-        x_ = (x_image[i] + 0.5) * delta_pix_x + origin[0]
-        y_ = (y_image[i] + 0.5) * delta_pix + origin[1]
+        x_ = (x_image[i]) * delta_pix_x + origin[0]
+        y_ = (y_image[i]) * delta_pix + origin[1]
         ax.plot(
             x_, y_, "dk", markersize=4 * (1 + np.log(np.abs(mag_images[i]))), alpha=0.5
         )
         ax.text(x_, y_, name_list[i], fontsize=20, color="k")
     x_source, y_source = pixel_grid.map_coord2pix(source_x, source_y)
     ax.plot(
-        (x_source + 0.5) * delta_pix_x + origin[0],
-        (y_source + 0.5) * delta_pix + origin[1],
+        x_source * delta_pix_x + origin[0],
+        y_source * delta_pix + origin[1],
         "*k",
         markersize=10,
     )
@@ -455,7 +459,7 @@ def arrival_time_surface(
         vmin = np.min(fermat_surface)
         vmax = np.max(fermat_surface)
         levels = np.linspace(start=vmin, stop=vmax, num=n_levels)
-        im = ax.contour(
+        _ = ax.contour(
             x_grid,
             y_grid,
             fermat_surface,

--- a/lenstronomy/Plots/lens_plot.py
+++ b/lenstronomy/Plots/lens_plot.py
@@ -104,7 +104,6 @@ def lens_model_plot(
             kwargs_lens=kwargs_lens,
             fast_caustic=fast_caustic,
             coord_inverse=coord_inverse,
-            pixel_offset=False,
             **kwargs_caustics
         )
     if point_source:
@@ -180,7 +179,6 @@ def caustics_plot(
     coord_inverse=False,
     color_crit="r",
     color_caustic="g",
-    pixel_offset=False,
     *args,
     **kwargs
 ):
@@ -196,8 +194,6 @@ def caustics_plot(
      (effectively the RA definition)
     :param color_crit: string, color of critical curve
     :param color_caustic: string, color of caustic curve
-    :param pixel_offset: boolean; if True (default plotting), the coordinates are shifted a half a pixel to match with
-     the matshow() command to center the coordinates in the pixel center
     :param args: argument for plotting curve
     :param kwargs: keyword arguments for plotting curves
     :return: updated matplotlib axis instance
@@ -247,7 +243,6 @@ def caustics_plot(
         origin=origin,
         flipped_x=coord_inverse,
         points_only=points_only,
-        pixel_offset=pixel_offset,
         *args,
         **kwargs
     )
@@ -260,7 +255,6 @@ def caustics_plot(
         origin=origin,
         flipped_x=coord_inverse,
         points_only=points_only,
-        pixel_offset=pixel_offset,
         *args,
         **kwargs
     )

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -78,8 +78,12 @@ class ModelBandPlot(ModelBand):
         self._arrow_size = arrow_size
         self._fast_caustic = fast_caustic
 
-        self._image_extent = [-self._deltaPix/2, self._width_x - self._deltaPix/2,
-                              - self._deltaPix/2, self._width_y - self._deltaPix/2]
+        self._image_extent = [
+            -self._deltaPix / 2,
+            self._width_x - self._deltaPix / 2,
+            -self._deltaPix / 2,
+            self._width_y - self._deltaPix / 2,
+        ]
 
     def _critical_curves(self):
         if not hasattr(self, "_ra_crit_list") or not hasattr(self, "_dec_crit_list"):
@@ -671,8 +675,12 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             source_scale,
             origin="lower",
-            extent=[-deltaPix_source/2, d_s - deltaPix_source/2,
-                    -deltaPix_source/2, d_s - deltaPix_source/2],
+            extent=[
+                -deltaPix_source / 2,
+                d_s - deltaPix_source / 2,
+                -deltaPix_source / 2,
+                d_s - deltaPix_source / 2,
+            ],
             cmap=self._cmap,
             vmin=v_min,
             vmax=v_max,
@@ -795,8 +803,12 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             error_map_source,
             origin="lower",
-            extent=[-deltaPix_source / 2, d_s - deltaPix_source / 2,
-                    -deltaPix_source / 2, d_s - deltaPix_source / 2],
+            extent=[
+                -deltaPix_source / 2,
+                d_s - deltaPix_source / 2,
+                -deltaPix_source / 2,
+                d_s - deltaPix_source / 2,
+            ],
             cmap=self._cmap,
             vmin=v_min,
             vmax=v_max,

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -65,6 +65,7 @@ class ModelBandPlot(ModelBand):
         self._v_min_default = max(np.min(log_model), -5)
         self._v_max_default = min(np.max(log_model), 10)
         self._coords = self._bandmodel.Data
+        self._width_x, self._width_y = self._coords.width
         self._data = self._coords.data
         self._deltaPix = self._coords.pixel_width
         self._frame_size = np.max(self._coords.width)
@@ -76,6 +77,9 @@ class ModelBandPlot(ModelBand):
         self._cmap = plot_util.cmap_conf(cmap_string)
         self._arrow_size = arrow_size
         self._fast_caustic = fast_caustic
+
+        self._image_extent = [-self._deltaPix/2, self._width_x - self._deltaPix/2,
+                              - self._deltaPix/2, self._width_y - self._deltaPix/2]
 
     def _critical_curves(self):
         if not hasattr(self, "_ra_crit_list") or not hasattr(self, "_dec_crit_list"):
@@ -147,7 +151,7 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             np.log10(self._data),
             origin="lower",
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             cmap=self._cmap,
             vmin=v_min,
             vmax=v_max,
@@ -212,7 +216,7 @@ class ModelBandPlot(ModelBand):
             origin="lower",
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             cmap=self._cmap,
         )
         ax.get_xaxis().set_visible(False)
@@ -285,7 +289,7 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             np.log10(kappa_result),
             origin="lower",
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             cmap=kwargs["cmap"],
             vmin=v_min,
             vmax=v_max,
@@ -396,7 +400,7 @@ class ModelBandPlot(ModelBand):
             origin="lower",
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             cmap=cmap,
         )
         ax.get_xaxis().set_visible(False)
@@ -482,7 +486,7 @@ class ModelBandPlot(ModelBand):
             self._norm_residuals,
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             origin="lower",
             **kwargs
         )
@@ -534,7 +538,7 @@ class ModelBandPlot(ModelBand):
             self._model - self._data,
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             cmap="bwr",
             origin="lower",
         )
@@ -667,7 +671,8 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             source_scale,
             origin="lower",
-            extent=[0, d_s, 0, d_s],
+            extent=[-deltaPix_source/2, d_s - deltaPix_source/2,
+                    -deltaPix_source/2, d_s - deltaPix_source/2],
             cmap=self._cmap,
             vmin=v_min,
             vmax=v_max,
@@ -790,7 +795,8 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             error_map_source,
             origin="lower",
-            extent=[0, d_s, 0, d_s],
+            extent=[-deltaPix_source / 2, d_s - deltaPix_source / 2,
+                    -deltaPix_source / 2, d_s - deltaPix_source / 2],
             cmap=self._cmap,
             vmin=v_min,
             vmax=v_max,
@@ -877,7 +883,7 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             mag_result,
             origin="lower",
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             vmin=v_min,
             vmax=v_max,
             **kwargs
@@ -952,7 +958,7 @@ class ModelBandPlot(ModelBand):
         im = ax.matshow(
             alpha,
             origin="lower",
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             vmin=v_min,
             vmax=v_max,
             cmap=self._cmap,
@@ -1063,7 +1069,7 @@ class ModelBandPlot(ModelBand):
             origin="lower",
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             **kwargs
         )
         ax.get_xaxis().set_visible(False)
@@ -1118,7 +1124,7 @@ class ModelBandPlot(ModelBand):
             origin="lower",
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             cmap=self._cmap,
         )
         ax.get_xaxis().set_visible(False)
@@ -1264,7 +1270,7 @@ class ModelBandPlot(ModelBand):
             origin="lower",
             vmin=v_min,
             vmax=v_max,
-            extent=[0, self._frame_size, 0, self._frame_size],
+            extent=self._image_extent,
             **kwargs
         )
         return ax

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -114,7 +114,7 @@ def coordinate_arrows(ax, d, coords, color="w", font_size=15, arrow_size=0.05):
     :param arrow_size: size of arrow
     :return: updated ax instance
     """
-    d0 = d / 6.0 # from right side of plot
+    d0 = d / 6.0  # from right side of plot
     p0 = d / 15.0
     pt = d / 10.0
     deltaPix = coords.pixel_width

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -42,8 +42,8 @@ def sqrt(inputArray, scale_min=None, scale_max=None):
 def text_description(
     ax, d, text, color="w", backgroundcolor="k", flipped=False, font_size=15
 ):
-    c_vertical = 1 / 15.0  # + font_size / d / 10.**2
-    c_horizontal = 1.0 / 30
+    c_vertical = 1 / 13.0  # + font_size / d / 10.**2
+    c_horizontal = 1.0 / 50
     if flipped:
         ax.text(
             d - d * c_horizontal,
@@ -114,9 +114,9 @@ def coordinate_arrows(ax, d, coords, color="w", font_size=15, arrow_size=0.05):
     :param arrow_size: size of arrow
     :return: updated ax instance
     """
-    d0 = d / 8.0
+    d0 = d / 6.0 # from right side of plot
     p0 = d / 15.0
-    pt = d / 9.0
+    pt = d / 10.0
     deltaPix = coords.pixel_width
     ra0, dec0 = coords.map_pix2coord((d - d0) / deltaPix, d0 / deltaPix)
     xx_, yy_ = coords.map_coord2pix(ra0, dec0)
@@ -174,7 +174,6 @@ def plot_line_set(
     origin=None,
     flipped_x=False,
     points_only=False,
-    pixel_offset=True,
     *args,
     **kwargs
 ):
@@ -194,9 +193,6 @@ def plot_line_set(
     :param flipped_x: bool, if True, flips x-axis
     :param points_only: bool, if True, sets plotting keywords to plot single points
         without connecting lines
-    :param pixel_offset: boolean; if True (default plotting), the coordinates are
-        shifted a half a pixel to match with the matshow() command to center the
-        coordinates in the pixel center
     :return: plot with line sets on matplotlib axis in pixel coordinates
     """
     if origin is None:
@@ -212,24 +208,20 @@ def plot_line_set(
             kwargs["markersize"] = 0.01
     if flipped_x:
         pixel_width_x = -pixel_width
-    if pixel_offset is True:
-        shift = 0.5
-    else:
-        shift = 0
     if isinstance(line_set_list_x, list):
         for i in range(len(line_set_list_x)):
             x_c, y_c = coords.map_coord2pix(line_set_list_x[i], line_set_list_y[i])
             ax.plot(
-                (x_c + shift) * pixel_width_x + origin[0],
-                (y_c + shift) * pixel_width + origin[1],
+                x_c * pixel_width_x + origin[0],
+                y_c * pixel_width + origin[1],
                 *args,
                 **kwargs
             )
     else:
         x_c, y_c = coords.map_coord2pix(line_set_list_x, line_set_list_y)
         ax.plot(
-            (x_c + shift) * pixel_width_x + origin[0],
-            (y_c + shift) * pixel_width + origin[1],
+            x_c * pixel_width_x + origin[0],
+            y_c * pixel_width + origin[1],
             *args,
             **kwargs
         )
@@ -246,7 +238,6 @@ def image_position_plot(
     image_name_list=None,
     origin=None,
     flipped_x=False,
-    pixel_offset=True,
     plot_out_of_image=True,
 ):
     """
@@ -259,8 +250,6 @@ def image_position_plot(
     :param image_name_list: list of strings for names of the images in the same order as the positions
     :param origin: [x0, y0], lower left pixel coordinate in the frame of the pixels
     :param flipped_x: bool, if True, flips x-axis
-    :param pixel_offset: boolean; if True (default plotting), the coordinates are shifted a half a pixel to match with
-     the matshow() command to center the coordinates in the pixel center
     :param plot_out_of_image: if True, plots images even appearing out of the Coordinate frame
     :type plot_out_of_image: bool
     :return: matplotlib axis instance with images plotted on
@@ -278,10 +267,6 @@ def image_position_plot(
         ra_image_, dec_image_ = [ra_image], [dec_image]
     else:
         ra_image_, dec_image_ = ra_image, dec_image
-    if pixel_offset is True:
-        shift = 0.5
-    else:
-        shift = 0
     try:
         nx, ny = coords.num_pixel_axes
     except:
@@ -292,8 +277,8 @@ def image_position_plot(
         for i in range(len(x_image)):
             if not plot_out_of_image:
                 if 0 < x_image[i] < nx and 0 < y_image[i] < ny:
-                    x_ = (x_image[i] + shift) * pixel_width_x + origin[0]
-                    y_ = (y_image[i] + shift) * pixel_width + origin[1]
+                    x_ = x_image[i] * pixel_width_x + origin[0]
+                    y_ = y_image[i] * pixel_width + origin[1]
                     ax.plot(x_, y_, "o", color=color)
                     ax.text(x_, y_, image_name_list[i], fontsize=20, color=color)
     return ax
@@ -318,8 +303,8 @@ def source_position_plot(
         for ra, dec in zip(ra_source, dec_source):
             x_source, y_source = coords.map_coord2pix(ra, dec)
             ax.plot(
-                (x_source + 0.5) * delta_pix,
-                (y_source + 0.5) * delta_pix,
+                x_source * delta_pix,
+                y_source + 0.5 * delta_pix,
                 marker=marker,
                 markersize=markersize,
                 **kwargs

--- a/test/test_Plots/test_plot_util.py
+++ b/test/test_Plots/test_plot_util.py
@@ -80,7 +80,6 @@ class TestPlotUtil(object):
             origin=None,
             color="g",
             flipped_x=True,
-            pixel_offset=False,
         )
         plt.close()
 
@@ -93,7 +92,6 @@ class TestPlotUtil(object):
             origin=[1, 1],
             color="g",
             flipped_x=False,
-            pixel_offset=True,
         )
         plt.close()
 
@@ -147,7 +145,6 @@ class TestPlotUtil(object):
             image_name_list=None,
             origin=None,
             flipped_x=False,
-            pixel_offset=False,
         )
         plt.close()
         ax = plot_util.image_position_plot(
@@ -159,7 +156,6 @@ class TestPlotUtil(object):
             image_name_list=["A", "B"],
             origin=[1, 1],
             flipped_x=True,
-            pixel_offset=True,
         )
         plt.close()
 


### PR DESCRIPTION
this PR improves how point sources are plotted onto pixelated data (i.e. images). Instead of shifting the point source coordinates by 1/2 pixel, the coordinate system gets changed by -1/2 pixel (such that the pixel center is the one equivalent to the coordinate, and not the pixel edge)