### PR TITLE
Use codecov for coverage report

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pytest
-          python -m pip install flake8 pytest pytest-cov coveralls
+          python -m pip install flake8 pytest pytest-cov
+          python -m pip install codecov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f test_requirements.txt ]; then pip install -r test_requirements.txt; fi
           python -m pip install .
@@ -38,13 +39,21 @@ jobs:
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest --cov=lenstronomy
+          pytest --cov=./ --cov-report=xml
+          codecov
 
-      - name: Coveralls
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          coveralls --service=github
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage.xml
+
+#      - name: Coveralls
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          coveralls --service=github
 
       # from this source for coveralls: https://github.com/marketplace/actions/coveralls-github-action
       #- uses: actions/checkout@v1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:                  # this is a top-level key
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]


### PR DESCRIPTION
This PR replaces `coveralls` with `codecov` for coverage report.