### PR TITLE
Feature/gnfw

### DIFF
--- a/lenstronomy/LensModel/Profiles/cnfw.py
+++ b/lenstronomy/LensModel/Profiles/cnfw.py
@@ -105,7 +105,7 @@ class CNFW(LensProfileBase):
         R = np.sqrt(x_**2 + y_**2)
 
         kappa = self.density_2d(x_, y_, Rs, rho0, r_core)
-        gamma1, gamma2 = self.cnfwGamma(R, Rs, rho0, r_core, x_, y_)
+        gamma1, gamma2 = self.cnfw_gamma(R, Rs, rho0, r_core, x_, y_)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -201,7 +201,7 @@ class CNFW(LensProfileBase):
         a = 4 * rho0 * Rs**2 * gx / x
         return a
 
-    def cnfwGamma(self, R, Rs, rho0, r_core, ax_x, ax_y):
+    def cnfw_gamma(self, R, Rs, rho0, r_core, ax_x, ax_y):
         """Shear gamma of NFW profile (times Sigma_crit) along the projection to
         coordinate 'axis'.
 

--- a/lenstronomy/LensModel/Profiles/gnfw.py
+++ b/lenstronomy/LensModel/Profiles/gnfw.py
@@ -1,0 +1,411 @@
+__author__ = "ajshajib"
+
+import numpy as np
+from scipy.integrate import quad
+from scipy.special import hyp2f1
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+
+__all__ = ["GNFW"]
+
+
+class GNFW(LensProfileBase):
+    """
+    This class computes the lensing quantities of a generalized NFW profile:
+
+    .. math::
+    \rho(r) = \frac{\rho_{\rm s}} { (r/r_{\rm s}})^{\gamma_{\rm in}} * (1 + r/r_{\rm
+    s})^{3 - {\gamma_{\rm in}}}
+
+    This class uses the normalization parameter `kappa_s` defined as:
+
+    .. math::
+    kappas_{\rm s} = \frac{\rho_{\rm s} r_{\rm s}}{\Sigma_{\rm crit}}
+
+    Some expressions are obtained from Keeton 2001 (
+    https://ui.adsabs.harvard.edu/abs/2001astro.ph..2341K/abstract). See and cite the
+    references therein.
+    """
+
+    model_name = "GNFW"
+    _s = 0.001  # numerical limit for minimal radius
+    param_names = ["Rs", "kappa_s", "gamma_in", "center_x", "center_y"]
+    lower_limit_default = {
+        "Rs": 0,
+        "kappa_s": 0,
+        "gamma_in": 0.,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "Rs": 100,
+        "kappa_s": 1000.,
+        "gamma_in": 3.,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    def __init__(self):
+        """"""
+        super(GNFW, self).__init__()
+
+    def function(self, x, y, Rs, kappa_s, gamma_in, center_x=0, center_y=0):
+        """
+        Potential of gNFW profile.
+
+        :param x: angular position
+        :type x: float/numpy array
+        :param y: angular position
+        :type y: float/numpy array
+        :param Rs: angular turn over point
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :param center_x: center of halo
+        :type center_x: float
+        :param center_y: center of halo
+        :type center_y: float
+        :return: potential at radius r
+        :rtype: float
+        """
+        x_ = x - center_x
+        y_ = y - center_y
+        r = np.sqrt(x_**2 + y_**2)
+        r = np.maximum(r, self._s)
+
+        if isinstance(r, int) or isinstance(r, float):
+            return self._num_integral_potential(r, Rs, kappa_s, gamma_in)
+        else:
+            # TODO: currently the numerical integral is done one by one. More efficient is sorting the radial list and
+            # then perform one numerical integral reading out to the radial points
+            f_ = []
+            for i in range(len(r)):
+                f_.append(self._num_integral_potential(r[i], Rs, kappa_s, gamma_in))
+            return np.array(f_)
+
+    def _num_integral_potential(self, r, Rs, kappa_s, gamma_in):
+        """
+        Compute the numerical integral of the potential.
+
+        :param r: radius of interest
+        :type r: float
+        :param Rs: scale radius
+        :type Rs: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :param kappa_s: convergence correspoding to rho0
+        :return: potential at radius r
+        :rtype: float
+        """
+
+        def _integrand(x):
+            return self.alpha(x, Rs, kappa_s, gamma_in)
+
+        return quad(_integrand, 0, r)[0]
+
+
+    def derivatives(self, x, y, Rs, kappa_s, gamma_in, center_x=0, center_y=0):
+        """Returns df/dx and df/dy of the function
+
+        :param x: angular position
+        :type x: float/numpy array
+        :param y: angular position
+        :type y: float/numpy array
+        :param Rs: angular turn over point
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :param center_x: center of halo
+        :type center_x: float
+        :param center_y: center of halo
+        :type center_y: float
+        :return: deflection angle in x, deflection angle in y
+        :rtype: float, float
+        """
+        if Rs < 0.0000001:
+            Rs = 0.0000001
+        x_ = x - center_x
+        y_ = y - center_y
+        R = np.sqrt(x_**2 + y_**2)
+        R = np.maximum(R, self._s)
+
+        f_r = self.alpha(R, Rs, kappa_s, gamma_in)
+        f_x = f_r * x_ / R
+        f_y = f_r * y_ / R
+
+        return f_x, f_y
+
+    def hessian(self, x, y, Rs, kappa_s, gamma_in, center_x=0, center_y=0):
+        """Returns Hessian matrix of function d^2f/dx^2, d^f/dy^2, d^2/dxdy.
+
+        :param x: angular position
+        :type x: float/numpy array
+        :param y: angular position
+        :type y: float/numpy array
+        :param Rs: angular turn over point
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :param center_x: center of halo
+        :type center_x: float
+        :param center_y: center of halo
+        :type center_y: float
+        :return: f_xx, f_xy, f_xy, f_yy
+        :rtype: float, float, float, float
+        """
+        rho0 = self.kappa_s2rho0(kappa_s=kappa_s, Rs=Rs, gamma_in=gamma_in)
+        if Rs < 0.0001:
+            Rs = 0.0001
+        x_ = x - center_x
+        y_ = y - center_y
+        R = np.sqrt(x_**2 + y_**2)
+
+        kappa = self.kappa(R, Rs, kappa_s, gamma_in)
+        f_r = self.alpha(R, Rs, kappa_s, gamma_in)
+        f_rr = 2 * kappa - f_r / R
+
+        cost = x_ / R
+        sint = y_ / R
+
+        f_xx = cost**2 * f_rr - sint * cost * f_r / R
+        f_yy = sint**2 * f_rr + sint * cost * f_r / R
+        f_xy = sint * cost * f_rr + cost**2 * f_r
+
+        return f_xx, f_xy, f_xy, f_yy
+
+    def density(self, R, Rs, rho0, gamma_in):
+        """Three dimensional truncated NFW profile.
+
+        :param R: radius of interest
+        :type R: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param rho0: density normalization
+        :type rho0: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: rho(R) density
+        :rtype: float
+        """
+        return rho0 * (R / Rs)**-gamma_in * (1 + R / Rs)**(gamma_in - 3)
+
+    def density_lens(self, R, Rs, kappa_s, gamma_in):
+        """Computes the density at 3d radius r given lens model parameterization. The integral in the LOS projection of this quantity results in the convergence
+        quantity.
+
+        :param R: radius of interest
+        :type R: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: density at radius R
+        :rtype: float
+        """
+        rho0 = self.kappa2rho(kappa_s=kappa_s, Rs=Rs, gamma_in=gamma_in)
+        return self.density(R, Rs, rho0, gamma_in)
+
+    def density_2d(self, x, y, Rs, rho0, gamma_in, center_x=0, center_y=0):
+        """Projected two dimenstional NFW profile (kappa*Sigma_crit)
+
+        :param x: x-coordinate
+        :type x: float/numpy array
+        :param y: y-coordinate
+        :type y: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param rho0: density normalization (characteristic density)
+        :type rho0: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :param center_x: center of halo
+        :type center_x: float
+        :param center_y: center of halo
+        :type center_y: float
+        :return: Epsilon(R) projected density at radius R
+        """
+        x_ = x - center_x
+        y_ = y - center_y
+        R = np.sqrt(x_**2 + y_**2)
+        kappa_s = self.rho02kappa_s(rho0, Rs, gamma_in)
+
+        return self.kappa(R, Rs, kappa_s, gamma_in)
+
+    def mass_3d(self, R, Rs, rho0, gamma_in):
+        """Mass enclosed a 3d sphere or radius r.
+
+        :param R: radius of interest
+        :type R: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param rho0: density normalization (characteristic density)
+        :type rho0: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: mass enclosed a 3d sphere or radius r
+        :rtype: float
+        """
+        M_0 = 4 * np.pi * rho0 * Rs**3 / (3 - gamma_in)
+        x = R / Rs
+        return M_0 * x**(3 - gamma_in) * hyp2f1(3- gamma_in, 3 - gamma_in, 4 - gamma_in,
+                                                -x)
+
+    def mass_3d_lens(self, R, Rs, kappa_s, gamma_in):
+        """Mass enclosed a 3d sphere or radius r given a lens parameterization with
+        angular units.
+
+        :param R: radius of interest
+        :type R: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: mass enclosed a 3d sphere or radius r
+        :rtype: float
+        """
+        rho0 = self.kappa_s2rho0(kappa_s=kappa_s, Rs=Rs, gamma_in=gamma_in)
+        return self.mass_3d(R, Rs, rho0, gamma_in)
+
+    def _trapezoid_integrate(self, func, x, gamma_in, steps=100):
+        """Integrate a function using the trapezoid rule.
+
+        :param func: function to integrate
+        :type func: function
+        :param x: x = R/Rs
+        :type x: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :param steps: number of steps
+        :type steps: int
+        :return: integral
+        :rtype: float
+        """
+        y = np.linspace(1e-10, 1 - 1e-10, steps)
+        dy = y[1] - y[0]
+        ys = np.repeat(y[:, np.newaxis], len(x), axis=1)
+
+        weights = np.ones(steps)
+        weights[0] = 0.5
+        weights[-1] = 0.5
+
+        integral = np.sum(func(ys, x) * dy * weights[:, np.newaxis], axis=0)
+
+        return integral
+
+
+    def _alpha_integrand(self, y, x):
+        """Integrand of the deflection angel integral.
+
+        :param y: integration variable
+        :type y: np.array
+        :param x: x = R/Rs
+        :type x: float
+        :return: integrand of the deflection angel integral
+        """
+        return (y + x)**(gamma_in - 3) * (1 - np.sqrt(1 - y**2)) / y
+
+    def _kappa_integrand(self, y, x):
+        """Integrand of the deflection angel integral in eq. (57) of Keeton 2001.
+
+        :param y: integration variable
+        :type y: np.array
+        :param x: x = R/Rs
+        :type x: float
+        :return: integrand of the deflection angel integral
+        """
+        return (y + x)**(gamma_in - 4) * (1 - np.sqrt(1 - y**2))
+
+    def alpha(self, R, Rs, kappa_s, gamma_in):
+        """Deflection angel of gNFW profile along the radial direction.
+
+        :param R: radius of interest
+        :type R: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: deflection angel at radius R
+        :rtype: float
+        """
+        # R = np.maximum(R, self._s)
+        x = R / Rs
+        x = np.maximum(x, self._s)
+
+        integral = self._trapezoid_integrate(self._alpha_integrand, x, gamma_in)
+
+        alpha = 4 * kappa_s * Rs * x**(2 - gamma_in) * (hyp2f1(3-gamma_in,
+                                                               3-gamma_in,
+                                                               4-gamma_in,
+                                                               -x) / (3-gamma_in) +
+                                                        integral)
+
+        return alpha
+
+    def kappa(self, R, Rs, kappa_s, gamma_in):
+        """
+        Convergence of gNFW profile along the radial direction.
+
+        :param R: radius of interest
+        :type R: float/numpy array
+        :param Rs: scale radius
+        :type Rs: float
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: convergence at radius R
+        :rtype: float
+        """
+        x = R / Rs
+        x = np.maximum(x, self._s)
+
+        integral = self._trapezoid_integrate(self._kappa_r_integrand, x, gamma_in)
+
+        kappa = 2 * kappa_s * Rs * x ** (1 - gamma_in) * ((1 + x)**(gamma_in - 3) +
+                                                           (3 - gamma_in) * integral)
+
+        return kappa
+
+    @staticmethod
+    def rho02kappa_s(rho0, Rs, gamma_in):
+        """convenience function to compute rho0 from alpha_Rs
+
+        :param rho0: density normalization (characteristic density)
+        :type rho0: float
+        :param Rs: scale radius
+        :type Rs: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: kappa_s
+        :rtype: float
+        """
+        return rho0 * Rs
+
+
+    @staticmethod
+    def kappa_s2rho0(kappa_s, Rs, gamma_in):
+        """
+        convenience function to compute rho0 from kappa_s. The returned rho_0 is
+        normalized with $\Sigma_crit$.
+
+        :param kappa_s: convergence correspoding to rho0
+        :type kappa_s: float
+        :param Rs: scale radius
+        :type Rs: float
+        :param gamma_in: inner slope
+        :type gamma_in: float
+        :return: rho0
+        :rtype: float
+        """
+        return kappa_s / Rs

--- a/lenstronomy/LensModel/Profiles/nfw.py
+++ b/lenstronomy/LensModel/Profiles/nfw.py
@@ -12,10 +12,11 @@ class NFW(LensProfileBase):
     """This class contains functions concerning the NFW profile.
 
     relation are: R_200 = c * Rs
-    The definition of 'Rs' is in angular (arc second) units and the normalization is put in with regard to a deflection
-    angle at 'Rs' - 'alpha_Rs'. To convert a physical mass and concentration definition into those lensing quantities
-    for a specific redshift configuration and cosmological model, you can find routines in
-    lenstronomy.Cosmo.lens_cosmo.py
+    The definition of 'Rs' is in angular (arc second) units and the normalization is put
+    in with regard to a deflection angle at 'Rs' - 'alpha_Rs'. To convert a physical
+    mass and concentration definition into those lensing quantities for a specific
+    redshift configuration and cosmological model, you can find routines in
+    `lenstronomy.Cosmo.lens_cosmo.py`
 
     Examples for converting angular to physical mass units
     ------------------------------------------------------
@@ -75,7 +76,7 @@ class NFW(LensProfileBase):
         x_ = x - center_x
         y_ = y - center_y
         R = np.sqrt(x_**2 + y_**2)
-        f_ = self.nfwPot(R, Rs, rho0_input)
+        f_ = self.nfw_potential(R, Rs, rho0_input)
         return f_
 
     def derivatives(self, x, y, Rs, alpha_Rs, center_x=0, center_y=0):
@@ -96,7 +97,7 @@ class NFW(LensProfileBase):
         x_ = x - center_x
         y_ = y - center_y
         R = np.sqrt(x_**2 + y_**2)
-        f_x, f_y = self.nfwAlpha(R, Rs, rho0_input, x_, y_)
+        f_x, f_y = self.nfw_alpha(R, Rs, rho0_input, x_, y_)
         return f_x, f_y
 
     def hessian(self, x, y, Rs, alpha_Rs, center_x=0, center_y=0):
@@ -117,7 +118,7 @@ class NFW(LensProfileBase):
         y_ = y - center_y
         R = np.sqrt(x_**2 + y_**2)
         kappa = self.density_2d(R, 0, Rs, rho0_input)
-        gamma1, gamma2 = self.nfwGamma(R, Rs, rho0_input, x_, y_)
+        gamma1, gamma2 = self.nfw_gamma(R, Rs, rho0_input, x_, y_)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -196,9 +197,12 @@ class NFW(LensProfileBase):
         return m_3d
 
     def mass_2d(self, R, Rs, rho0):
-        """Mass enclosed a 2d cylinder or projected radius R :param R: projected radius
-        :param Rs: scale radius :param rho0: density normalization (characteristic
-        density) :return: mass in cylinder."""
+        """Mass enclosed a 2d cylinder or projected radius R
+
+        :param R: projected radius
+        :param Rs: scale radius
+        :param rho0: density normalization (characteristic density)
+        :return: mass in cylinder."""
         x = R / Rs
         gx = self.g_(x)
         m_2d = 4 * rho0 * Rs * R**2 * gx / x**2 * np.pi
@@ -216,7 +220,7 @@ class NFW(LensProfileBase):
         rho0 = self.alpha2rho0(alpha_Rs, Rs)
         return self.mass_2d(R, Rs=Rs, rho0=rho0)
 
-    def nfwPot(self, R, Rs, rho0):
+    def nfw_potential(self, R, Rs, rho0):
         """Lensing potential of NFW profile (Sigma_crit D_OL**2)
 
         :param R: radius of interest
@@ -231,7 +235,7 @@ class NFW(LensProfileBase):
         hx = self.h_(x)
         return 2 * rho0 * Rs**3 * hx
 
-    def nfwAlpha(self, R, Rs, rho0, ax_x, ax_y):
+    def nfw_alpha(self, R, Rs, rho0, ax_x, ax_y):
         """Deflection angel of NFW profile (times Sigma_crit D_OL) along the projection
         to coordinate 'axis'.
 
@@ -253,7 +257,7 @@ class NFW(LensProfileBase):
         a = 4 * rho0 * Rs * gx / x**2
         return a * ax_x, a * ax_y
 
-    def nfwGamma(self, R, Rs, rho0, ax_x, ax_y):
+    def nfw_gamma(self, R, Rs, rho0, ax_x, ax_y):
         """Shear gamma of NFW profile (times Sigma_crit) along the projection to
         coordinate 'axis'.
 

--- a/lenstronomy/LensModel/Profiles/nfw_ellipse.py
+++ b/lenstronomy/LensModel/Profiles/nfw_ellipse.py
@@ -71,7 +71,7 @@ class NFW_ELLIPSE(LensProfileBase):
         rho0_input = self.nfw.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         if Rs < 0.0000001:
             Rs = 0.0000001
-        f_ = self.nfw.nfwPot(R_, Rs, rho0_input)
+        f_ = self.nfw.nfw_potential(R_, Rs, rho0_input)
         return f_
 
     def derivatives(self, x, y, Rs, alpha_Rs, e1, e2, center_x=0, center_y=0):
@@ -100,7 +100,7 @@ class NFW_ELLIPSE(LensProfileBase):
         rho0_input = self.nfw.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         if Rs < 0.0000001:
             Rs = 0.0000001
-        f_x_prim, f_y_prim = self.nfw.nfwAlpha(R_, Rs, rho0_input, x_, y_)
+        f_x_prim, f_y_prim = self.nfw.nfw_alpha(R_, Rs, rho0_input, x_, y_)
         f_x_prim *= np.sqrt(1 - e)
         f_y_prim *= np.sqrt(1 + e)
         f_x = cos_phi * f_x_prim - sin_phi * f_y_prim

--- a/lenstronomy/LensModel/Profiles/pseudo_double_powerlaw.py
+++ b/lenstronomy/LensModel/Profiles/pseudo_double_powerlaw.py
@@ -1,15 +1,14 @@
 __author__ = "dgilman"
 
-# this file contains a class to compute the Navaro-Frenk-White profile
 import numpy as np
 from scipy.special import hyp2f1
 from scipy.special import beta
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
-__all__ = ["GNFW"]
+__all__ = ["PSEUDO_DPL"]
 
 
-class GNFW(LensProfileBase):
+class PseudoDoublePowerlaw(LensProfileBase):
     """This class contains a double power law profile with flexible inner and outer
     logarithmic slopes g and n.
 
@@ -24,7 +23,7 @@ class GNFW(LensProfileBase):
     TODO: implement the gravitational potential for this profile
     """
 
-    profile_name = "GNFW"
+    profile_name = "PSEUDO_DPL"
     param_names = [
         "Rs",
         "alpha_Rs",
@@ -70,7 +69,7 @@ class GNFW(LensProfileBase):
         x_ = x - center_x
         y_ = y - center_y
         R = np.sqrt(x_**2 + y_**2)
-        f_x, f_y = self.nfwAlpha(R, Rs, rho0_input, gamma_inner, gamma_outer, x_, y_)
+        f_x, f_y = self.alpha(R, Rs, rho0_input, gamma_inner, gamma_outer, x_, y_)
         return f_x, f_y
 
     def hessian(
@@ -94,7 +93,7 @@ class GNFW(LensProfileBase):
         R = np.sqrt(x_**2 + y_**2)
         R = np.maximum(R, 0.00000001)
         kappa = self.density_2d(R, 0, Rs, rho0_input, gamma_inner, gamma_outer)
-        gamma1, gamma2 = self.nfwGamma(
+        gamma1, gamma2 = self.gamma(
             R, Rs, rho0_input, gamma_inner, gamma_outer, x_, y_
         )
         f_xx = kappa + gamma1
@@ -210,7 +209,7 @@ class GNFW(LensProfileBase):
         m_2d = 4 * rho0 * Rs * R**2 * gx / x**2 * np.pi
         return m_2d
 
-    def nfwAlpha(self, R, Rs, rho0, gamma_inner, gamma_outer, ax_x, ax_y):
+    def alpha(self, R, Rs, rho0, gamma_inner, gamma_outer, ax_x, ax_y):
         """Deflection angel of NFW profile (times Sigma_crit D_OL) along the projection
         to coordinate 'axis'.
 
@@ -229,7 +228,7 @@ class GNFW(LensProfileBase):
         a = 4 * rho0 * Rs * R * gx / x**2 / R
         return a * ax_x, a * ax_y
 
-    def nfwGamma(self, R, Rs, rho0, gamma_inner, gamma_outer, ax_x, ax_y):
+    def gamma(self, R, Rs, rho0, gamma_inner, gamma_outer, ax_x, ax_y):
         """Shear gamma of NFW profile (times Sigma_crit) along the projection to
         coordinate 'axis'.
 

--- a/lenstronomy/LensModel/Profiles/tnfw.py
+++ b/lenstronomy/LensModel/Profiles/tnfw.py
@@ -61,7 +61,7 @@ class TNFW(LensProfileBase):
         y_ = y - center_y
         R = np.sqrt(x_**2 + y_**2)
         R = np.maximum(R, self._s * Rs)
-        f_ = self.nfwPot(R, Rs, rho0_input, r_trunc)
+        f_ = self.nfw_potential(R, Rs, rho0_input, r_trunc)
 
         return f_
 
@@ -126,7 +126,7 @@ class TNFW(LensProfileBase):
         y_ = y - center_y
         R = np.sqrt(x_**2 + y_**2)
         R = np.maximum(R, self._s * Rs)
-        f_x, f_y = self.nfwAlpha(R, Rs, rho0_input, r_trunc, x_, y_)
+        f_x, f_y = self.nfw_alpha(R, Rs, rho0_input, r_trunc, x_, y_)
         return f_x, f_y
 
     def hessian(self, x, y, Rs, alpha_Rs, r_trunc, center_x=0, center_y=0):
@@ -149,7 +149,7 @@ class TNFW(LensProfileBase):
         R = np.maximum(R, self._s * Rs)
 
         kappa = self.density_2d(x_, y_, Rs, rho0_input, r_trunc)
-        gamma1, gamma2 = self.nfwGamma(R, Rs, rho0_input, r_trunc, x_, y_)
+        gamma1, gamma2 = self.nfw_gamma(R, Rs, rho0_input, r_trunc, x_, y_)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -223,7 +223,7 @@ class TNFW(LensProfileBase):
         m_3d = 4 * np.pi * Rs**3 * rho0 * func
         return m_3d
 
-    def nfwPot(self, R, Rs, rho0, r_trunc):
+    def nfw_potential(self, R, Rs, rho0, r_trunc):
         """Lensing potential of truncated NFW profile.
 
         :param R: radius of interest
@@ -242,7 +242,7 @@ class TNFW(LensProfileBase):
         hx = self._h(x, tau)
         return 2 * rho0 * Rs**3 * hx
 
-    def nfwAlpha(self, R, Rs, rho0, r_trunc, ax_x, ax_y):
+    def nfw_alpha(self, R, Rs, rho0, r_trunc, ax_x, ax_y):
         """Deflection angel of NFW profile along the projection to coordinate axis.
 
         :param R: radius of interest
@@ -265,7 +265,7 @@ class TNFW(LensProfileBase):
         a = 4 * rho0 * Rs * gx / x**2
         return a * ax_x, a * ax_y
 
-    def nfwGamma(self, R, Rs, rho0, r_trunc, ax_x, ax_y):
+    def nfw_gamma(self, R, Rs, rho0, r_trunc, ax_x, ax_y):
         """Shear gamma of NFW profile (times Sigma_crit) along the projection to
         coordinate 'axis'.
 

--- a/lenstronomy/LensModel/Profiles/tnfw_ellipse.py
+++ b/lenstronomy/LensModel/Profiles/tnfw_ellipse.py
@@ -67,7 +67,7 @@ class TNFW_ELLIPSE(LensProfileBase):
         Rs = np.maximum(Rs, 0.0000001)
         # if Rs < 0.0000001:
         #    Rs = 0.0000001
-        f_ = self.tnfw.nfwPot(R_, Rs, rho0_input, r_trunc)
+        f_ = self.tnfw.nfw_potential(R_, Rs, rho0_input, r_trunc)
         return f_
 
     def derivatives(self, x, y, Rs, alpha_Rs, r_trunc, e1, e2, center_x=0, center_y=0):
@@ -98,7 +98,7 @@ class TNFW_ELLIPSE(LensProfileBase):
         Rs = np.maximum(Rs, 0.0000001)
         # if Rs < 0.0000001:
         #    Rs = 0.0000001
-        f_x_prim, f_y_prim = self.tnfw.nfwAlpha(R_, Rs, rho0_input, r_trunc, x_, y_)
+        f_x_prim, f_y_prim = self.tnfw.nfw_alpha(R_, Rs, rho0_input, r_trunc, x_, y_)
         f_x_prim *= np.sqrt(1 - e)
         f_y_prim *= np.sqrt(1 + e)
         f_x = cos_phi * f_x_prim - sin_phi * f_y_prim

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -39,7 +39,6 @@ _SUPPORTED_MODELS = [
     "GAUSSIAN_ELLIPSE_KAPPA",
     "GAUSSIAN_ELLIPSE_POTENTIAL",
     "GAUSSIAN_KAPPA",
-    "GNFW",
     "HERNQUIST",
     "HERNQUIST_ELLIPSE",
     "HERNQUIST_ELLIPSE_CSE",
@@ -64,6 +63,7 @@ _SUPPORTED_MODELS = [
     "PJAFFE",
     "PJAFFE_ELLIPSE",
     "POINT_MASS",
+    "PSEUDO_DPL",
     "SERSIC",
     "SERSIC_ELLIPSE_GAUSS_DEC",
     "SERSIC_ELLIPSE_KAPPA",
@@ -392,10 +392,6 @@ def lens_class(
         from lenstronomy.LensModel.Profiles.gaussian_kappa import GaussianKappa
 
         return GaussianKappa()
-    elif lens_type == "GNFW":
-        from lenstronomy.LensModel.Profiles.general_nfw import GNFW
-
-        return GNFW()
     elif lens_type == "HERNQUIST":
         from lenstronomy.LensModel.Profiles.hernquist import Hernquist
 
@@ -506,6 +502,10 @@ def lens_class(
         from lenstronomy.LensModel.Profiles.point_mass import PointMass
 
         return PointMass()
+    elif lens_type == "PSEUDO_DPL":
+        from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import PseudoDoublePowerlaw
+
+        return PseudoDoublePowerlaw()
     elif lens_type == "RADIAL_INTERPOL":
         from lenstronomy.LensModel.Profiles.radial_interpolated import (
             RadialInterpolate,

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -39,6 +39,7 @@ _SUPPORTED_MODELS = [
     "GAUSSIAN_ELLIPSE_KAPPA",
     "GAUSSIAN_ELLIPSE_POTENTIAL",
     "GAUSSIAN_KAPPA",
+    "GNFW",
     "HERNQUIST",
     "HERNQUIST_ELLIPSE",
     "HERNQUIST_ELLIPSE_CSE",
@@ -392,6 +393,10 @@ def lens_class(
         from lenstronomy.LensModel.Profiles.gaussian_kappa import GaussianKappa
 
         return GaussianKappa()
+    elif lens_type == "GNFW":
+        from lenstronomy.LensModel.Profiles.gnfw import GNFW
+
+        return GNFW()
     elif lens_type == "HERNQUIST":
         from lenstronomy.LensModel.Profiles.hernquist import Hernquist
 

--- a/test/test_LensModel/test_Profiles/test_cnfw.py
+++ b/test/test_LensModel/test_Profiles/test_cnfw.py
@@ -82,9 +82,9 @@ class Testcnfw(object):
 
         R = np.array([0.5 * Rs, 0.8 * Rs, 1.1 * Rs])
 
-        g1_array, g2_array = self.cn.cnfwGamma(R, Rs, rho0, r_core, R, 0.6 * Rs)
+        g1_array, g2_array = self.cn.cnfw_gamma(R, Rs, rho0, r_core, R, 0.6 * Rs)
         for i in range(0, len(R)):
-            g1, g2 = self.cn.cnfwGamma(R[i], Rs, rho0, r_core, R[i], 0.6 * Rs)
+            g1, g2 = self.cn.cnfw_gamma(R[i], Rs, rho0, r_core, R[i], 0.6 * Rs)
             npt.assert_almost_equal(g1_array[i], g1)
             npt.assert_almost_equal(g2_array[i], g2)
 

--- a/test/test_LensModel/test_Profiles/test_gnfw.py
+++ b/test/test_LensModel/test_Profiles/test_gnfw.py
@@ -1,0 +1,156 @@
+__author__ = "sibirrer"
+
+
+from lenstronomy.LensModel.Profiles.nfw import NFW
+from lenstronomy.LensModel.Profiles.gnfw import GNFW
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestGNFW(object):
+    """
+    This class tests the generalized NFW profile.
+    """
+    def setup_method(self):
+        self.nfw = NFW()
+        self.gnfw = GNFW()
+
+    def test_function(self):
+        """
+        Tests `GNFW.function()`
+        """
+        x = np.array([1., 1])
+        y = np.array([2., 2])
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        alpha_Rs = self.nfw.rho02alpha(rho0, Rs)
+        values_nfw = self.nfw.function(x, y, Rs, alpha_Rs)
+
+        kappa_s = self.gnfw.rho02kappa_s(rho0, Rs, gamma_in)
+        values_gnfw = self.gnfw.function(x, y, Rs, kappa_s, gamma_in)
+        npt.assert_almost_equal(values_nfw, values_gnfw, decimal=3)
+
+    def test_derivatives(self):
+        """
+        Tests `GNFW.derivatives()`
+        """
+        x = np.array([1])
+        y = np.array([2])
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        alpha_Rs = self.nfw.rho02alpha(rho0, Rs)
+        f_x_nfw, f_y_nfw = self.nfw.derivatives(x, y, Rs, alpha_Rs)
+
+        kappa_s = self.gnfw.rho02kappa_s(rho0, Rs, gamma_in)
+        f_x_gnfw, f_y_gnfw = self.gnfw.derivatives(x, y, Rs, kappa_s, gamma_in)
+
+        npt.assert_almost_equal(f_x_nfw, f_x_gnfw, decimal=3)
+        npt.assert_almost_equal(f_y_nfw, f_y_gnfw, decimal=3)
+
+    def test_hessian(self):
+        """
+        Tests `GNFW.hessian()`
+        """
+        x = 1
+        y = 2
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        alpha_Rs = self.nfw.rho02alpha(rho0, Rs)
+        f_xx_nfw, f_xy_nfw, _, f_yy_nfw = self.nfw.hessian(x, y, Rs, alpha_Rs)
+
+        kappa_s = self.gnfw.rho02kappa_s(rho0, Rs, gamma_in)
+        f_xx_gnfw, f_xy_gnfw, _, f_yy_gnfw = self.gnfw.hessian(x, y, Rs, kappa_s,
+                                                              gamma_in)
+
+        npt.assert_almost_equal(f_xx_nfw, f_xx_gnfw, decimal=3)
+        npt.assert_almost_equal(f_yy_nfw, f_yy_gnfw, decimal=3)
+        npt.assert_almost_equal(f_xy_nfw, f_xy_gnfw, decimal=3)
+
+    def test_density(self):
+        """
+        Tests `GNFW.density()`
+        """
+        R = 1
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        density_nfw = self.nfw.density(R, Rs, rho0)
+        density_gnfw = self.gnfw.density(R, Rs, rho0, gamma_in)
+
+        npt.assert_almost_equal(density_nfw, density_gnfw, decimal=6)
+
+    def test_density_lens(self):
+        """
+        Tests `GNFW.density_lens()`
+        """
+        R = 1
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        alpha_Rs = self.nfw.rho02alpha(rho0, Rs)
+        density_nfw = self.nfw.density_lens(R, Rs, alpha_Rs)
+
+        kappa_s = self.gnfw.rho02kappa_s(rho0, Rs, gamma_in)
+        density_gnfw = self.gnfw.density_lens(R, Rs, kappa_s, gamma_in)
+
+        npt.assert_almost_equal(density_nfw, density_gnfw, decimal=6)
+
+    def test_density_2d(self):
+        """
+        Tests `GNFW.density_2d_lens()`
+        """
+        x = np.array([1])
+        y = np.array([2])
+        Rs = 1.0
+        rho0 = 10
+        gamma_in = 1
+
+        kappa_nfw = self.nfw.density_2d(x, y, Rs, rho0)
+        kappa_gnfw = self.gnfw.density_2d(x, y, Rs, rho0, gamma_in)
+
+        npt.assert_almost_equal(kappa_nfw, kappa_gnfw, decimal=3)
+
+    def test_mass_3d(self):
+        """
+        Tests `GNFW.mass_3d()`
+        """
+        r = 1
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        mass_3d_nfw = self.nfw.mass_3d(r, Rs, rho0)
+        mass_3d_gnfw = self.gnfw.mass_3d(r, Rs, rho0, gamma_in)
+
+        npt.assert_almost_equal(mass_3d_nfw, mass_3d_gnfw, decimal=10)
+
+    def test_mass_3d_lens(self):
+        """
+        Tests `GNFW.mass_3d_lens()`
+        """
+        r = 1
+        Rs = 1.0
+        rho0 = 1
+        gamma_in = 1
+
+        alpha_Rs = self.nfw.rho02alpha(rho0, Rs)
+        mass_3d_nfw = self.nfw.mass_3d_lens(r, Rs, alpha_Rs)
+
+        kappa_s = self.gnfw.rho02kappa_s(rho0, Rs, gamma_in)
+        mass_3d_gnfw = self.gnfw.mass_3d_lens(r, Rs, kappa_s, gamma_in)
+
+        npt.assert_almost_equal(mass_3d_nfw, mass_3d_gnfw, decimal=10)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
+++ b/test/test_LensModel/test_Profiles/test_nfw_core_truncated.py
@@ -2,7 +2,7 @@ __author__ = "dgilman"
 
 import unittest
 from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC
-from lenstronomy.LensModel.Profiles.general_nfw import GNFW
+from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import PseudoDoublePowerlaw
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -11,7 +11,7 @@ import pytest
 class TestTNFWC(object):
     def setup_method(self):
         self.tnfwc = TNFWC()
-        self.gnfw = GNFW()
+        self.pdpl = PseudoDoublePowerlaw()
 
     def test_alphaRs(self):
         kwargs_lens = {
@@ -61,13 +61,13 @@ class TestTNFWC(object):
         r_trunc = 1000 * Rs
 
         alpha_tnfwc = self.tnfwc.derivatives(R, 0.0, Rs, alpha_Rs, r_core, r_trunc)
-        alpha_gnfw = self.gnfw.derivatives(R, 0.0, Rs, alpha_Rs, 1.0, 3.0)
+        alpha_gnfw = self.pdpl.derivatives(R, 0.0, Rs, alpha_Rs, 1.0, 3.0)
         npt.assert_almost_equal(alpha_gnfw, alpha_tnfwc, 3.0)
 
         rho0 = self.tnfwc.alpha2rho0(alpha_Rs, Rs, r_core, r_trunc)
         density_2d_tnfwc = self.tnfwc.density_2d(R, 0.0, Rs, rho0, r_core, r_trunc)
-        rho0 = self.gnfw.alpha2rho0(alpha_Rs, Rs, 1.0, 3.0)
-        density_2d_gnfw = self.gnfw.density_2d(R, 0.0, Rs, rho0, 1.0, 3.0)
+        rho0 = self.pdpl.alpha2rho0(alpha_Rs, Rs, 1.0, 3.0)
+        density_2d_gnfw = self.pdpl.density_2d(R, 0.0, Rs, rho0, 1.0, 3.0)
         npt.assert_almost_equal(density_2d_tnfwc, density_2d_gnfw, 3.0)
 
     def test_mass3d(self):

--- a/test/test_LensModel/test_Profiles/test_pseudo_double_powerlaw.py
+++ b/test/test_LensModel/test_Profiles/test_pseudo_double_powerlaw.py
@@ -1,7 +1,7 @@
 __author__ = "dgilman"
 
 import unittest
-from lenstronomy.LensModel.Profiles.general_nfw import GNFW
+from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import PseudoDoublePowerlaw
 from lenstronomy.LensModel.lens_model import LensModel
 from scipy.integrate import quad
 from lenstronomy.LensModel.Profiles.splcore import SPLCORE
@@ -10,9 +10,9 @@ import numpy.testing as npt
 import pytest
 
 
-class TestGNFW(object):
+class TestPseudoDoublePowerlaw(object):
     def setup_method(self):
-        self.gnfw = GNFW()
+        self.pdpl = PseudoDoublePowerlaw()
         self.splcore = SPLCORE()
         self.kwargs_lens = {
             "alpha_Rs": 2.1,
@@ -24,7 +24,7 @@ class TestGNFW(object):
         }
 
     def test_alphaRs(self):
-        alpha_rs = self.gnfw.derivatives(
+        alpha_rs = self.pdpl.derivatives(
             self.kwargs_lens["Rs"],
             0.0,
             self.kwargs_lens["Rs"],
@@ -35,13 +35,13 @@ class TestGNFW(object):
         npt.assert_almost_equal(alpha_rs, self.kwargs_lens["alpha_Rs"], 8)
 
     def test_alphaRs_rho0_conversion(self):
-        rho0 = self.gnfw.alpha2rho0(
+        rho0 = self.pdpl.alpha2rho0(
             self.kwargs_lens["alpha_Rs"],
             self.kwargs_lens["Rs"],
             self.kwargs_lens["gamma_inner"],
             self.kwargs_lens["gamma_outer"],
         )
-        alpha_Rs = self.gnfw.rho02alpha(
+        alpha_Rs = self.pdpl.rho02alpha(
             rho0,
             self.kwargs_lens["Rs"],
             self.kwargs_lens["gamma_inner"],
@@ -50,26 +50,26 @@ class TestGNFW(object):
         npt.assert_almost_equal(alpha_Rs, self.kwargs_lens["alpha_Rs"], 5)
 
     def test_lensing_quantities(self):
-        lensmodel = LensModel(["GNFW"])
-        f_x, f_y = self.gnfw.derivatives(1.0, 1.5, **self.kwargs_lens)
+        lensmodel = LensModel(["PSEUDO_DPL"])
+        f_x, f_y = self.pdpl.derivatives(1.0, 1.5, **self.kwargs_lens)
         f_x_, f_y_ = lensmodel.alpha(1.0, 1.5, [self.kwargs_lens])
         npt.assert_almost_equal(f_x, f_x_, 5)
         npt.assert_almost_equal(f_y, f_y_, 5)
 
-        f_xx, f_xy, f_yx, f_yy = self.gnfw.hessian(1.0, 1.5, **self.kwargs_lens)
+        f_xx, f_xy, f_yx, f_yy = self.pdpl.hessian(1.0, 1.5, **self.kwargs_lens)
         f_xx_, f_xy_, f_yx_, f_yy_ = lensmodel.hessian(1.0, 1.5, [self.kwargs_lens])
         npt.assert_almost_equal(f_xx, f_xx_, 5)
         npt.assert_almost_equal(f_yy, f_yy_, 5)
         npt.assert_almost_equal(f_xy, f_xy_, 5)
 
     def test_mass2d(self):
-        rho0 = self.gnfw.alpha2rho0(
+        rho0 = self.pdpl.alpha2rho0(
             self.kwargs_lens["alpha_Rs"],
             self.kwargs_lens["Rs"],
             self.kwargs_lens["gamma_inner"],
             self.kwargs_lens["gamma_outer"],
         )
-        m2d = self.gnfw.mass_2d(
+        m2d = self.pdpl.mass_2d(
             10.0,
             self.kwargs_lens["Rs"],
             rho0,
@@ -80,7 +80,7 @@ class TestGNFW(object):
             lambda x: 2
             * 3.14159265
             * x
-            * self.gnfw.density_2d(
+            * self.pdpl.density_2d(
                 x,
                 0.0,
                 self.kwargs_lens["Rs"],
@@ -96,15 +96,15 @@ class TestGNFW(object):
         rs = 1.5
         kwargs_spl = {"sigma0": 1e13, "gamma": 3.0, "r_core": 0.00000001}
         alpha_rs = self.splcore.derivatives(rs, 0.0, **kwargs_spl)[0]
-        kwargs_gnfw = {
+        kwargs_pdpl = {
             "alpha_Rs": alpha_rs,
             "Rs": rs,
             "gamma_inner": 2.99999,
             "gamma_outer": 3.00001,
         }
-        m3d_gnfw = self.gnfw.mass_3d_lens(5 * rs, **kwargs_gnfw)
+        m3d_pdpl = self.pdpl.mass_3d_lens(5 * rs, **kwargs_pdpl)
         m3d_splcore = self.splcore.mass_3d_lens(5 * rs, **kwargs_spl)
-        npt.assert_almost_equal(m3d_gnfw / m3d_splcore, 0.935, 3)
+        npt.assert_almost_equal(m3d_pdpl / m3d_splcore, 0.935, 3)
         # approximate match to splcore with similar properties
 
 

--- a/test/test_LensModel/test_Profiles/test_tnfw.py
+++ b/test/test_LensModel/test_Profiles/test_tnfw.py
@@ -46,12 +46,12 @@ class TestTNFW(object):
         R = np.linspace(0.5 * Rs, 2.2 * Rs, 5000)
         dx = R[1] - R[0]
 
-        alpha_tnfw = self.tnfw.nfwAlpha(R, Rs, 1, r_trunc, R, 0)[0]
+        alpha_tnfw = self.tnfw.nfw_alpha(R, Rs, 1, r_trunc, R, 0)[0]
 
-        potential_array = self.tnfw.nfwPot(R, Rs, 1, r_trunc)
+        potential_array = self.tnfw.nfw_potential(R, Rs, 1, r_trunc)
         alpha_tnfw_num_array = np.gradient(potential_array, dx)
 
-        potential_from_float = [self.tnfw.nfwPot(R_i, Rs, 1, r_trunc) for R_i in R]
+        potential_from_float = [self.tnfw.nfw_potential(R_i, Rs, 1, r_trunc) for R_i in R]
         alpha_tnfw_num_from_float = np.gradient(potential_from_float, dx)
 
         npt.assert_almost_equal(alpha_tnfw_num_array, alpha_tnfw, 4)
@@ -64,10 +64,10 @@ class TestTNFW(object):
         x = np.linspace(0.1 * Rs, 5 * Rs, 1000)
         y = np.linspace(0.2, 1, 1000)
 
-        g1t, g2t = self.tnfw.nfwGamma(
+        g1t, g2t = self.tnfw.nfw_gamma(
             (x**2 + y**2) ** 0.5, Rs, alpha_Rs, r_trunc, x, y
         )
-        g1, g2 = self.nfw.nfwGamma((x**2 + y**2) ** 0.5, Rs, alpha_Rs, x, y)
+        g1, g2 = self.nfw.nfw_gamma((x ** 2 + y ** 2) ** 0.5, Rs, alpha_Rs, x, y)
 
         np.testing.assert_almost_equal(g1t, g1, 5)
         np.testing.assert_almost_equal(g2t, g2, 5)

--- a/test/test_LensModel/test_convergence_integrals.py
+++ b/test/test_LensModel/test_convergence_integrals.py
@@ -142,7 +142,7 @@ class TestConvergenceIntegrals(object):
         npt.assert_almost_equal(f_ - f_00, f_num[x1, y1] - f_num[x0, y0], decimal=2)
 
     def test_gnfw(self):
-        from lenstronomy.LensModel.Profiles.general_nfw import GNFW
+        from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import GNFW
 
         gnfw = GNFW()
         deltaPix = 0.005

--- a/test/test_LensModel/test_profile_integrals.py
+++ b/test/test_LensModel/test_profile_integrals.py
@@ -443,7 +443,7 @@ class TestNumerics(object):
         self.assert_lens_integrals(Model, kwargs)
 
     def test_gnfw(self):
-        from lenstronomy.LensModel.Profiles.general_nfw import GNFW as Model
+        from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import GNFW as Model
 
         kwargs = {"alpha_Rs": 0.7, "Rs": 0.3, "gamma_inner": 1.0, "gamma_outer": 3.2}
         self.assert_lens_integrals(Model, kwargs)


### PR DESCRIPTION
This PR:

- renames the previous `"GNFW"` profile as the `"PSEUDO_DPL"` profile, with "DPL" standing for double power law. The "pseudo" part denotes the fact that the definition of this profile has pseudo-Jaffe and pseudo-Hernquist profiles as special cases.
- implements the generalized NFW profile with a variable inner slope as the `"GNFW"` profile.
- changes the naming of several functions to conform to PEP8.