### PR TITLE
isiterable as built in function in lenstronomy to be compatible with astropy v6.0

### DIFF
--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -1,4 +1,5 @@
 import astropy
+from lenstronomy.Util.util import isiterable
 
 
 if float(astropy.__version__[0]) < 5.0:
@@ -9,8 +10,10 @@ if float(astropy.__version__[0]) < 5.0:
         "We recommend you to update astropy to the latest versionbut keep supporting your settings for "
         "the time being."
     )
-else:
-    from astropy.cosmology.utils import isiterable
+#elif float(astropy.__version__[0]) < 6.0:
+#    from astropy.cosmology.utils import isiterable
+#else:
+#    from astropy.cosmology.utils.misc import isiterable
 #
 from astropy import units
 import numpy as np

--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -10,9 +10,9 @@ if float(astropy.__version__[0]) < 5.0:
         "We recommend you to update astropy to the latest versionbut keep supporting your settings for "
         "the time being."
     )
-#elif float(astropy.__version__[0]) < 6.0:
+# elif float(astropy.__version__[0]) < 6.0:
 #    from astropy.cosmology.utils import isiterable
-#else:
+# else:
 #    from astropy.cosmology.utils.misc import isiterable
 #
 from astropy import units

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -18,6 +18,15 @@ def merge_dicts(*dict_args):
         result.update(dictionary)
     return result
 
+@export
+def isiterable(obj):
+    """Returns `True` if the given object is iterable."""
+    try:
+        iter(obj)
+        return True
+    except TypeError:
+        return False
+
 
 @export
 def approx_theta_E(ximg, yimg):

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -18,6 +18,7 @@ def merge_dicts(*dict_args):
         result.update(dictionary)
     return result
 
+
 @export
 def isiterable(obj):
     """Returns `True` if the given object is iterable."""

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -8,6 +8,15 @@ import numpy.testing as npt
 import unittest
 
 
+def test_isiterable():
+    z = np.array([0, 1])
+    boolean = util.isiterable(z)
+    assert boolean is True
+
+    z = 1
+    boolean = util.isiterable(z)
+    assert boolean is False
+
 def test_estimate_theta_E():
     x = np.array([-0.45328229, 0.57461556, 0.53757501, -0.42312438])
     y = np.array([0.69582971, -0.51226356, 0.37577509, -0.40245467])

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -17,6 +17,7 @@ def test_isiterable():
     boolean = util.isiterable(z)
     assert boolean is False
 
+
 def test_estimate_theta_E():
     x = np.array([-0.45328229, 0.57461556, 0.53757501, -0.42312438])
     y = np.array([0.69582971, -0.51226356, 0.37577509, -0.40245467])


### PR DESCRIPTION
The new astropy 6.0 is incompatible as isiterable has been moved. This PR makes it less prong to the astropy versions