### PR TITLE
Fix unsupported arguments  for image_linear_solve methods

### DIFF
--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -58,6 +58,8 @@ class MultiBandImageReconstruction(object):
         source_marg = kwargs_likelihood.get("source_marg", False)
         linear_prior = kwargs_likelihood.get("linear_prior", None)
         bands_compute = kwargs_likelihood.get("bands_compute", None)
+        kwargs_params_copy = copy.deepcopy(kwargs_params)
+        kwargs_params_copy.pop("kwargs_tracer_source", None)
         if bands_compute is None:
             bands_compute = [True] * len(multi_band_list)
         if multi_band_type == "single-band":
@@ -72,13 +74,13 @@ class MultiBandImageReconstruction(object):
 
         # here we perform the (joint) linear inversion with all data
         model, error_map, cov_param, param = self._imageModel.image_linear_solve(
-            inv_bool=True, **kwargs_params
+            inv_bool=True, **kwargs_params_copy
         )
         check_solver_error(param)
 
         if verbose:
             logL, _ = self._imageModel.likelihood_data_given_model(
-                source_marg=source_marg, linear_prior=linear_prior, **kwargs_params
+                source_marg=source_marg, linear_prior=linear_prior, **kwargs_params_copy
             )
             n_data = self._imageModel.num_data_evaluate
             if n_data > 0:


### PR DESCRIPTION
I came across this issue while retrieving the fitting sequence class best-fit kwargs, which are now augmented by a `kwargs_tracer_source` placeholder, but it seems that this kwargs is not (yet?) supported in linear solver classes created via `class_creator.create_im_sim`. This PR is an easy fix for the constructor of `MultiBandImageReconstruction` following what is already done in the `ModelBand` class. I don't know what `kwargs_tracer_source` is made for, so please let me know if this fix is not appropriate for some reason.