### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ mpmath
 emcee>=3.0.0
 matplotlib
 scikit-learn
-numba>=0.43.1
+numba>=0.43.1,<=0.56.4
 dynesty
 pymultinest
 nestcheck


### PR DESCRIPTION
Currently numba_util.py implementation uses numba.generated_jit which is no longer available in numba 0.57.0 and further.

https://github.com/lenstronomy/lenstronomy/blob/d81ab6402e5727fc01a31d31713a8b4215ae51c5/lenstronomy/Util/numba_util.py#L79-L86