### PR TITLE
more robust lens equation solver settings when dealing with imaging data

### DIFF
--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -64,11 +64,14 @@ class ImageModel(object):
         if self.PointSource._lens_model is None:
             self.PointSource.update_lens_model(lens_model_class=lens_model_class)
         x_center, y_center = self.Data.center
+        search_window = np.max(self.Data.width)
+        # either have the pixel resolution of the window resolved in 200x200 grid
+        min_distance = min(self.Data.pixel_width, search_window / 200)
         self.PointSource.update_search_window(
-            search_window=np.max(self.Data.width),
+            search_window=search_window,
             x_center=x_center,
             y_center=y_center,
-            min_distance=self.Data.pixel_width,
+            min_distance=min_distance,
             only_from_unspecified=True,
         )
         self._psf_error_map = self.PSF.psf_error_map_bool

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -34,7 +34,7 @@ class PointSource(object):
         :param flux_from_point_source_list: list of booleans (optional), if set, will only return image positions
          (for imaging modeling) for the subset of the point source lists that =True. This option enables to model
          imaging data with transient point sources, when the point source positions are measured and present at a
-         different time than the imaging data
+         different time than the imaging data, or when the image position is not known (such as for lensed GW)
         :param magnification_limit: float >0 or None, if float is set and additional images are computed, only those
          images will be computed that exceed the lensing magnification (absolute value) limit
         :param save_cache: bool, saves image positions and only if delete_cache is executed, a new solution of the lens


### PR DESCRIPTION
I set the default as at least 200x200 grid sampling the imaging data when looking for solution of the lens equation. Prior to this PR, it takes the pixel resolution of the data, which can be not accurate when the pixels are too sparse (large pixel for small Einstein radius).