### PR TITLE
faster solver implemented including constant convergence

### DIFF
--- a/lenstronomy/LensModel/Solver/epl_shear_solver.py
+++ b/lenstronomy/LensModel/Solver/epl_shear_solver.py
@@ -271,7 +271,9 @@ def solve_lenseq_pemd(pos_, kwargs_lens, Nmeas=400, Nmeas_extra=80, **kwargs):
     :param pos_: The source plane position (shape (2,)), or the source plane positions (shape (2,N)) for which to solve the lens equation
     :param kwargs_lens: List of kwargs in lenstronomy style, following ['EPL', 'SHEAR'] format
     :param Nmeas: resolution with which to sample the angular grid, higher means more reliable lens equation solving. For solving many positions at once, you may want to set this higher.
-    :param Nmeas_extra: resolution with which to additionally sample the angular grid at the low-shear end, higher means more reliable lens equation solving. For solving many positions at once, you may want to set this higher.
+    :param Nmeas_extra: resolution with which to additionally sample the angular grid at the low-shear end,
+     higher means more reliable lens equation solving.
+     For solving many positions at once, you may want to set this higher.
     :return: The lens plane positions.
     Note: generally the (demagnified) central image will also be included.
     """

--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -174,7 +174,9 @@ class LensEquationSolver(object):
             kappa = kwargs_lens_[index_convergence]["kappa"]
             ra0 = kwargs_lens_[index_convergence].get("ra_0", 0)
             dec0 = kwargs_lens_[index_convergence].get("dec_0", 0)
-            lambda_mst = 1 - kappa  # a mass sheet that compensates the convergence field
+            lambda_mst = (
+                1 - kappa
+            )  # a mass sheet that compensates the convergence field
             # source position mapping
             x_ = (x - ra0) / lambda_mst
             y_ = (y - dec0) / lambda_mst
@@ -183,7 +185,7 @@ class LensEquationSolver(object):
             # alpha = theta_E * (r2 / theta_E**2) ** (1 - gamma / 2.0)
             gamma = kwargs_lens[0]["gamma"] if "gamma" in kwargs_lens[0] else 1
 
-            kwargs_lens_[0]["theta_E"] /= lambda_mst ** (1./(gamma - 1))
+            kwargs_lens_[0]["theta_E"] /= lambda_mst ** (1.0 / (gamma - 1))
             if "SHEAR" in lens_model_list:
                 kwargs_lens_[1]["gamma1"] /= lambda_mst
                 kwargs_lens_[1]["gamma2"] /= lambda_mst

--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import lenstronomy.Util.util as util
 import lenstronomy.Util.image_util as image_util
@@ -158,9 +160,41 @@ class LensEquationSolver(object):
         :param kwargs_solver: additional kwargs to be supplied to the solver. Particularly relevant are Nmeas and Nmeas_extra
         :returns: (exact) angular position of (multiple) images ra_pos, dec_pos in units of angle
          Note: in contrast to the other solvers, generally the (heavily demagnified) central image will also be included, so
-         setting a a proper magnification_limit is more important. To get similar behaviour, a limit of 1e-1 is acceptable
+         setting a proper magnification_limit is more important. To get similar behaviour, a limit of 1e-1 is acceptable
         """
-        lens_model_list = list(self.lensModel.lens_model_list)
+        lens_model_list = copy.deepcopy(list(self.lensModel.lens_model_list))
+
+        # make MST when "CONVERGENCE" profile is given
+        if "CONVERGENCE" in lens_model_list:
+            # here we apply an inverse MST that leaves image positions invariant under the MST
+            kwargs_lens_ = copy.deepcopy(kwargs_lens)
+            index_convergence = lens_model_list.index("CONVERGENCE")
+
+            # MST in source position and Einstein radius
+            kappa = kwargs_lens_[index_convergence]["kappa"]
+            ra0 = kwargs_lens_[index_convergence].get("ra_0", 0)
+            dec0 = kwargs_lens_[index_convergence].get("dec_0", 0)
+            lambda_mst = 1 - kappa  # a mass sheet that compensates the convergence field
+            # source position mapping
+            x_ = (x - ra0) / lambda_mst
+            y_ = (y - dec0) / lambda_mst
+            # lens mapping
+            # power-law scaling with mst
+            # alpha = theta_E * (r2 / theta_E**2) ** (1 - gamma / 2.0)
+            gamma = kwargs_lens[0]["gamma"] if "gamma" in kwargs_lens[0] else 1
+
+            kwargs_lens_[0]["theta_E"] /= lambda_mst ** (1./(gamma - 1))
+            if "SHEAR" in lens_model_list:
+                kwargs_lens_[1]["gamma1"] /= lambda_mst
+                kwargs_lens_[1]["gamma2"] /= lambda_mst
+
+            # removing of kwargs_lens of "CONVERGENCE" profile
+            kwargs_lens_.pop(index_convergence)
+            lens_model_list.pop(index_convergence)
+        else:
+            kwargs_lens_ = kwargs_lens
+            x_, y_ = x, y
+
         if lens_model_list not in (
             ["SIE", "SHEAR"],
             ["SIE"],
@@ -170,10 +204,10 @@ class LensEquationSolver(object):
             ["EPL"],
         ):
             raise ValueError(
-                "Only SIE, EPL, EPL_NUMBA (+shear) supported in the analytical solver for now."
+                "Only SIE, EPL, EPL_NUMBA (+shear +convergence) supported in the analytical solver for now."
             )
+        x_mins, y_mins = solve_lenseq_pemd((x_, y_), kwargs_lens_, **kwargs_solver)
 
-        x_mins, y_mins = solve_lenseq_pemd((x, y), kwargs_lens, **kwargs_solver)
         if arrival_time_sort:
             x_mins, y_mins = self.sort_arrival_times(x_mins, y_mins, kwargs_lens)
         if magnification_limit is not None:

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -279,6 +279,40 @@ class TestLensEquationSolver(object):
         npt.assert_almost_equal(sourcePos_x, source_x, decimal=10)
         npt.assert_almost_equal(sourcePos_y, source_y, decimal=10)
 
+    def test_lens_equation_analytical_mst(self):
+        # here we test with convergence shear and mass profile centroids not aligned
+        lensModel = LensModel(["EPL", "SHEAR", "CONVERGENCE"])
+        lensEquationSolver = LensEquationSolver(lensModel)
+        sourcePos_x = 0.02
+        sourcePos_y = 0.02
+        kwargs_lens = [
+            {
+                "theta_E": 1.0,
+                "gamma": 2.2,
+                "center_x": 0.0,
+                "center_y": 0.0,
+                "e1": 0.01,
+                "e2": 0.05,
+            },
+            {"gamma1": -0.04, "gamma2": -0.1, "ra_0": 0.0, "dec_0": 1.0},
+            {"kappa": 0.2, "ra_0": 0, "dec_0": 0}
+        ]
+
+        x_pos, y_pos = lensEquationSolver.image_position_from_source(
+            sourcePos_x, sourcePos_y, kwargs_lens, solver="analytical"
+        )
+        x_pos_num, y_pos_num = lensEquationSolver.image_position_from_source(
+            sourcePos_x, sourcePos_y, kwargs_lens, solver="lenstronomy"
+        )
+
+        npt.assert_almost_equal(x_pos, x_pos_num)
+
+        print(kwargs_lens, 'test kwargs_lens')
+        source_x, source_y = lensModel.ray_shooting(x_pos, y_pos, kwargs_lens)
+        assert len(source_x) == len(source_y) >= 2
+        npt.assert_almost_equal(sourcePos_x, source_x, decimal=10)
+        npt.assert_almost_equal(sourcePos_y, source_y, decimal=10)
+
     def test_caustics(self):
         lm = LensModel(["EPL_NUMBA", "SHEAR"])
         leqs = LensEquationSolver(lm)

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -295,7 +295,7 @@ class TestLensEquationSolver(object):
                 "e2": 0.05,
             },
             {"gamma1": -0.04, "gamma2": -0.1, "ra_0": 0.0, "dec_0": 1.0},
-            {"kappa": 0.2, "ra_0": 0, "dec_0": 0}
+            {"kappa": 0.2, "ra_0": 0, "dec_0": 0},
         ]
 
         x_pos, y_pos = lensEquationSolver.image_position_from_source(
@@ -307,7 +307,7 @@ class TestLensEquationSolver(object):
 
         npt.assert_almost_equal(x_pos, x_pos_num)
 
-        print(kwargs_lens, 'test kwargs_lens')
+        print(kwargs_lens, "test kwargs_lens")
         source_x, source_y = lensModel.ray_shooting(x_pos, y_pos, kwargs_lens)
         assert len(source_x) == len(source_y) >= 2
         npt.assert_almost_equal(sourcePos_x, source_x, decimal=10)


### PR DESCRIPTION
the faster lens equation solver is now able to scale the model with an MST and hence enables the inclusion of convergence. 