### PR TITLE
bug fix in analytical lens equation solver when using SIE+CONVERGENCE

### DIFF
--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -192,7 +192,7 @@ class LensEquationSolver(object):
             # lens mapping
             # power-law scaling with mst
             # alpha = theta_E * (r2 / theta_E**2) ** (1 - gamma / 2.0)
-            gamma = kwargs_lens[0]["gamma"] if "gamma" in kwargs_lens[0] else 1
+            gamma = kwargs_lens[0]["gamma"] if "gamma" in kwargs_lens[0] else 2
 
             kwargs_lens_[0]["theta_E"] /= lambda_mst ** (1.0 / (gamma - 1))
             if "SHEAR" in lens_model_list:

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -371,10 +371,11 @@ class TestLensEquationSolver(object):
         sourcePos_x = 0.03
         sourcePos_y = 0.0
 
-        lensModel = LensModel(["SIE"])
+        lensModel = LensModel(["SIE", "CONVERGENCE"])
         lensEquationSolver = LensEquationSolver(lensModel)
         kwargs_lens = [
             {"theta_E": 1.0, "center_x": 0.0, "center_y": 0.0, "e1": 0.5, "e2": 0.05},
+            {"kappa": 0.2, "ra_0": 0, "dec_0": 0},
         ]
 
         x_pos, y_pos = lensEquationSolver.image_position_from_source(


### PR DESCRIPTION
previously using gamma=1, now fixed to gamma=2