### PR TITLE
bug fix for GAUSSIAN PSF when being supersampled (kernel size)

### DIFF
--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -205,7 +205,7 @@ class PSF(object):
         if self.psf_type == "GAUSSIAN":
             try:
                 del self._kernel_point_source
-            except NameError:
+            except:
                 pass
 
     @property

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -107,7 +107,7 @@ class PSF(object):
         if not hasattr(self, "_kernel_point_source"):
             if self.psf_type == "GAUSSIAN":
                 kernel_num_pix = min(
-                    round(self._truncation * self._fwhm / self._pixel_size), 201
+                    round(self._truncation * self._fwhm / self._pixel_size), 221
                 )
                 if kernel_num_pix % 2 == 0:
                     kernel_num_pix += 1
@@ -147,20 +147,19 @@ class PSF(object):
             kernel_point_source_supersampled = self._kernel_point_source_supersampled
         else:
             if self.psf_type == "GAUSSIAN":
-                kernel_numPix = (
-                    self._truncation / self._pixel_size * supersampling_factor
+                kernel_num_pix = int(
+                    round(self._truncation * self._fwhm / self._pixel_size * supersampling_factor)
                 )
-                kernel_numPix = int(round(kernel_numPix))
-                if kernel_numPix > 10000:
+                if kernel_num_pix > 10000:
                     raise ValueError(
                         "The pixelized Gaussian kernel has a grid of %s pixels with a truncation at "
                         "%s times the sigma of the Gaussian, exceeding the limit allowed."
-                        % (kernel_numPix, self._truncation)
+                        % (kernel_num_pix, self._truncation)
                     )
-                if kernel_numPix % 2 == 0:
-                    kernel_numPix += 1
+                if kernel_num_pix % 2 == 0:
+                    kernel_num_pix += 1
                 kernel_point_source_supersampled = kernel_util.kernel_gaussian(
-                    kernel_numPix, self._pixel_size / supersampling_factor, self._fwhm
+                    kernel_num_pix, self._pixel_size / supersampling_factor, self._fwhm
                 )
 
             elif self.psf_type == "PIXEL":

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -148,7 +148,12 @@ class PSF(object):
         else:
             if self.psf_type == "GAUSSIAN":
                 kernel_num_pix = int(
-                    round(self._truncation * self._fwhm / self._pixel_size * supersampling_factor)
+                    round(
+                        self._truncation
+                        * self._fwhm
+                        / self._pixel_size
+                        * supersampling_factor
+                    )
                 )
                 if kernel_num_pix > 10000:
                     raise ValueError(

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -205,7 +205,7 @@ class PSF(object):
         if self.psf_type == "GAUSSIAN":
             try:
                 del self._kernel_point_source
-            except:
+            except NameError:
                 pass
 
     @property
@@ -226,7 +226,7 @@ class PSF(object):
     def fwhm(self):
         """
 
-        :return: full width at half maximum of kernel (in units of pixel)
+        :return: full width at half maximum of kernel (in units of angle)
         """
         if self.psf_type == "GAUSSIAN":
             return self._fwhm

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -269,7 +269,8 @@ class LikelihoodModule(object):
         """
 
         :param kwargs_model: lenstronomy model keyword arguments
-        :param kwargs_imaging: keyword arguments for imaging likelihood
+        :param kwargs_image_sim: keyword arguments for imaging likelihood
+        :param kwargs_image_likelihood: image likelihood dictionary
         :param kwargs_position: keyword arguments for positional likelihood
         :param kwargs_flux: keyword arguments for flux ratio likelihood
         :param kwargs_time_delay: keyword arguments for time delay likelihood


### PR DESCRIPTION
this fixes a bug for the GAUSSIAN PSF kernel size when being supersampled. FWHM was not considered in the size of the kernel