### PR TITLE
Fixing a typo in point source plotting utility 

### DIFF
--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -304,7 +304,7 @@ def source_position_plot(
             x_source, y_source = coords.map_coord2pix(ra, dec)
             ax.plot(
                 x_source * delta_pix,
-                y_source + 0.5 * delta_pix,
+                y_source * delta_pix,
                 marker=marker,
                 markersize=markersize,
                 **kwargs


### PR DESCRIPTION
When plotting the reconstructed source with ModelPlot.source_plot, the y coordinate of the point source should be `y_source * delta_pix` and not `y_source + 0.5 * delta_pix` to be consistent with the x coordinate (otherwise the y coordinate is out of range and the point source's location is not shown)