### PR TITLE
Enable batched fermat potential computation with EPL_NUMBA

### DIFF
--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -197,9 +197,15 @@ def alpha(x, y, b, q, t, Omega=None):
 def omega(phi, t, q, niter_max=200, tol=1e-16):
     f = (1 - q) / (1 + q)
     omegas = np.zeros_like(phi, dtype=np.complex128)
-    niter = min(
-        niter_max, int(np.max(np.log(tol) / np.log(f))) + 2
-    )  # The absolute value of each summand is always less than f, hence this limit for the number of iterations.
+    # determine # of iterations
+    if hasattr(f, "__len__"):
+        niter = min(
+            niter_max, int(np.max(np.log(tol) / np.log(f)))+2
+        )
+    else:
+        niter = min(
+            niter_max, int(np.log(tol) / np.log(f)) + 2
+        )# The absolute value of each summand is always less than f, hence this limit for the number of iterations.
     Omega = 1 * np.exp(1j * phi)
     fact = -f * np.exp(2j * phi)
     for n in range(1, niter):

--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -198,7 +198,7 @@ def omega(phi, t, q, niter_max=200, tol=1e-16):
     f = (1 - q) / (1 + q)
     omegas = np.zeros_like(phi, dtype=np.complex128)
     niter = min(
-        niter_max, int(np.log(tol) / np.log(f)) + 2
+        niter_max, int(np.max(np.log(tol) / np.log(f))) + 2
     )  # The absolute value of each summand is always less than f, hence this limit for the number of iterations.
     Omega = 1 * np.exp(1j * phi)
     fact = -f * np.exp(2j * phi)

--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -199,13 +199,11 @@ def omega(phi, t, q, niter_max=200, tol=1e-16):
     omegas = np.zeros_like(phi, dtype=np.complex128)
     # determine # of iterations
     if hasattr(f, "__len__"):
-        niter = min(
-            niter_max, int(np.max(np.log(tol) / np.log(f)))+2
-        )
+        niter = min(niter_max, int(np.max(np.log(tol) / np.log(f))) + 2)
     else:
         niter = min(
             niter_max, int(np.log(tol) / np.log(f)) + 2
-        )# The absolute value of each summand is always less than f, hence this limit for the number of iterations.
+        )  # The absolute value of each summand is always less than f, hence this limit for the number of iterations.
     Omega = 1 * np.exp(1j * phi)
     fact = -f * np.exp(2j * phi)
     for n in range(1, niter):


### PR DESCRIPTION
- I want to use the static method EPL_numba.function() to compute many fermat potentials from many lenses at one time
- Basically, I want to be able to add a batch dimension to the inputs, and keep everything working
- It turns out this already almost works, the only thing that is not batch compatible is the way in which niter is computed in the subfunction omega()
- If I take the max of the quantity f = (1 - q) / (1 + q) across the many lenses, and use that to determine niter, everything works.
- Since np.max(scalar) just returns that scalar, this should not change the interface for existing use cases