### PR TITLE
recall change to niter calculation in epl_numba

### DIFF
--- a/lenstronomy/LensModel/Profiles/epl_numba.py
+++ b/lenstronomy/LensModel/Profiles/epl_numba.py
@@ -197,13 +197,9 @@ def alpha(x, y, b, q, t, Omega=None):
 def omega(phi, t, q, niter_max=200, tol=1e-16):
     f = (1 - q) / (1 + q)
     omegas = np.zeros_like(phi, dtype=np.complex128)
-    # determine # of iterations
-    if hasattr(f, "__len__"):
-        niter = min(niter_max, int(np.max(np.log(tol) / np.log(f))) + 2)
-    else:
-        niter = min(
-            niter_max, int(np.log(tol) / np.log(f)) + 2
-        )  # The absolute value of each summand is always less than f, hence this limit for the number of iterations.
+    niter = min(
+        niter_max, int(np.log(tol) / np.log(f)) + 2
+    )  # The absolute value of each summand is always less than f, hence this limit for the number of iterations.
     Omega = 1 * np.exp(1j * phi)
     fact = -f * np.exp(2j * phi)
     for n in range(1, niter):


### PR DESCRIPTION
- Recalls the change from a recent PR to attempt to use epl_numba for batched fermat potential computations (see https://github.com/lenstronomy/lenstronomy/commit/5144659b9b09e8e6937c845442fea52bd78181c3)
- I previously changed the niter calculation in the omega() function to be compatible with a scalar f, or with an array f, using hasattr(f, "__len__"). But, upon further usage of this change, it seems this is not numba compatible. It's breaking some of my existing usage of epl_numba. 
- I'll recall the change for now, and if I can find a good solution, I'll make a new PR. 