### PR TITLE
Non-italic text in absolute residual plot colourbar label

### DIFF
--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -552,7 +552,7 @@ class ModelBandPlot(ModelBand):
         v_max=1,
         font_size=15,
         text="Residuals",
-        colorbar_label=r"(f$_{model}$-f$_{data}$)",
+        colorbar_label=r"(f$_{\rm model}$-f$_{\rm data}$)",
     ):
         """
 


### PR DESCRIPTION
Very tiny PR to change colourbar labels to non-italic text in the absolute residuals plot!