### PR TITLE
minor bug fix for analytical lens equation solver with deflection angle scaling

### DIFF
--- a/lenstronomy/Cosmo/cosmo_interp.py
+++ b/lenstronomy/Cosmo/cosmo_interp.py
@@ -7,7 +7,7 @@ if float(astropy.__version__[0]) < 5.0:
 
     DeprecationWarning(
         "Astropy<5 is going to be deprecated soon. This is in combination with Python version<3.8."
-        "We recommend you to update astropy to the latest versionbut keep supporting your settings for "
+        "We recommend you to update astropy to the latest version but keep supporting your settings for "
         "the time being."
     )
 # elif float(astropy.__version__[0]) < 6.0:

--- a/lenstronomy/LensModel/Solver/lens_equation_solver.py
+++ b/lenstronomy/LensModel/Solver/lens_equation_solver.py
@@ -183,6 +183,13 @@ class LensEquationSolver(object):
         """
         lens_model_list = copy.deepcopy(list(self.lensModel.lens_model_list))
 
+
+        if self.lensModel.type != "SinglePlane":
+            raise ValueError(
+                "lens model type %s not supported for analytical lens equation solver, "
+                "Needs to be SinglePlane." % self.lensModel.type
+            )
+        alpha_scaling = self.lensModel.lens_model.alpha_scaling
         # make MST when "CONVERGENCE" profile is given
         if "CONVERGENCE" in lens_model_list:
             # here we apply an inverse MST that leaves image positions invariant under the MST
@@ -190,7 +197,7 @@ class LensEquationSolver(object):
             index_convergence = lens_model_list.index("CONVERGENCE")
 
             # MST in source position and Einstein radius
-            kappa = kwargs_lens_[index_convergence]["kappa"]
+            kappa = kwargs_lens_[index_convergence]["kappa"] * alpha_scaling
             ra0 = kwargs_lens_[index_convergence].get("ra_0", 0)
             dec0 = kwargs_lens_[index_convergence].get("dec_0", 0)
             lambda_mst = (
@@ -213,23 +220,16 @@ class LensEquationSolver(object):
             kwargs_lens_.pop(index_convergence)
             lens_model_list.pop(index_convergence)
         else:
-            kwargs_lens_ = kwargs_lens
+            kwargs_lens_ = copy.deepcopy(kwargs_lens)
             x_, y_ = x, y
-
         if lens_model_list not in SUPPORTED_LENS_MODELS_ANALYTICAL:
             raise ValueError(
                 "Only SIS (only with shear), SIE, EPL, EPL_NUMBA (+shear +convergence) "
                 "supported in the analytical solver for now."
             )
 
-        if self.lensModel.type != "SinglePlane":
-            raise ValueError(
-                "lens model type %s not supported for analytical lens equation solver, "
-                "Needs to be SinglePlane." % self.lensModel.type
-            )
-
         # re-scale solutions if source redshift has changed (i.e. alpha_scaling != 1)
-        alpha_scaling = self.lensModel.lens_model.alpha_scaling
+
         gamma = kwargs_lens[0]["gamma"] if "gamma" in kwargs_lens[0] else 2
         kwargs_lens_[0]["theta_E"] *= alpha_scaling ** (1.0 / (gamma - 1))
         if "SHEAR" in lens_model_list:

--- a/lenstronomy/Plots/lens_plot.py
+++ b/lenstronomy/Plots/lens_plot.py
@@ -135,6 +135,8 @@ def lens_model_plot(
     # ax.get_xaxis().set_visible(False)
     # ax.get_yaxis().set_visible(False)
     ax.autoscale(False)
+    ax.set_xlabel("RA/x [arcsec]")
+    ax.set_ylabel("DEC/y [arcsec]")
     return ax
 
 
@@ -253,6 +255,7 @@ def caustics_plot(
         origin=origin,
         flipped_x=coord_inverse,
         points_only=points_only,
+        label="caustics",
         *args,
         **kwargs,
     )
@@ -265,6 +268,7 @@ def caustics_plot(
         origin=origin,
         flipped_x=coord_inverse,
         points_only=points_only,
+        label="critical curves",
         *args,
         **kwargs,
     )

--- a/lenstronomy/Plots/plot_util.py
+++ b/lenstronomy/Plots/plot_util.py
@@ -174,6 +174,7 @@ def plot_line_set(
     origin=None,
     flipped_x=False,
     points_only=False,
+    label=None,
     *args,
     **kwargs
 ):
@@ -225,6 +226,8 @@ def plot_line_set(
             *args,
             **kwargs
         )
+    if label is not None:
+        ax.plot(-1000, -1000, label=label, *args, **kwargs)
     return ax
 
 

--- a/lenstronomy/Sampling/Samplers/pso.py
+++ b/lenstronomy/Sampling/Samplers/pso.py
@@ -7,6 +7,8 @@ from copy import copy
 from math import floor
 import math
 import numpy as np
+from tqdm import tqdm
+
 
 __all__ = ["ParticleSwarmOptimizer"]
 
@@ -229,15 +231,17 @@ class ParticleSwarmOptimizer(object):
         pos_list = []
 
         num_iter = 0
-        for _ in self.sample(max_iter, c1, c2, p, m, n, early_stop_tolerance, verbose):
-            log_likelihood_list.append(self.global_best.fitness)
-            vel_list.append(self.global_best.velocity)
-            pos_list.append(self.global_best.position)
-            num_iter += 1
+        with tqdm(total=max_iter) as pbar:
+            for _ in self.sample(max_iter, c1, c2, p, m, n, early_stop_tolerance, verbose):
+                log_likelihood_list.append(self.global_best.fitness)
+                vel_list.append(self.global_best.velocity)
+                pos_list.append(self.global_best.position)
+                num_iter += 1
 
-            if verbose and self.is_master():
-                if num_iter % 10 == 0:
-                    print(num_iter)
+                if verbose and self.is_master():
+                    pbar.update(1)
+                    #if num_iter % 10 == 0:
+                    #    print(num_iter)
 
         return self.global_best.position, [log_likelihood_list, pos_list, vel_list]
 

--- a/lenstronomy/Util/param_util.py
+++ b/lenstronomy/Util/param_util.py
@@ -164,16 +164,16 @@ def elliptical_distortion_product_average(x, y, e1, e2, center_x, center_y):
     :return: distorted coordinates x', y'
     """
     x_, y_ = transform_e1e2_product_average(x, y, e1, e2, center_x, center_y)
-    # rotate back
-    phi_g, q = ellipticity2phi_q(e1, e2)
-    cos_phi = np.cos(-phi_g)
-    sin_phi = np.sin(-phi_g)
+    # rotate back (only used in the old version of transform_e1e2_product_average < lenstronomy 1.12.2)
+    # phi_g, q = ellipticity2phi_q(e1, e2)
+    # cos_phi = np.cos(-phi_g)
+    # sin_phi = np.sin(-phi_g)
 
-    x__ = cos_phi * x_ + sin_phi * y_
-    y__ = -sin_phi * x_ + cos_phi * y_
+    # x__ = cos_phi * x_ + sin_phi * y_
+    # y__ = -sin_phi * x_ + cos_phi * y_
     # shift
-    x___ = x__ + center_x
-    y___ = y__ + center_y
+    # x___ = x__ + center_x
+    # y___ = y__ + center_y
     # return x___, y___
     return x_ + center_x, y_ + center_y
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ scikit-image
 pyyaml
 pyxdg
 h5py
+tqdm
 zeus-mcmc
 cobaya
 nautilus-sampler>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy<2
-astropy
+astropy<7.0.0
 scipy>=0.19.1
 mpmath
 emcee>=3.0.0

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -244,8 +244,12 @@ class TestLensCosmo(object):
         npt.assert_almost_equal(theta_E_dPIED / theta_E_sis, 1, decimal=2)
 
     def test_beta_double_source_plane(self):
-        beta = self.lensCosmo.beta_double_source_plane(z_lens=0.5, z_source_1=1, z_source_2=2)
-        beta_true = self.lensCosmo.background.beta_double_source_plane(z_lens=0.5, z_source_1=1, z_source_2=2)
+        beta = self.lensCosmo.beta_double_source_plane(
+            z_lens=0.5, z_source_1=1, z_source_2=2
+        )
+        beta_true = self.lensCosmo.background.beta_double_source_plane(
+            z_lens=0.5, z_source_1=1, z_source_2=2
+        )
         npt.assert_almost_equal(beta, beta_true, decimal=5)
 
 

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -243,6 +243,11 @@ class TestLensCosmo(object):
         theta_E_dPIED = lens_analysis.effective_einstein_radius(kwargs_lens=kwargs_lens)
         npt.assert_almost_equal(theta_E_dPIED / theta_E_sis, 1, decimal=2)
 
+    def test_beta_double_source_plane(self):
+        beta = self.lensCosmo.beta_double_source_plane(z_lens=0.5, z_source_1=1, z_source_2=2)
+        beta_true = self.lensCosmo.background.beta_double_source_plane(z_lens=0.5, z_source_1=1, z_source_2=2)
+        npt.assert_almost_equal(beta, beta_true, decimal=5)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -457,11 +457,13 @@ class TestLensEquationSolver(object):
         kwargs_lens_scaling[1]["gamma2"] *= alpha_scaling
         kwargs_lens_scaling[2]["kappa"] *= alpha_scaling
 
-        x_pos, y_pos = lensEquationSolver_no_scaling.image_position_from_source(
-            sourcePos_x, sourcePos_y, kwargs_lens_scaling, solver="analytical"
-        )
+        # establishing the truth
         x_pos_num, y_pos_num = lensEquationSolver.image_position_from_source(
             sourcePos_x, sourcePos_y, kwargs_lens, solver="lenstronomy"
+        )
+
+        x_pos, y_pos = lensEquationSolver_no_scaling.image_position_from_source(
+            sourcePos_x, sourcePos_y, kwargs_lens_scaling, solver="analytical"
         )
 
         npt.assert_almost_equal(x_pos, x_pos_num)
@@ -472,23 +474,22 @@ class TestLensEquationSolver(object):
         npt.assert_almost_equal(sourcePos_y, source_y, decimal=10)
 
         x_pos_, y_pos_ = lensEquationSolver_no_scaling.image_position_from_source(
-            sourcePos_x, sourcePos_y, kwargs_lens_scaling, solver="analytical"
-        )
-        npt.assert_almost_equal(x_pos_, x_pos)
-
-        x_pos_, y_pos_ = lensEquationSolver_no_scaling.image_position_from_source(
             sourcePos_x, sourcePos_y, kwargs_lens_scaling, solver="lenstronomy"
         )
 
         npt.assert_almost_equal(x_pos_, x_pos)
 
-        print(kwargs_lens, "test kwargs_lens")
         source_x, source_y = lensModel_no_scaling.ray_shooting(
             x_pos_, y_pos_, kwargs_lens_scaling
         )
         assert len(source_x) == len(source_y) >= 2
         npt.assert_almost_equal(sourcePos_x, source_x, decimal=10)
         npt.assert_almost_equal(sourcePos_y, source_y, decimal=10)
+
+        x_pos_, y_pos_ = lensEquationSolver.image_position_from_source(
+            sourcePos_x, sourcePos_y, kwargs_lens, solver="analytical"
+        )
+        npt.assert_almost_equal(x_pos_, x_pos)
 
     def test_assertions(self):
         lensModel = LensModel(["SPEP"])


### PR DESCRIPTION
the MST correction in the analytical lens equation solver was not scaled with the deflection angle scaling. This PR fixes odd behavior with the analytical lens equation solver when a) external convergence is non-zero and b) alpha_scaling != 1. Any other behavior worked.

Then I added a tqdm progress bar for the PSO (finally) and allow a legend to be plotted for the lens_plot indicating caustics and critical curves