### PR TITLE
add function to ModelPlot to return single band chi square

### DIFF
--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -209,9 +209,9 @@ class ModelBand(object):
         self._norm_residuals = self._bandmodel.reduced_residuals(
             model, error_map=error_map
         )
-        self._reduced_x2 = self._bandmodel.reduced_chi2(model, error_map=error_map)
+        self.reduced_x2 = self._bandmodel.reduced_chi2(model, error_map=error_map)
         if verbose:
-            print("reduced chi^2 of data ", band_index, "= ", self._reduced_x2)
+            print("reduced chi^2 of data ", band_index, "= ", self.reduced_x2)
 
         self._model = model
         self._cov_param = cov_param

--- a/lenstronomy/Plots/model_plot.py
+++ b/lenstronomy/Plots/model_plot.py
@@ -368,4 +368,4 @@ class ModelPlot(object):
         :return: the reduced chi-square value of the band as a float
         """
         plot_band = self._select_band(band_index)
-        return plot_band._reduced_x2
+        return plot_band.reduced_x2

--- a/lenstronomy/Plots/model_plot.py
+++ b/lenstronomy/Plots/model_plot.py
@@ -361,7 +361,7 @@ class ModelPlot(object):
         plot_band = self._select_band(band_index)
         return plot_band.source(**kwargs)
 
-     def single_band_chi2(self, band_index=0):
+    def single_band_chi2(self, band_index=0):
         """
         
         :param band_index: index of band

--- a/lenstronomy/Plots/model_plot.py
+++ b/lenstronomy/Plots/model_plot.py
@@ -363,7 +363,7 @@ class ModelPlot(object):
 
     def single_band_chi2(self, band_index=0):
         """
-        
+
         :param band_index: index of band
         :return: the reduced chi-square value of the band as a float
         """

--- a/lenstronomy/Plots/model_plot.py
+++ b/lenstronomy/Plots/model_plot.py
@@ -360,3 +360,12 @@ class ModelPlot(object):
         """
         plot_band = self._select_band(band_index)
         return plot_band.source(**kwargs)
+
+     def single_band_chi2(self, band_index=0):
+        """
+        
+        :param band_index: index of band
+        :return: the reduced chi-square value of the band as a float
+        """
+        plot_band = self._select_band(band_index)
+        return plot_band._reduced_x2

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -18,7 +18,6 @@ import matplotlib
 matplotlib.use("agg")
 import matplotlib.pyplot as plt
 import unittest
-import numpy.testing as npt
 
 
 class TestOutputPlots(object):
@@ -300,9 +299,7 @@ class TestOutputPlots(object):
 
         chi2 = lensPlot.single_band_chi2(band_index=0)
 
-        npt.assert_almost_equal(
-            chi2, 1.3, decimal=1
-        )  # NH: not so sure about hardcoding a number to test against
+        assert isinstance(chi2, float)
 
     def test_joint_linear(self):
         multi_band_list = [

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -18,6 +18,7 @@ import matplotlib
 matplotlib.use("agg")
 import matplotlib.pyplot as plt
 import unittest
+import numpy.testing as npt
 
 
 class TestOutputPlots(object):
@@ -286,6 +287,20 @@ class TestOutputPlots(object):
             band_index=0, numPix=10, deltaPix=0.1, center=[0, 0]
         )
         assert len(source) == 10
+    
+    def test_single_band_chi2(self):
+        multi_band_list = [[self.kwargs_data, self.kwargs_psf, self.kwargs_numerics]]
+        lensPlot = ModelPlot(
+            multi_band_list,
+            self.kwargs_model,
+            self.kwargs_params,
+            arrow_size=0.02,
+            cmap_string="gist_heat",
+        )
+
+        chi2 = lensPlot.single_band_chi2(band_index=0)
+
+        npt.assert_almost_equal(chi2, 1.3, decimal=1) # NH: not so sure about hardcoding a number to test against
 
     def test_joint_linear(self):
         multi_band_list = [

--- a/test/test_Plots/test_model_plot.py
+++ b/test/test_Plots/test_model_plot.py
@@ -287,7 +287,7 @@ class TestOutputPlots(object):
             band_index=0, numPix=10, deltaPix=0.1, center=[0, 0]
         )
         assert len(source) == 10
-    
+
     def test_single_band_chi2(self):
         multi_band_list = [[self.kwargs_data, self.kwargs_psf, self.kwargs_numerics]]
         lensPlot = ModelPlot(
@@ -300,7 +300,9 @@ class TestOutputPlots(object):
 
         chi2 = lensPlot.single_band_chi2(band_index=0)
 
-        npt.assert_almost_equal(chi2, 1.3, decimal=1) # NH: not so sure about hardcoding a number to test against
+        npt.assert_almost_equal(
+            chi2, 1.3, decimal=1
+        )  # NH: not so sure about hardcoding a number to test against
 
     def test_joint_linear(self):
         multi_band_list = [


### PR DESCRIPTION
Short function added to ModelPlot to allow direct access to the single band chi square i.e. `chi2 = model_plot.single_band_chi2(band_index=0)`. This is useful if for example you want to automatically add the chi square value of a model to a plot/legend. I'm not sure if this is already possible or if there's a neater way to do it.