### PR TITLE
New EPL+powerlawmultipole profile (EPL+PLMultipole)

### DIFF
--- a/lenstronomy/LensModel/Profiles/epl_powermulitpole.py
+++ b/lenstronomy/LensModel/Profiles/epl_powermulitpole.py
@@ -1,0 +1,439 @@
+__author__ = "eckerl"
+
+import numpy as np
+import lenstronomy.Util.util as util
+import lenstronomy.Util.param_util as param_util
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from lenstronomy.LensModel.Profiles.epl import EPL
+from lenstronomy.LensModel.Profiles.spp import SPP
+from scipy.special import hyp2f1
+
+__all__ = ["EPL_PMULTIPOL","EPL_PMULTIPOL_QPHI"]
+
+class EPL_PMultipol(LensProfileBase):
+    """This class contains a EPL+PLMultipole contribution over e1,e2.
+    The PLMultipole is an extention to the parametrization of Chu et al.(2013) (https://arxiv.org/abs/1302.5482). The equation is Eq. (8) from Nightingale et al. (2023) (https://arxiv.org/abs/2209.10566)
+    It scales the contribution of the multipoles with the same power-law as the EPL.  It is defined with a prefactor 1/2 and the einstein radius theta_e in order to achieve k = theta_E / 2theta as the m=0
+    contribution (Reason stated in Chu et al.(2013) (https://arxiv.org/abs/1302.5482) Eq. (3)).
+
+
+    theta_E : float, Einstein radius
+    gamma : float, power-law slope
+    e1: eccentricity component
+    e2: eccentricity component
+    m : int, multipole order, m>=2
+    k_m : float, multipole strength and sqrt (a_m^2+b_m^2) of old definition.
+    phi_m : float, multipole orientation in radian
+    center_x: x-position
+    center_y: y-position
+    """
+
+    param_names = ["theta_E", "gamma", "e1", "e2", "m", "k_m", "phi_m", "center_x", "center_y"]
+    lower_limit_default = {
+        "theta_E": 0,
+        "gamma": 1.5,
+        "e1": -0.5,
+        "e2":-0.5,
+        "m": 0,
+        "k_m": 0,
+        "phi_m": -np.pi,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "theta_E": 100,
+        "gamma": 2.5,
+        "e1": 0.5,
+        "e2": 0.5,
+        "m": 100,
+        "k_m": 100,
+        "phi_m": np.pi,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    def __init__(self):
+        self._EPL = EPL()
+        super(EPL_PMultipol, self).__init__()
+
+
+
+
+    def function(self, x, y, theta_E, gamma, e1, e2, m, k_m, phi_m, center_x=0, center_y=0):
+        """
+        Lensing potential of PLmultipole contribution (for 1 component with m>=2)+EPL.
+        The equation for PLMultipol is Eq. (8) from Nightingale et al. (2023) (https://arxiv.org/abs/2209.10566)
+
+
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param gamma: power law slope
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: lensing potential
+        """
+        r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
+        f_multi = theta_E**(gamma-1)*k_m/((3-gamma)**2-m**2)*r**(3-gamma)*np.cos(m*(phi-phi_m))
+        f_epl = self._EPL.function(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+        f_=f_epl+f_multi
+        return f_
+
+    def derivatives(self, x, y, theta_E, gamma, e1, e2, m, k_m, phi_m, center_x=0, center_y=0):
+        """
+        Deflection of a multipole contribution (for 1 component with m>=2)
+        This uses an extention to the parametrization of Chu et al.(2013) (https://arxiv.org/abs/1302.5482). The equation is Eq. (8) from Nightingale et al. (2023) (https://arxiv.org/abs/2209.10566)
+        It scales the contribution of the multipoles with the same power-law as the EPL.  It is defined with a prefactor 1/2 and the einstein radius theta_e in order to achieve k = theta_E / 2theta as the m=0
+        contribution (Reason stated in Chu et al.(2013) (https://arxiv.org/abs/1302.5482) Eq. (3)).
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param gamma: power law slope
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: alpha_x, alpha_y
+        """
+        r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
+        pre_factor=theta_E**(gamma-1)*k_m/((3-gamma)**2-m**2)
+        f_x_multi = pre_factor*(np.cos(phi)*r**(2-gamma)*np.cos(m*(phi-phi_m))+np.sin(phi)*r**(1-gamma)*m*np.sin(m*(phi-phi_m)))
+        f_y_multi = pre_factor*(np.sin(phi)*r**(2-gamma)*np.cos(m*(phi-phi_m))-np.cos(phi)*r**(1-gamma)*m*np.sin(m*(phi-phi_m)))
+        
+        f_x_epl, f_y_epl = self._EPL.derivatives(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+
+        f_x =f_x_epl+f_x_multi
+        f_y =f_y_epl+f_y_multi
+
+
+        return f_x,f_y
+
+    def hessian(self, x, y, theta_E, gamma, e1, e2, m, k_m, phi_m, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param gamma: power law slope
+        :param e1: eccentricity component
+        :param e2: eccentricity component
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: f_xx, f_xy, f_yx, f_yy
+        """
+
+        r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
+        pre_factor=theta_E**(gamma-1)*k_m/((3-gamma)**2-m**2)
+
+        term1_xx =  pre_factor * r**(1-gamma) * (2 - gamma)*np.cos(phi)*(np.cos(phi) * (3-gamma)*np.cos(m * (phi - phi_m))+ np.sin(phi)*m*np.sin(m * (phi - phi_m)))
+        term2_xx = pre_factor * r**(1-gamma) * (np.sin(phi)**2*np.cos(m * (phi - phi_m))*((3-gamma)-m**2) + (2-gamma)*np.cos(phi)* np.sin(phi) * m * np.sin(m * (phi - phi_m)))
+        f_xx_multi = term1_xx+term2_xx
+
+
+        term1_yy = pre_factor * r**(1-gamma) * (2 - gamma)*np.sin(phi)*(np.sin(phi) * (3-gamma)*np.cos(m * (phi - phi_m))- np.cos(phi)*m*np.sin(m * (phi - phi_m)))
+
+        term2_yy = pre_factor * r**(1-gamma) * (np.cos(phi)**2*np.cos(m * (phi - phi_m))*((3-gamma)-m**2) - (2-gamma)*np.cos(phi)* np.sin(phi) * m * np.sin(m * (phi - phi_m)))
+        
+        f_yy_multi = term1_yy + term2_yy 
+
+        # Term calculations
+        term1_xy = pre_factor * r**(1-gamma) * (2 - gamma)*np.sin(phi)*(np.cos(phi) * (3-gamma)*np.cos(m * (phi - phi_m))+ np.sin(phi)*m*np.sin(m * (phi - phi_m)))
+
+        term2_xy = pre_factor * r**(1-gamma) * (np.sin(phi)*np.cos(phi)*np.cos(m * (phi - phi_m))*(-(3-gamma)+m**2) - (2-gamma)*np.cos(phi)**2 * m * np.sin(m * (phi - phi_m)))
+        
+        f_xy_multi = term1_xy + term2_xy 
+
+
+        f_xx_epl,f_xy_epl,f_xy_epl,f_yy_epl=self._EPL.hessian(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+
+
+        f_xx=f_xx_epl+f_xx_multi
+        f_xy=f_xy_epl+f_xy_multi
+        f_yy=f_yy_epl+f_yy_multi
+
+
+
+        return f_xx, f_xy, f_xy, f_yy
+
+    def density_lens(self, *args, **kwargs):
+        """Computes the density at 3d radius r given lens model parameterization. The
+        integral in the LOS projection of this quantity results in the convergence
+        quantity. (optional definition)
+
+        .. math::
+            \\kappa(x, y) = \\int_{-\\infty}^{\\infty} \\rho(x, y, z) dz
+
+        :param kwargs: keywords of the profile
+        :return: raise as definition is not defined
+        """
+        raise ValueError(
+            "density_lens definition is not defined in the profile you want to execute."
+        )
+
+    def mass_3d_lens(self, *args, **kwargs):
+        """Mass enclosed within a 3D sphere or radius r given a lens parameterization
+        with angular units. The input parameter are identical as for the derivatives
+        definition. (optional definition)
+
+        :param kwargs: keywords of the profile
+        :return: raise as definition is not defined
+        """
+        raise ValueError(
+            "mass_3d_lens definition is not defined in the profile you want to execute."
+        )
+
+    def mass_2d_lens(self, *args, **kwargs):
+        """Two-dimensional enclosed mass at radius r (optional definition)
+
+        .. math::
+            M_{2d}(R) = \\int_{0}^{R} \\rho_{2d}(r) 2\\pi r dr
+
+        with :math:`\\rho_{2d}(r)` is the density_2d_lens() definition
+
+        The mass definition is such that:
+
+        .. math::
+            \\alpha = mass_2d / r / \\pi
+
+        with alpha is the deflection angle
+
+        :param kwargs: keywords of the profile
+        :return: raise as definition is not defined
+        """
+        raise ValueError(
+            "mass_2d_lens definition is not defined in the profiel you want to execute."
+        )
+
+    def set_static(self, **kwargs):
+        """Pre-computes certain computations that do only relate to the lens model
+        parameters and not to the specific position where to evaluate the lens model.
+
+        :param kwargs: lens model parameters
+        :return: no return, for certain lens model some private self variables are
+            initiated
+        """
+        pass
+
+    def set_dynamic(self):
+        """
+
+        :return: no return, deletes pre-computed variables for certain lens models
+        """
+        pass
+
+
+class EPL_PMultipol_qphi(LensProfileBase):
+    """This class contains a EPL+PLMultipole contribution over q and phi instead of e1,e2.
+    The PLMultipole is an extention to the parametrization of Chu et al.(2013) (https://arxiv.org/abs/1302.5482). The equation is Eq. (8) from Nightingale et al. (2023) (https://arxiv.org/abs/2209.10566)
+    It scales the contribution of the multipoles with the same power-law as the EPL.  It is defined with a prefactor 1/2 and the einstein radius theta_e in order to achieve k = theta_E / 2theta as the m=0
+    contribution (Reason stated in Chu et al.(2013) (https://arxiv.org/abs/1302.5482) Eq. (3)).
+
+
+    theta_E : float, Einstein radius
+    gamma : float, power-law slope
+    q: axis ratio
+    phi: position angle
+    m : int, multipole order, m>=2
+    k_m : float, multipole strength and sqrt (a_m^2+b_m^2) of old definition.
+    phi_m : float, multipole orientation in radian
+    center_x: x-position
+    center_y: y-position
+    """
+
+    param_names = ["theta_E", "gamma", "q", "m", "k_m", "phi_m","phi", "center_x", "center_y"]
+    lower_limit_default = {
+        "theta_E": 0,
+        "gamma": 1.5,
+        "q": 0,
+        "m": 0,
+        "k_m": 0,
+        "phi_m": -np.pi,
+        "phi": -np.pi,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "theta_E": 100,
+        "gamma": 2.5,
+        "q": 1,
+        "m": 100,
+        "k_m": 100,
+        "phi_m": np.pi,
+        "phi": np.pi,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    def __init__(self):
+        self._epl = EPL()
+
+    def function(self, x, y, theta_E, gamma, q, m, phi, k_m, phi_m, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param gamma: power law slope
+        :param q: axis ratio
+        :param phi: position angle
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: lensing potential
+        """
+        e1, e2 = param_util.phi_q2_ellipticity(phi, q)
+        r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
+        f_multi = theta_E**(gamma-1)*k_m/((3-gamma)**2-m**2)*r**(3-gamma)*np.cos(m*(phi-phi_m))
+        f_epl = self._EPL.function(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+        f_=f_epl+f_multi
+        return f_
+
+    def derivatives(self, x, y, theta_E, gamma, q, phi, k_m ,m, phi_m, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param gamma: power law slope
+        :param q: axis ratio
+        :param phi: position angle
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: alpha_x, alpha_y
+        """
+        e1, e2 = param_util.phi_q2_ellipticity(phi, q)
+        r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
+        pre_factor=theta_E**(gamma-1)*k_m/((3-gamma)**2-m**2)
+        f_x_multi = pre_factor*(np.cos(phi)*r**(2-gamma)*np.cos(m*(phi-phi_m))+np.sin(phi)*r**(1-gamma)*m*np.sin(m*(phi-phi_m)))
+        f_y_multi = pre_factor*(np.sin(phi)*r**(2-gamma)*np.cos(m*(phi-phi_m))-np.cos(phi)*r**(1-gamma)*m*np.sin(m*(phi-phi_m)))
+        
+        f_x_epl, f_y_epl = self._EPL.derivatives(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+
+        f_x =f_x_epl+f_x_multi
+        f_y =f_y_epl+f_y_multi
+
+
+        return f_x,f_y
+
+    def hessian(self, x, y, theta_E, gamma, q, phi, k_m ,m, phi_m, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinate in image plane
+        :param y: y-coordinate in image plane
+        :param theta_E: Einstein radius
+        :param gamma: power law slope
+        :param q: axis ratio
+        :param phi: position angle
+        :param center_x: profile center
+        :param center_y: profile center
+        :return: f_xx, f_xy, f_yx, f_yy
+        """
+        e1, e2 = param_util.phi_q2_ellipticity(phi, q)
+
+        r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
+        pre_factor=theta_E**(gamma-1)*k_m/((3-gamma)**2-m**2)
+
+        term1_xx =  pre_factor * r**(1-gamma) * (2 - gamma)*np.cos(phi)*(np.cos(phi) * (3-gamma)*np.cos(m * (phi - phi_m))+ np.sin(phi)*m*np.sin(m * (phi - phi_m)))
+        term2_xx = pre_factor * r**(1-gamma) * (np.sin(phi)**2*np.cos(m * (phi - phi_m))*((3-gamma)-m**2) + (2-gamma)*np.cos(phi)* np.sin(phi) * m * np.sin(m * (phi - phi_m)))
+        f_xx_multi = term1_xx+term2_xx
+
+
+        term1_yy = pre_factor * r**(1-gamma) * (2 - gamma)*np.sin(phi)*(np.sin(phi) * (3-gamma)*np.cos(m * (phi - phi_m))- np.cos(phi)*m*np.sin(m * (phi - phi_m)))
+
+        term2_yy = pre_factor * r**(1-gamma) * (np.cos(phi)**2*np.cos(m * (phi - phi_m))*((3-gamma)-m**2) - (2-gamma)*np.cos(phi)* np.sin(phi) * m * np.sin(m * (phi - phi_m)))
+        
+        f_yy_multi = term1_yy + term2_yy 
+
+        # Term calculations
+        term1_xy = pre_factor * r**(1-gamma) * (2 - gamma)*np.sin(phi)*(np.cos(phi) * (3-gamma)*np.cos(m * (phi - phi_m))+ np.sin(phi)*m*np.sin(m * (phi - phi_m)))
+
+        term2_xy = pre_factor * r**(1-gamma) * (np.sin(phi)*np.cos(phi)*np.cos(m * (phi - phi_m))*(-(3-gamma)+m**2) - (2-gamma)*np.cos(phi)**2 * m * np.sin(m * (phi - phi_m)))
+        
+        f_xy_multi = term1_xy + term2_xy 
+
+
+        f_xx_epl,f_xy_epl,f_xy_epl,f_yy_epl=self._EPL.hessian(x, y, theta_E, gamma, e1, e2, center_x, center_y)
+
+
+        f_xx=f_xx_epl+f_xx_multi
+        f_xy=f_xy_epl+f_xy_multi
+        f_yy=f_yy_epl+f_yy_multi
+
+
+
+        return f_xx, f_xy, f_xy, f_yy
+
+    def density_lens(self, *args, **kwargs):
+        """Computes the density at 3d radius r given lens model parameterization. The
+        integral in the LOS projection of this quantity results in the convergence
+        quantity. (optional definition)
+
+        .. math::
+            \\kappa(x, y) = \\int_{-\\infty}^{\\infty} \\rho(x, y, z) dz
+
+        :param kwargs: keywords of the profile
+        :return: raise as definition is not defined
+        """
+        raise ValueError(
+            "density_lens definition is not defined in the profile you want to execute."
+        )
+
+    def mass_3d_lens(self, *args, **kwargs):
+        """Mass enclosed within a 3D sphere or radius r given a lens parameterization
+        with angular units. The input parameter are identical as for the derivatives
+        definition. (optional definition)
+
+        :param kwargs: keywords of the profile
+        :return: raise as definition is not defined
+        """
+        raise ValueError(
+            "mass_3d_lens definition is not defined in the profile you want to execute."
+        )
+
+    def mass_2d_lens(self, *args, **kwargs):
+        """Two-dimensional enclosed mass at radius r (optional definition)
+
+        .. math::
+            M_{2d}(R) = \\int_{0}^{R} \\rho_{2d}(r) 2\\pi r dr
+
+        with :math:`\\rho_{2d}(r)` is the density_2d_lens() definition
+
+        The mass definition is such that:
+
+        .. math::
+            \\alpha = mass_2d / r / \\pi
+
+        with alpha is the deflection angle
+
+        :param kwargs: keywords of the profile
+        :return: raise as definition is not defined
+        """
+        raise ValueError(
+            "mass_2d_lens definition is not defined in the profiel you want to execute."
+        )
+
+    def set_static(self, **kwargs):
+        """Pre-computes certain computations that do only relate to the lens model
+        parameters and not to the specific position where to evaluate the lens model.
+
+        :param kwargs: lens model parameters
+        :return: no return, for certain lens model some private self variables are
+            initiated
+        """
+        pass
+
+    def set_dynamic(self):
+        """
+
+        :return: no return, deletes pre-computed variables for certain lens models
+        """
+        pass

--- a/lenstronomy/LensModel/Profiles/epl_powermulitpole.py
+++ b/lenstronomy/LensModel/Profiles/epl_powermulitpole.py
@@ -5,8 +5,6 @@ import lenstronomy.Util.util as util
 import lenstronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from lenstronomy.LensModel.Profiles.epl import EPL
-from lenstronomy.LensModel.Profiles.spp import SPP
-from scipy.special import hyp2f1
 
 __all__ = ["EPL_PMULTIPOL","EPL_PMULTIPOL_QPHI"]
 

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -34,6 +34,8 @@ _SUPPORTED_MODELS = [
     "EPL_MULTIPOLE_M3M4_ELL",
     "EPL_MULTIPOLE_M3M4",
     "EPL_NUMBA",
+    "EPL_PMULTIPOL",
+    "EPL_PMULTIPOL_QPHI",
     "EPL_Q_PHI",
     "ElliSLICE",
     "FLEXION",
@@ -397,6 +399,14 @@ def lens_class(
         from lenstronomy.LensModel.Profiles.epl import EPLQPhi
 
         return EPLQPhi()
+    elif lens_type == "EPL_PMULTIPOL":
+        from lenstronomy.LensModel.Profiles.epl_powermultipole import EPL_PMultipol
+
+        return EPL_PMultipol()
+    elif lens_type == "EPL_PMULTIPOL_QPHI":
+        from lenstronomy.LensModel.Profiles.epl_powermultipole import EPL_PMultipol_qphi
+
+        return EPL_PMultipol_qphi()
     elif lens_type == "ElliSLICE":
         from lenstronomy.LensModel.Profiles.elliptical_density_slice import (
             ElliSLICE,

--- a/test/test_LensModel/test_Profiles/test_epl_powermultipole.py
+++ b/test/test_LensModel/test_Profiles/test_epl_powermultipole.py
@@ -1,0 +1,70 @@
+__author__ = "eckerl"
+
+
+import numpy as np
+import pytest
+import numpy.testing as npt
+from lenstronomy.LensModel.Profiles.epl_powermultipole import EPL_PMultipol
+from lenstronomy.LensModel.Profiles.epl import EPL
+from lenstronomy.Util import util
+
+class EPL_PMultipolTest(object):
+    """Test analytical kappa vs kappa from Hessian (0.5 * (f_xx + f_yy))."""
+
+    def setup_method(self):
+        # Define parameters for the EPL_PMultipol profile
+        self.lens_model = EPL_PMultipol() 
+        self.epl=EPL() # Correct profile here
+        self.theta_E = 1.0
+        self.gamma = 2.0
+        self.k_m = 0.1
+        self.m = 4
+        self.phi_m = np.pi / 4
+        self.e1 = 0.0  # Example value for eccentricity
+        self.e2 = 0.0  # Example value for eccentricity
+
+    def analytical_kappa(self, x, y):
+        """Compute analytical kappa."""
+        r = np.sqrt(x**2 + y**2)
+        phi = np.arctan2(y, x)
+
+        if r == 0:
+            raise ValueError("Kappa is not defined at r = 0")
+
+        kappa = 0.5 * (self.theta_E / r)**(self.gamma - 1) * self.k_m * np.cos(self.m * (phi - self.phi_m))+(3-self.gamma)/2*(self.theta_E/r)**(self.gamma-1)
+        return kappa
+
+    def test_kappa_comparison(self):
+        """Test analytical kappa vs kappa from Hessian."""
+        test_points = [(1, 2), (-0.5, 0.8), (0.5, -0.5), (-1, -1)]
+        kwargs = {
+            "theta_E": self.theta_E,
+            "gamma": self.gamma,
+            "e1": self.e1,
+            "e2": self.e2,
+            "m": self.m,
+            "k_m": self.k_m,
+            "phi_m": self.phi_m,
+        }
+
+        for i, (x_i, y_i) in enumerate(test_points):
+            if np.sqrt(x_i**2 + y_i**2) > 0.1:  # Avoid division by zero
+                # Compute analytical kappa
+                kappa_analytical = self.analytical_kappa(x_i, y_i)
+
+                # Compute numerical f_xx, f_xy, f_yy using EPL_PMultipol
+                f_xx, f_xy, _, f_yy = self.lens_model.hessian(x_i, y_i, **kwargs)
+
+                # Compute numerical kappa
+                kappa_numerical = 0.5 * (f_xx + f_yy)
+
+                # Compare analytical and numerical kappa
+                npt.assert_almost_equal(
+                    kappa_analytical, kappa_numerical, decimal=4,
+                    err_msg=f"Kappa mismatch at (x, y) = ({x_i}, {y_i})"
+                )
+
+                print(
+                    f"Point {i+1}: (x, y) = ({x_i}, {y_i}), "
+                    f"Relative Difference Kappa = {np.abs(kappa_analytical - kappa_numerical) / np.abs(kappa_analytical):.4e}"
+                )


### PR DESCRIPTION
A new combined profile of EPL+powerlawmultipole. 

The PLMultipole is an extention to the parametrization of Chu et al.(2013) (https://arxiv.org/abs/1302.5482). The equation used is Eq. (8) from Nightingale et al. (2023) (https://arxiv.org/abs/2209.10566)
It scales the contribution of the multipoles with the same power-law as the EPL.  It is defined with a prefactor 1/2 and the einstein radius theta_e in order to achieve k = theta_E / 2theta as the m=0 contribution (Reason stated in Chu et al.(2013) (https://arxiv.org/abs/1302.5482) Eq. (3)) The Multipole definition before is only valid in the isothermal case and should only be used with isothermal profiles. This is a profile which is already the combination of an EPL+PLMultipol and not its own multipole profile.