### PR TITLE
Use distance ratio betas instead of a and b ratios for sampling free parameters in multi-lens-plane

### DIFF
--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -3,6 +3,7 @@ import warnings
 from astropy.cosmology import *
 from lenstronomy.Cosmo.background import Background
 from lenstronomy.ImSim.multiplane_organizer import MultiPlaneOrganizer
+from lenstronomy.Util.cosmo_util import get_cosmology
 
 __all__ = ["Image2SourceMapping"]
 
@@ -178,43 +179,6 @@ class Image2SourceMapping(object):
         plane."""
         self._T_ij_end_list = T_ij_end_list
 
-    @staticmethod
-    def _get_cosmo(cosmology_model, kwargs_special):
-        """Returns the cosmology instance.
-
-        :param cosmology_model: str, name of the cosmology model
-        :param kwargs_special: keyword arguments for the cosmology model
-        :return: astropy.cosmology instance
-        """
-        H0 = kwargs_special.get("H0", 70)
-        Om0 = kwargs_special.get("Om0", 0.3)
-        Ode0 = kwargs_special.get("Ode0", 0.7)
-        w0 = kwargs_special.get("w0", -1)
-        wa = kwargs_special.get("wa", 0)
-
-        supported_models = [
-            "FlatLambdaCDM",
-            "LambdaCDM",
-            "FlatwCDM",
-            "wCDM",
-            "Flatw0waCDM",
-            "w0waCDM",
-        ]
-        cosmo_classes = [FlatLambdaCDM, LambdaCDM, FlatwCDM, wCDM, Flatw0waCDM, w0waCDM]
-        cosmo_kwargs = [
-            {"H0": H0, "Om0": Om0},
-            {"H0": H0, "Om0": Om0, "Ode0": Ode0},
-            {"H0": H0, "Om0": Om0, "w0": w0},
-            {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0},
-            {"H0": H0, "Om0": Om0, "w0": w0, "wa": wa},
-            {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0, "wa": wa},
-        ]
-
-        index = supported_models.index(cosmology_model)
-        cosmo = cosmo_classes[index](**cosmo_kwargs[index])
-
-        return cosmo
-
     def image2source(self, x, y, kwargs_lens, index_source, kwargs_special=None):
         """
         mapping of image plane to source plane coordinates
@@ -272,7 +236,7 @@ class Image2SourceMapping(object):
             )
 
         if self._cosmology_sampling:
-            cosmo = self._get_cosmo(
+            cosmo = get_cosmology(
                 self._lens_model.lens_model.cosmology_model, kwargs_special
             )
             self.set_background_cosmo(cosmo)

--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -1,6 +1,4 @@
 import numpy as np
-import warnings
-from astropy.cosmology import *
 from lenstronomy.Cosmo.background import Background
 from lenstronomy.ImSim.multiplane_organizer import MultiPlaneOrganizer
 from lenstronomy.Util.cosmo_util import get_cosmology

--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -1,7 +1,7 @@
 import numpy as np
 from lenstronomy.Cosmo.background import Background
 from lenstronomy.ImSim.multiplane_organizer import MultiPlaneOrganizer
-from lenstronomy.Util.cosmo_util import get_astropy_cosmo
+from lenstronomy.Util.cosmo_util import get_astropy_cosmology
 
 __all__ = ["Image2SourceMapping"]
 
@@ -234,7 +234,7 @@ class Image2SourceMapping(object):
             )
 
         if self._cosmology_sampling:
-            cosmo = get_astropy_cosmo(
+            cosmo = get_astropy_cosmology(
                 self._lens_model.lens_model.cosmology_model, kwargs_special
             )
             self.set_background_cosmo(cosmo)

--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -210,11 +210,6 @@ class Image2SourceMapping(object):
             {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0, "wa": wa},
         ]
 
-        if cosmology_model not in supported_models:
-            raise ValueError(
-                f"cosmology model {cosmology_model} not supported! Choose between {supported_models}."
-            )
-
         index = supported_models.index(cosmology_model)
         cosmo = cosmo_classes[index](**cosmo_kwargs[index])
 

--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+from astropy.cosmology import *
 from lenstronomy.Cosmo.background import Background
 from lenstronomy.ImSim.multiplane_organizer import MultiPlaneOrganizer
 
@@ -38,6 +40,7 @@ class Image2SourceMapping(object):
         light_model_list = source_model.profile_type_list
         self._multi_lens_plane = lens_model.multi_plane
         self._distance_ratio_sampling = False
+        self._cosmology_sampling = False
 
         # sort out source redshifts in the multi-lens-plane case
         if self._multi_lens_plane:
@@ -48,6 +51,9 @@ class Image2SourceMapping(object):
             else:
                 self._source_redshift_list = source_model.redshift_list
             self._lens_redshift_list = self._lens_model.redshift_list
+
+            if self._lens_model.lens_model.cosmology_sampling:
+                self._cosmology_sampling = True
 
             if self._lens_model.lens_model.distance_ratio_sampling:
                 self._distance_ratio_sampling = True
@@ -90,26 +96,10 @@ class Image2SourceMapping(object):
                 self._sorted_source_redshift_index = self._index_ordering(
                     self._source_redshift_list
                 )
-
                 self._T0z_list = []
-                for z_stop in self._source_redshift_list:
-                    self._T0z_list.append(self._bkg_cosmo.T_xy(0, z_stop))
-                z_start = 0
                 self._T_ij_start_list = []
                 self._T_ij_end_list = []
-                for i, index_source in enumerate(self._sorted_source_redshift_index):
-                    z_stop = self._source_redshift_list[index_source]
-
-                    (
-                        T_ij_start,
-                        T_ij_end,
-                    ) = self._lens_model.lens_model.transverse_distance_start_stop(
-                        z_start, z_stop, include_z_start=False
-                    )
-
-                    self._T_ij_start_list.append(T_ij_start)
-                    self._T_ij_end_list.append(T_ij_end)
-                    z_start = z_stop
+                self.set_T_ij_arrays()
         else:
             if self._deflection_scaling_list is None:
                 self._multi_source_plane = False
@@ -132,6 +122,37 @@ class Image2SourceMapping(object):
                 self._lens_model.lens_model.z_source_convention,
                 self._bkg_cosmo,
             )
+
+    def set_T_ij_arrays(self):
+        """Sets the transverse distance arrays for the multi-lens-plane case."""
+        self._T0z_list = []
+
+        for z_stop in self._source_redshift_list:
+            self._T0z_list.append(self._bkg_cosmo.T_xy(0, z_stop))
+
+        z_start = 0
+        self._T_ij_start_list = []
+        self._T_ij_end_list = []
+
+        for i, index_source in enumerate(self._sorted_source_redshift_index):
+            z_stop = self._source_redshift_list[index_source]
+
+            (
+                T_ij_start,
+                T_ij_end,
+            ) = self._lens_model.lens_model.transverse_distance_start_stop(
+                z_start, z_stop, include_z_start=False
+            )
+
+            self._T_ij_start_list.append(T_ij_start)
+            self._T_ij_end_list.append(T_ij_end)
+            z_start = z_stop
+
+    def set_background_cosmo(self, cosmo):
+        """Sets the cosmology for the multi-lens-plane case."""
+        self._lens_model.lens_model.set_background_cosmo(cosmo)
+        self._bkg_cosmo.cosmo = cosmo
+        self.set_T_ij_arrays()
 
     @property
     def T_ij_start_list(self):
@@ -157,6 +178,41 @@ class Image2SourceMapping(object):
         plane."""
         self._T_ij_end_list = T_ij_end_list
 
+    @staticmethod
+    def _get_cosmo(cosmology_model, kwargs_special):
+        """Returns the cosmology instance.
+
+        :param cosmology_model: str, name of the cosmology model
+        :param kwargs_special: keyword arguments for the cosmology model
+        :return: astropy.cosmology instance
+        """
+        H0 = kwargs_special.get("H0", 70)
+        Om0 = kwargs_special.get("Om0", 0.3)
+        Ode0 = kwargs_special.get("Ode0", 0.7)
+        w0 = kwargs_special.get("w0", -1)
+        wa = kwargs_special.get("wa", 0)
+
+        supported_models = ["FlatLambdaCDM", "LambdaCDM", "FlatwCDM", "wCDM", "Flatw0waCDM", "w0waCDM"]
+        cosmo_classes = [FlatLambdaCDM, LambdaCDM, FlatwCDM, wCDM, Flatw0waCDM, w0waCDM]
+        cosmo_kwargs = [
+            {"H0": H0, "Om0": Om0},
+            {"H0": H0, "Om0": Om0, "Ode0": Ode0},
+            {"H0": H0, "Om0": Om0, "w0": w0},
+            {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0},
+            {"H0": H0, "Om0": Om0, "w0": w0, "wa": wa},
+            {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0, "wa": wa},
+        ]
+
+        if cosmology_model not in supported_models:
+            raise ValueError(
+                f"cosmology model {cosmology_model} not supported! Choose between {supported_models}."
+            )
+        
+        index = supported_models.index(cosmology_model)
+        cosmo = cosmo_classes[index](**cosmo_kwargs[index])
+        
+        return cosmo
+
     def image2source(self, x, y, kwargs_lens, index_source, kwargs_special=None):
         """
         mapping of image plane to source plane coordinates
@@ -169,13 +225,7 @@ class Image2SourceMapping(object):
         :param index_source: int, index of source model
         :return: source plane coordinate corresponding to the source model of index index_source
         """
-        if self._distance_ratio_sampling:
-            self.multi_plane_organizer.update_lens_T_lists(
-                self._lens_model, kwargs_special
-            )
-            self.multi_plane_organizer.update_source_mapping_T_lists(
-                self, kwargs_special
-            )
+        self.update_distances(kwargs_special)
 
         if self._multi_source_plane is False:
             x_source, y_source = self._lens_model.ray_shooting(x, y, kwargs_lens)
@@ -208,6 +258,21 @@ class Image2SourceMapping(object):
 
         return x_source, y_source
 
+    def update_distances(self, kwargs_special):
+        """Updates the distances for the multi-lens-plane case if distance_ratio_sampling or cosmology_sampling is True.
+        """
+        if self._distance_ratio_sampling:
+            self.multi_plane_organizer.update_lens_T_lists(
+                self._lens_model, kwargs_special
+            )
+            self.multi_plane_organizer.update_source_mapping_T_lists(
+                self, kwargs_special
+            )
+        
+        if self._cosmology_sampling:
+            cosmo = self._get_cosmo(self._lens_model.lens_model.cosmology_model, kwargs_special)
+            self.set_background_cosmo(cosmo)
+
     def image_flux_joint(
         self, x, y, kwargs_lens, kwargs_source, kwargs_special=None, k=None
     ):
@@ -222,13 +287,7 @@ class Image2SourceMapping(object):
         :return: surface brightness of all joint light components at image position (x,
             y)
         """
-        if self._distance_ratio_sampling:
-            self.multi_plane_organizer.update_lens_T_lists(
-                self._lens_model, kwargs_special
-            )
-            self.multi_plane_organizer.update_source_mapping_T_lists(
-                self, kwargs_special
-            )
+        self.update_distances(kwargs_special)
 
         if self._multi_source_plane is False:
             x_source, y_source = self._lens_model.ray_shooting(x, y, kwargs_lens)
@@ -293,13 +352,8 @@ class Image2SourceMapping(object):
         :return: list of responses of every single basis component with default
             amplitude amp=1, in the same order as the light_model_list
         """
-        if self._distance_ratio_sampling:
-            self.multi_plane_organizer.update_lens_T_lists(
-                self._lens_model, kwargs_special
-            )
-            self.multi_plane_organizer.update_source_mapping_T_lists(
-                self, kwargs_special
-            )
+        self.update_distances(kwargs_special)
+        
         if self._multi_source_plane is False:
             x_source, y_source = self._lens_model.ray_shooting(x, y, kwargs_lens)
             return self._light_model.functions_split(x_source, y_source, kwargs_source)

--- a/lenstronomy/ImSim/image2source_mapping.py
+++ b/lenstronomy/ImSim/image2source_mapping.py
@@ -1,7 +1,7 @@
 import numpy as np
 from lenstronomy.Cosmo.background import Background
 from lenstronomy.ImSim.multiplane_organizer import MultiPlaneOrganizer
-from lenstronomy.Util.cosmo_util import get_cosmology
+from lenstronomy.Util.cosmo_util import get_astropy_cosmo
 
 __all__ = ["Image2SourceMapping"]
 
@@ -234,7 +234,7 @@ class Image2SourceMapping(object):
             )
 
         if self._cosmology_sampling:
-            cosmo = get_cosmology(
+            cosmo = get_astropy_cosmo(
                 self._lens_model.lens_model.cosmology_model, kwargs_special
             )
             self.set_background_cosmo(cosmo)

--- a/lenstronomy/ImSim/multiplane_organizer.py
+++ b/lenstronomy/ImSim/multiplane_organizer.py
@@ -13,21 +13,19 @@ class MultiPlaneOrganizer(object):
     being the $P+1$-th plane), the effective Fermat potential is defined as (eq. 9 of Shajib et al. 2020):
 
     .. math::
-    \\phi^{\\rm eff} (\\theta) \\equiv \\sum_{i=1}^{P} \\frac{1+z_i}{1+z_{\\rm d}} \\frac{D_i D_{i+1} D_{\\rm ds}}{D_{\\rm d} D_{\\rm s}D_{i\\ i+1} } \\left[ \\frac{(\\theta_{i} - \\theta_{ i+1})^2}{2} - \\zeta_{i,i+1} \\psi_{i}(\\theta_{i})  \\right].
+    \\phi^{\\rm eff} (\\theta) \\equiv \\sum_{i=1}^{P} \\frac{1+z_i}{1+z_{\\rm d}} \\frac{D_i D_{i+1} D_{\\rm ds}}{D_{\\rm d} D_{\\rm s}D_{i\\ i+1} } \\left[ \\frac{(\\theta_{i} - \\theta_{ i+1})^2}{2} - \\beta_{i,i+1} \\psi_{i}(\\theta_{i})  \\right].
 
-    Then, the $a_i$ and $b_i$ distance ratios are defined as:
+    Satisfying $\\Delta \\phi^{\\rm eff} = 0$ will lead to the lens equation in the multiplane, where $\\beta_{ij}$ parameters are free parameters that are defined as:
 
     .. math::
-    a_i \\equiv \\frac{D_i D_{i+1} D_{1\\ P+1}}{D_{\\rm 1} D_{P+1}D_{i\\ i+1} } = \\frac{D_i D_{i+1}}{D_{i\\ i+1} D_{\\Delta t}^{\\rm eff}}
-    b_i \\equiv \\frac{D_i D_{1\\ P+1}}{D_1 D_{i\\ P+1}} = \\frac{D_i D_{P+1}}{D_{i\\ P+1} D_{\\Delta t}^{\\rm eff}}.
+    \\beta_{ij} \\equiv \\frac{D_{ij} D_{\\rm s}}{D_{j} D_{i\\rm s}}.
 
-    This class converts the $a_i$ and $b_i$ ratios to the relevant cosmological
-    distances needed for ray-tracing. However, instead of using $a_i$ and $b_i$,
-    lenstronomy uses factor_a and factor_b parameters that are defined using a
+    For $P$ lens planes, there are $\\rm{comb}(P, 2)$ number of $\\beta_{ij}$ parameters to track. This class converts the $\\beta_{ij}$ to the relevant cosmological
+    distances needed for ray-tracing. However, instead of sampling absolute values of $\\beta_{ij}$,
+    lenstronomy uses factor_beta parameters that are defined using a
     fiducial cosmology as follows:
 
-    factor_a_i = a_i / a_i_fiducial
-    factor_b_i = b_i / b_i_fiducial
+    factor_beta_ij = beta_ij / beta_ij_fiducial
     """
 
     def __init__(
@@ -73,9 +71,8 @@ class MultiPlaneOrganizer(object):
         # self._sorted_unique_lens_redshifts = sorted(list(set(
         #     lens_redshift_list)))
 
-        self.a_coeffs_fiducial = []
-        self.b_coeffs_fiducial = []
-        self._D_z_list_fiducial = []
+        self.betas_fiducial = []
+        self._D_z_list_fiducial = [] # D_z upto P lens planes, does not include the last source plane. D_s = _D_is_list_fiducial[0]
         self._D_is_list_fiducial = (
             []
         )  # distance between lens planes and the last (source) plane
@@ -100,50 +97,46 @@ class MultiPlaneOrganizer(object):
             self._cosmo_bkg.d_xy(0, self.z_source_convention)
         )
 
+        self._beta_ij_ordering_list = []
         for i in range(len(self._sorted_joint_unique_redshift_list) - 1):
             z_i = self._sorted_joint_unique_redshift_list[i]
-            z_ip1 = self._sorted_joint_unique_redshift_list[i + 1]
+            # z_ip1 = self._sorted_joint_unique_redshift_list[i + 1]
 
             self._D_z_list_fiducial.append(self._cosmo_bkg.d_xy(0, z_i))
             self._D_is_list_fiducial.append(
                 self._cosmo_bkg.d_xy(z_i, self.z_source_convention)
             )
 
-            self.a_coeffs_fiducial.append(
-                self._cosmo_bkg.d_xy(0, z_i)
-                * self._cosmo_bkg.d_xy(0, z_ip1)
-                / self._cosmo_bkg.d_xy(z_i, z_ip1)
-                / self.D_dt_eff_fiducial
-            )
-            self.b_coeffs_fiducial.append(
-                self._cosmo_bkg.d_xy(0, z_i)
-                * D_s
-                / self._cosmo_bkg.d_xy(z_i, z_source_convention)
-                / self.D_dt_eff_fiducial
-            )
+            if i > 0:
+                for k in range(i):
+                    z_k = self._sorted_joint_unique_redshift_list[k]
+                    self.betas_fiducial.append(
+                        self._cosmo_bkg.d_xy(z_k, z_i)
+                        * D_s
+                        / self._cosmo_bkg.d_xy(z_k, z_source_convention)
+                        / self._cosmo_bkg.d_xy(0, z_i)
+                    )
+                    self._beta_ij_ordering_list.append(f"{k}_{i}")
 
         self._D_z_list_fiducial.append(
             self._cosmo_bkg.d_xy(0, self.z_source_convention)
         )
 
-    def _extract_a_b_factors(self, kwargs_special):
+    def _extract_beta_factors(self, kwargs_special):
         """Extracts the a and b factors from the kwargs_special dictionary.
 
         :param kwargs_special: dictionary of special keyword arguments
         :type kwargs_special: dict
-        :return: a_factors, b_factors
-        :rtype: list, list
+        :return: beta_factors
+        :rtype: list
         """
-        a_factors = []
-        b_factors = [1.0]
+        beta_factors = []
 
-        for i in range(1, self._num_lens_planes + 1):
-            a_factors.append(kwargs_special["factor_a_{}".format(i)])
-        for i in range(2, self._num_lens_planes):
-            b_factors.append(kwargs_special["factor_b_{}".format(i)])
-        b_factors.append(a_factors[-1])
+        for j in range(1, self._num_lens_planes+1):
+            for i in range(j):
+                beta_factors.append(kwargs_special["factor_beta_{}_{}".format(i, j)])
 
-        return a_factors, b_factors
+        return beta_factors
 
     def update_lens_T_lists(self, lens_model, kwargs_special):
         """Updates the lens model's `T_ij`, `T_ij_start`, `T_ij_stop`, and `T_z lists`.
@@ -195,8 +188,7 @@ class MultiPlaneOrganizer(object):
         return index
 
     def _get_lens_T_lists(self, kwargs_special):
-        """Retreive the lens model's `T_ij` and `T_z` lists for a given set of a_factors
-        and b_factors.
+        """Retreive the lens model's `T_ij` and `T_z` lists for a given set of beta_factors.
 
         :param kwargs_special: dictionary of special keyword arguments
         :type kwargs_special: dict
@@ -225,7 +217,7 @@ class MultiPlaneOrganizer(object):
 
     def _get_D_ij(self, z_i, z_j, kwargs_special):
         """Returns the transverse distance between two redshifts for a given set of
-        a_factors and b_factors.
+        beta_factors.
 
         :param z_i: redshift of first plane
         :type z_i: float
@@ -241,55 +233,25 @@ class MultiPlaneOrganizer(object):
         elif z_i == z_j:
             return 0.0
         elif z_j == self._sorted_joint_unique_redshift_list[-1]:
-            ab_fiducial_index = self._get_element_index(
+            i_fiducial_index = self._get_element_index(
                 self._sorted_joint_unique_redshift_list, z_i
             )
-            return self._D_is_list_fiducial[ab_fiducial_index + 1]
+            return self._D_is_list_fiducial[i_fiducial_index + 1]
 
-        a_factors, b_factors = self._extract_a_b_factors(kwargs_special)
-        ab_fiducial_index = self._get_element_index(
-            self._sorted_joint_unique_redshift_list, z_j
-        )
+        beta_factors = self._extract_beta_factors(kwargs_special)
+        i_fiducial_index = self._get_element_index(self._sorted_joint_unique_redshift_list, z_i)
+        j_fiducial_index = self._get_element_index(self._sorted_joint_unique_redshift_list, z_j)
+        ij_fiducial_index = self._get_element_index(self._beta_ij_ordering_list, f"{i_fiducial_index}_{j_fiducial_index}")
+        
+        D_j = self._D_z_list_fiducial[j_fiducial_index]
+        D_s = self._D_is_list_fiducial[0]
+        D_is = self._D_is_list_fiducial[i_fiducial_index]
 
-        b_j = b_factors[ab_fiducial_index] * self.b_coeffs_fiducial[ab_fiducial_index]
-        D_j = (
-            b_j
-            * self._D_is_list_fiducial[ab_fiducial_index + 1]
-            * self.D_dt_eff_fiducial
-            / self._D_is_list_fiducial[0]
-        )
+        beta_ij = beta_factors[ij_fiducial_index] * self.betas_fiducial[ij_fiducial_index]
 
-        if ab_fiducial_index == 0:
-            raise ValueError("The code should not come here!")
-            # return D_j
-        else:
-            ab_fiducial_index_m1 = self._get_element_index(
-                self._sorted_joint_unique_redshift_list, z_i
-            )
-            assert ab_fiducial_index_m1 == ab_fiducial_index - 1
+        D_ij  = beta_ij * D_j * D_is / D_s
 
-            a_j = (
-                a_factors[ab_fiducial_index] * self.a_coeffs_fiducial[ab_fiducial_index]
-            )
-            a_i = (
-                a_factors[ab_fiducial_index - 1]
-                * self.a_coeffs_fiducial[ab_fiducial_index - 1]
-            )
-
-            b_i = (
-                b_factors[ab_fiducial_index - 1]
-                * self.b_coeffs_fiducial[ab_fiducial_index - 1]
-            )
-            D_i = (
-                b_i
-                * self._D_is_list_fiducial[ab_fiducial_index]
-                * self.D_dt_eff_fiducial
-                / self._D_is_list_fiducial[0]
-            )
-
-            D_ij = D_j * D_i / a_i / self.D_dt_eff_fiducial
-
-            return D_ij
+        return D_ij
 
     def _get_D_i(self, z_i, kwargs_special):
         """"""
@@ -298,21 +260,8 @@ class MultiPlaneOrganizer(object):
         elif z_i == self._sorted_joint_unique_redshift_list[-1]:
             return self._D_is_list_fiducial[0]
 
-        a_factors, b_factors = self._extract_a_b_factors(kwargs_special)
-
-        ab_fiducial_index = self._get_element_index(
-            self._sorted_joint_unique_redshift_list, z_i
-        )
-
-        b_i = b_factors[ab_fiducial_index] * self.b_coeffs_fiducial[ab_fiducial_index]
-        D_i = (
-            b_i
-            * self._D_is_list_fiducial[ab_fiducial_index + 1]
-            * self.D_dt_eff_fiducial
-            / self._D_is_list_fiducial[0]
-        )
-
-        return D_i
+        i_index  = self._get_element_index(self._sorted_joint_unique_redshift_list, z_i)
+        return self._D_z_list_fiducial[i_index]
 
     def _transverse_distance_start_stop(
         self, z_start, z_stop, kwargs_special, include_z_start=False

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -167,6 +167,7 @@ class MultiPlane(object):
             kwargs_interp=kwargs_interp,
             kwargs_synthesis=kwargs_synthesis,
         )
+        self._z_source = z_source
         self._set_source_distances(z_source)
         self._observed_convention_index = observed_convention_index
         if observed_convention_index is None:
@@ -237,6 +238,15 @@ class MultiPlane(object):
             z_start=0, z_stop=z_source, include_z_start=False
         )
         self._T_z_source = self._multi_plane_base._cosmo_bkg.T_xy(0, z_source)
+
+    def set_background_cosmo(self, cosmo):
+        """Set the background cosmology.
+
+        :param cosmo: instance of astropy.cosmology
+        :return: None
+        """
+        self._multi_plane_base.set_background_cosmo(cosmo)
+        self._set_source_distances(self._z_source)
 
     def observed2flat_convention(self, kwargs_lens):
         """

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -2,7 +2,7 @@ import numpy as np
 from copy import deepcopy
 from lenstronomy.LensModel.MultiPlane.multi_plane_base import MultiPlaneBase
 from lenstronomy.Util.package_util import exporter
-from lenstronomy.Util.cosmo_util import get_astropy_cosmo
+from lenstronomy.Util.cosmo_util import get_astropy_cosmology
 from astropy.cosmology import *
 import warnings
 
@@ -69,7 +69,7 @@ class MultiPlane(object):
         self.cosmology_sampling = cosmology_sampling
         self.cosmology_model = cosmology_model
         if self.cosmology_sampling:
-            cosmo = get_astropy_cosmo(cosmology_model=cosmology_model)
+            cosmo = get_astropy_cosmology(cosmology_model=cosmology_model)
 
             if distance_ratio_sampling:
                 warnings.warn(

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -65,9 +65,9 @@ class MultiPlane(object):
         :param cosmology_sampling: bool, if True, will use sampled cosmology
         :param cosmology_model: str, name of the cosmology model to use for
         """
-        if cosmology_sampling:
-            self.cosmology_model = cosmology_model
-
+        self.cosmology_sampling = cosmology_sampling
+        self.cosmology_model = cosmology_model
+        if self.cosmology_sampling:
             supported_cosmologies = [
                 "FlatLambdaCDM",
                 "LambdaCDM",

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -2,6 +2,7 @@ import numpy as np
 from copy import deepcopy
 from lenstronomy.LensModel.MultiPlane.multi_plane_base import MultiPlaneBase
 from lenstronomy.Util.package_util import exporter
+from lenstronomy.Util.cosmo_util import get_cosmology
 from astropy.cosmology import *
 import warnings
 
@@ -68,38 +69,7 @@ class MultiPlane(object):
         self.cosmology_sampling = cosmology_sampling
         self.cosmology_model = cosmology_model
         if self.cosmology_sampling:
-            supported_cosmologies = [
-                "FlatLambdaCDM",
-                "LambdaCDM",
-                "FlatwCDM",
-                "wCDM",
-                "Flatw0waCDM",
-                "w0waCDM",
-            ]
-
-            if cosmology_model not in supported_cosmologies:
-                raise ValueError(
-                    f"cosmology model {cosmology_model} not supported! Choose between {supported_cosmologies}."
-                )
-            index = supported_cosmologies.index(cosmology_model)
-            cosmo_classes = [
-                FlatLambdaCDM,
-                LambdaCDM,
-                FlatwCDM,
-                wCDM,
-                Flatw0waCDM,
-                w0waCDM,
-            ]
-            cosmo_kwargs = [
-                {"H0": 70, "Om0": 0.3},
-                {"H0": 70, "Om0": 0.3, "Ode0": 0.7},
-                {"H0": 70, "Om0": 0.3, "w0": -1},
-                {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -1},
-                {"H0": 70, "Om0": 0.3, "w0": -1, "wa": 0},
-                {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -1, "wa": 0},
-            ]
-
-            cosmo = cosmo_classes[index](**cosmo_kwargs[index])
+            cosmo = get_cosmology(cosmology_model=cosmology_model)
 
             if distance_ratio_sampling:
                 warnings.warn(

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -2,7 +2,7 @@ import numpy as np
 from copy import deepcopy
 from lenstronomy.LensModel.MultiPlane.multi_plane_base import MultiPlaneBase
 from lenstronomy.Util.package_util import exporter
-from lenstronomy.Util.cosmo_util import get_cosmology
+from lenstronomy.Util.cosmo_util import get_astropy_cosmo
 from astropy.cosmology import *
 import warnings
 
@@ -69,7 +69,7 @@ class MultiPlane(object):
         self.cosmology_sampling = cosmology_sampling
         self.cosmology_model = cosmology_model
         if self.cosmology_sampling:
-            cosmo = get_cosmology(cosmology_model=cosmology_model)
+            cosmo = get_astropy_cosmo(cosmology_model=cosmology_model)
 
             if distance_ratio_sampling:
                 warnings.warn(

--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -40,6 +40,8 @@ class MultiPlaneBase(ProfileListBase):
          See description in the Interpolate() class. Only applicable for 'INTERPOL' and 'INTERPOL_SCALED' models.
         :param kwargs_synthesis: keyword arguments for the 'SYNTHESIS' lens model, if applicable
         """
+        self._lens_model_list = lens_model_list
+
         if z_interp_stop is None:
             z_interp_stop = z_source_convention
         self._cosmo_bkg = Background(
@@ -54,14 +56,14 @@ class MultiPlaneBase(ProfileListBase):
                     "reduced lens model quantities not allowed (leads to negative reduced deflection "
                     "angles!" % (z_lens_max, z_source_convention)
                 )
-        if not len(lens_model_list) == len(lens_redshift_list):
+        if not len(self._lens_model_list) == len(lens_redshift_list):
             raise ValueError(
                 "The length of lens_model_list does not correspond to redshift_list"
             )
 
         self._lens_redshift_list = lens_redshift_list
         super(MultiPlaneBase, self).__init__(
-            lens_model_list,
+            self._lens_model_list,
             numerical_alpha_class=numerical_alpha_class,
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
@@ -69,22 +71,32 @@ class MultiPlaneBase(ProfileListBase):
             kwargs_synthesis=kwargs_synthesis,
         )
 
-        if len(lens_model_list) < 1:
+        if len(self._lens_model_list) < 1:
             self._sorted_redshift_index = []
         else:
             self._sorted_redshift_index = self._index_ordering(lens_redshift_list)
-        z_before = 0
-        T_z = 0
+
         self._T_ij_list = []
         self._T_z_list = []
+
+        self._reduced2physical_factor = []
+
+        self.set_T_zs_and_T_ijs()
+
+    def set_T_zs_and_T_ijs(self):
+        """Set the transverse angular diameter distances between the observer and the
+        lens planes and between the lens planes.
+        """
+        z_before = 0
+        T_z = 0
         # Sort redshift for vectorized reduced2physical factor calculation
-        if len(lens_model_list) < 1:
+        if len(self._lens_model_list) < 1:
             self._reduced2physical_factor = []
         else:
             z_sort = np.array(self._lens_redshift_list)[self._sorted_redshift_index]
-            z_source_array = np.ones(z_sort.shape) * z_source_convention
+            z_source_array = np.ones(z_sort.shape) * self._z_source_convention
             self._reduced2physical_factor = self._cosmo_bkg.d_xy(
-                0, z_source_convention
+                0, self._z_source_convention
             ) / self._cosmo_bkg.d_xy(z_sort, z_source_array)
         for idex in self._sorted_redshift_index:
             z_lens = self._lens_redshift_list[idex]
@@ -96,6 +108,14 @@ class MultiPlaneBase(ProfileListBase):
             self._T_ij_list.append(delta_T)
             self._T_z_list.append(T_z)
             z_before = z_lens
+
+    def set_background_cosmo(self, cosmo):
+        """Set the cosmology instance of the background class.
+
+        :param cosmo: instance of astropy.cosmology
+        """
+        self._cosmo_bkg.cosmo = cosmo
+        self.set_T_zs_and_T_ijs()
 
     @property
     def z_source_convention(self):

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -35,6 +35,8 @@ class LensModel(object):
         decouple_multi_plane=False,
         kwargs_multiplane_model=None,
         distance_ratio_sampling=False,
+        cosmology_sampling=False,
+        cosmology_model="FlatLambdaCDM",
     ):
         """
 
@@ -67,6 +69,10 @@ class LensModel(object):
          distances
         :param distance_ratio_sampling: bool, if True, will use sampled
          distance ratios to update T_ij value in multi-lens plane computation.
+        :param cosmology_sampling: bool, if True, will use sampled cosmology
+            to update T_ij value in multi-lens plane computation.
+        :param cosmology_model: str, name of the cosmology model to be used for
+            cosmology sampling. Default is 'FlatLambdaCDM'.
         """
         self.lens_model_list = lens_model_list
         self.z_lens = z_lens
@@ -153,6 +159,8 @@ class LensModel(object):
                     kwargs_interp=kwargs_interp,
                     kwargs_synthesis=kwargs_synthesis,
                     distance_ratio_sampling=distance_ratio_sampling,
+                    cosmology_sampling=cosmology_sampling,
+                    cosmology_model=cosmology_model,
                 )
                 self.type = "MultiPlane"
 

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -257,10 +257,9 @@ class Param(object):
         )
         self._kwargs_model = kwargs_model
 
-        if "distance_ratio_sampling" in self._kwargs_model:
-            distance_ratio_sampling = self._kwargs_model["distance_ratio_sampling"]
-        else:
-            distance_ratio_sampling = None
+        distance_ratio_sampling = self._kwargs_model.get("distance_ratio_sampling", None)
+        cosmology_sampling = self._kwargs_model.get("cosmology_sampling", None)
+        cosmology_model = self._kwargs_model.get("cosmology_model", "FlatLambdaCDM")
 
         # check how many redshifts need to be sampled
         num_z_sampling = 0
@@ -476,6 +475,8 @@ class Param(object):
             general_scaling_params=self._general_scaling_masks,
             distance_ratio_sampling=distance_ratio_sampling,
             num_lens_planes=num_lens_planes,
+            cosmology_sampling=cosmology_sampling,
+            cosmology_model=cosmology_model,
             kwargs_fixed=kwargs_fixed_special,
             num_scale_factor=self._num_scale_factor,
             kwargs_lower=kwargs_lower_special,

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -145,13 +145,12 @@ class GeneralScalingParam(ArrayParam):
                 self._kwargs_upper[pow_name] = 10
 
 
-class DistanceRatioFactorsAB(SingleParam):
+class DistanceRatioBetaFactors(SingleParam):
     """Distance ratio a and b factors.
 
-    If there are P lens planes, then there are P
-    factor_a and P-2 factor_b parameters. The parameter to be defined by the user are
-    "factor_a_1", "factor_a_2, ..., factor_a_P, factor_b_2, ..., factor_b_{P-1}". For
-    further definitions of factor_a and factor_b parameters, see the documentation of
+    If there are P lens planes, then there are comb(P, 2) factor_beta parameters. The 
+    parameter to be defined by the user are "factor_beta_12", "factor_beta_13", "factor_beta_23", ...,". For
+    further definitions of factor_beta parameters, see the documentation of
     `lesnstronomy.ImSim.multiplane_organizer.MultiplaneOrganizer()` class.
     """
 
@@ -170,17 +169,12 @@ class DistanceRatioFactorsAB(SingleParam):
         if not self.on:
             return
 
-        for i in range(self.num_lens_plane):
-            param_name = f"factor_a_{i+1}"
-            self.param_names[param_name] = 1
-            self._kwargs_lower[param_name] = 0
-            self._kwargs_upper[param_name] = 1000
-
-        for i in range(1, self.num_lens_plane - 1):
-            param_name = f"factor_b_{i + 1}"
-            self.param_names[param_name] = 1
-            self._kwargs_lower[param_name] = 0
-            self._kwargs_upper[param_name] = 1000
+        for j in range(self.num_lens_plane):
+            for i in range(j):
+                param_name = f"factor_beta_{i+1}_{j+1}"
+                self.param_names[param_name] = 1
+                self._kwargs_lower[param_name] = 0
+                self._kwargs_upper[param_name] = 1000
 
 
 # ======================================== #
@@ -242,7 +236,7 @@ class SpecialParam(object):
          sampled
         """
         self._num_lens_planes = num_lens_planes
-        self._distance_ratio_sampling = DistanceRatioFactorsAB(
+        self._distance_ratio_sampling = DistanceRatioBetaFactors(
             distance_ratio_sampling, num_lens_planes
         )
 

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -146,10 +146,10 @@ class GeneralScalingParam(ArrayParam):
 
 
 class DistanceRatioBetaFactors(SingleParam):
-    """Distance ratio a and b factors.
+    """Factors of distance ratio betas.
 
     If there are P lens planes, then there are comb(P, 2) factor_beta parameters. The 
-    parameter to be defined by the user are "factor_beta_12", "factor_beta_13", "factor_beta_23", ...,". For
+    parameter to be defined by the user are "factor_beta_1_2", "factor_beta_1_3", "factor_beta_2_3", ...,". For
     further definitions of factor_beta parameters, see the documentation of
     `lesnstronomy.ImSim.multiplane_organizer.MultiplaneOrganizer()` class.
     """

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -149,9 +149,10 @@ class DistanceRatioBetaFactors(SingleParam):
     """Factors of distance ratio betas.
 
     If there are P lens planes, then there are comb(P, 2) factor_beta parameters. The 
-    parameter to be defined by the user are "factor_beta_1_2", "factor_beta_1_3", "factor_beta_2_3", ...,". For
-    further definitions of factor_beta parameters, see the documentation of
-    `lesnstronomy.ImSim.multiplane_organizer.MultiplaneOrganizer()` class.
+    parameter to be defined by the user are "factor_beta_1_2", "factor_beta_1_3", 
+    "factor_beta_2_3", ...,". For further definitions of factor_beta parameters, see 
+    the documentation of `lesnstronomy.ImSim.multiplane_organizer.MultiplaneOrganizer()` 
+    class.
     """
 
     def __init__(self, on, num_lens_plane: int):

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -22,6 +22,8 @@ def create_class_instances(
     kwargs_interp=None,
     multi_plane=False,
     distance_ratio_sampling=False,
+    cosmology_sampling=False,
+    cosmology_model="FlatLambdaCDM",
     observed_convention_index=None,
     source_light_model_list=None,
     lens_light_model_list=None,
@@ -66,6 +68,8 @@ def create_class_instances(
     :param lens_redshift_list:
     :param multi_plane: bool, if True, computes the lensing quantities in multi-plane mode
     :param distance_ratio_sampling: bool, if True, samples the distance ratios in multi-lens-plane
+    :param cosmology_sampling: bool, if True, samples the cosmology in multi-lens-plane
+    :param cosmology_model: string, name of the cosmology model to be used in the multi-lens-plane mode
     :param kwargs_interp: interpolation keyword arguments specifying the numerics.
      See description in the Interpolate() class. Only applicable for 'INTERPOL' and 'INTERPOL_SCALED' models.
     :param observed_convention_index:
@@ -160,6 +164,8 @@ def create_class_instances(
         multi_plane=multi_plane,
         cosmo=cosmo,
         distance_ratio_sampling=distance_ratio_sampling,
+        cosmology_sampling=cosmology_sampling,
+        cosmology_model=cosmology_model,
         observed_convention_index=observed_convention_index_i,
         kwargs_interp=kwargs_interp,
         numerical_alpha_class=tabulated_deflection_angles,

--- a/lenstronomy/Util/cosmo_util.py
+++ b/lenstronomy/Util/cosmo_util.py
@@ -10,7 +10,7 @@ export, __all__ = exporter()
 
 
 @export
-def get_astropy_cosmo(cosmology_model="FlatLambdaCDM", param_kwargs={}):
+def get_astropy_cosmology(cosmology_model="FlatLambdaCDM", param_kwargs={}):
     """Return an instance of a astropy.cosmology class.
 
     :param cosmology_model: string, name of the cosmology model

--- a/lenstronomy/Util/cosmo_util.py
+++ b/lenstronomy/Util/cosmo_util.py
@@ -1,0 +1,52 @@
+from astropy.cosmology import FlatLambdaCDM
+from astropy.cosmology import LambdaCDM
+from astropy.cosmology import FlatwCDM
+from astropy.cosmology import wCDM
+from astropy.cosmology import Flatw0waCDM
+from astropy.cosmology import w0waCDM
+from lenstronomy.Util.package_util import exporter
+
+export, __all__ = exporter()
+
+
+@export
+def get_cosmology(cosmology_model="FlatLambdaCDM", param_kwargs={}):
+    """
+    Return an instance of a astropy.cosmology class.
+
+    :param cosmology_model: string, name of the cosmology model
+    :type cosmology_model: str
+    :param param_kwargs: keyword arguments of the cosmology class
+    :type param_kwargs: dict
+    :return: instance of a astropy.cosmology class
+    """
+
+
+    H0 = param_kwargs.get("H0", 70)
+    Om0 = param_kwargs.get("Om0", 0.3)
+    Ode0 = param_kwargs.get("Ode0", 0.7)
+    w0 = param_kwargs.get("w0", -1)
+    wa = param_kwargs.get("wa", 0)
+
+    supported_models = [
+        "FlatLambdaCDM",
+        "LambdaCDM",
+        "FlatwCDM",
+        "wCDM",
+        "Flatw0waCDM",
+        "w0waCDM",
+    ]
+    cosmo_classes = [FlatLambdaCDM, LambdaCDM, FlatwCDM, wCDM, Flatw0waCDM, w0waCDM]
+    cosmo_kwargs = [
+        {"H0": H0, "Om0": Om0},
+        {"H0": H0, "Om0": Om0, "Ode0": Ode0},
+        {"H0": H0, "Om0": Om0, "w0": w0},
+        {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0},
+        {"H0": H0, "Om0": Om0, "w0": w0, "wa": wa},
+        {"H0": H0, "Om0": Om0, "Ode0": Ode0, "w0": w0, "wa": wa},
+    ]
+
+    index = supported_models.index(cosmology_model)
+    cosmo = cosmo_classes[index](**cosmo_kwargs[index])
+
+    return cosmo

--- a/lenstronomy/Util/cosmo_util.py
+++ b/lenstronomy/Util/cosmo_util.py
@@ -36,6 +36,10 @@ def get_astropy_cosmo(cosmology_model="FlatLambdaCDM", param_kwargs={}):
         "Flatw0waCDM",
         "w0waCDM",
     ]
+
+    if cosmology_model not in supported_models:
+        raise ValueError(f"Cosmology model {cosmology_model} not supported! Choose from {supported_models}.")
+    
     cosmo_classes = [FlatLambdaCDM, LambdaCDM, FlatwCDM, wCDM, Flatw0waCDM, w0waCDM]
     cosmo_kwargs = [
         {"H0": H0, "Om0": Om0},

--- a/lenstronomy/Util/cosmo_util.py
+++ b/lenstronomy/Util/cosmo_util.py
@@ -10,7 +10,7 @@ export, __all__ = exporter()
 
 
 @export
-def get_cosmology(cosmology_model="FlatLambdaCDM", param_kwargs={}):
+def get_astropy_cosmo(cosmology_model="FlatLambdaCDM", param_kwargs={}):
     """
     Return an instance of a astropy.cosmology class.
 

--- a/test/test_ImSim/test_image2soure_mapping.py
+++ b/test/test_ImSim/test_image2soure_mapping.py
@@ -129,8 +129,7 @@ class TestMultiSourcePlane(object):
 
     def test_image_2_source(self):
         kwargs_special = {
-            "factor_a_1": 1,
-            "factor_a_2": 1,
+            "factor_beta_1_2": 1,
         }
         x, y = np.arange(10), np.arange(10)
         source_x, source_y = self.multi_free_multi.image2source(
@@ -145,8 +144,7 @@ class TestMultiSourcePlane(object):
 
     def test_image_flux_split(self):
         kwargs_special = {
-            "factor_a_1": 1,
-            "factor_a_2": 1,
+            "factor_beta_1_2": 1,
         }
         x, y = np.arange(10), np.arange(10)
         flux, n = self.multi_free_multi.image_flux_split(

--- a/test/test_ImSim/test_image2soure_mapping.py
+++ b/test/test_ImSim/test_image2soure_mapping.py
@@ -40,6 +40,15 @@ class TestMultiSourcePlane(object):
             cosmo=None,
             distance_ratio_sampling=True,
         )
+        multi_plane_free_cosmology = LensModel(
+            lens_model_list=lens_model_list,
+            multi_plane=True,
+            z_source=2,
+            lens_redshift_list=[0.2, 0.5],
+            cosmo=None,
+            cosmology_sampling=True,
+            cosmology_model="FlatwCDM",
+        )   
 
         light_model_list = ["SERSIC", "SERSIC"]
         self.kwargs_light = [
@@ -120,6 +129,16 @@ class TestMultiSourcePlane(object):
         # test multi lens plane with distance sampling, single source plane
         self.multi_free_multi = Image2SourceMapping(
             multi_plane_free_distance,
+            LightModel(
+                light_model_list,
+                deflection_scaling_list=None,
+                source_redshift_list=None,
+            ),
+        )
+
+        # test multi lens plane with cosmology sampling, single source plane
+        self.multi_cosmo_multi = Image2SourceMapping(
+            multi_plane_free_cosmology,
             LightModel(
                 light_model_list,
                 deflection_scaling_list=None,

--- a/test/test_ImSim/test_image2soure_mapping.py
+++ b/test/test_ImSim/test_image2soure_mapping.py
@@ -3,6 +3,7 @@ __author__ = "sibirrer"
 import numpy as np
 import numpy.testing as npt
 import lenstronomy.Util.util as util
+from astropy.cosmology import FlatwCDM
 from lenstronomy.ImSim.image2source_mapping import Image2SourceMapping
 from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.LightModel.light_model import LightModel
@@ -45,7 +46,16 @@ class TestMultiSourcePlane(object):
             multi_plane=True,
             z_source=2,
             lens_redshift_list=[0.2, 0.5],
-            cosmo=None,
+            cosmo=FlatwCDM(H0=70, Om0=0.3, w0=-0.5),
+            cosmology_sampling=True,
+            cosmology_model="FlatwCDM",
+        )
+        multi_plane_free_cosmology_2 = LensModel(
+            lens_model_list=lens_model_list,
+            multi_plane=True,
+            z_source=2,
+            lens_redshift_list=[0.2, 0.5],
+            cosmo=FlatwCDM(H0=70, Om0=0.3, w0=-1.5),
             cosmology_sampling=True,
             cosmology_model="FlatwCDM",
         )
@@ -127,7 +137,7 @@ class TestMultiSourcePlane(object):
         )
 
         # test multi lens plane with distance sampling, single source plane
-        self.multi_free_multi = Image2SourceMapping(
+        self.multi_lens_free_distance_ratios = Image2SourceMapping(
             multi_plane_free_distance,
             LightModel(
                 light_model_list,
@@ -137,8 +147,16 @@ class TestMultiSourcePlane(object):
         )
 
         # test multi lens plane with cosmology sampling, single source plane
-        self.multi_cosmo_multi = Image2SourceMapping(
+        self.multi_lens_free_cosmology = Image2SourceMapping(
             multi_plane_free_cosmology,
+            LightModel(
+                light_model_list,
+                deflection_scaling_list=None,
+                source_redshift_list=None,
+            ),
+        )
+        self.multi_lens_free_cosmology_2 = Image2SourceMapping(
+            multi_plane_free_cosmology_2,
             LightModel(
                 light_model_list,
                 deflection_scaling_list=None,
@@ -151,7 +169,7 @@ class TestMultiSourcePlane(object):
             "factor_beta_1_2": 1,
         }
         x, y = np.arange(10), np.arange(10)
-        source_x, source_y = self.multi_free_multi.image2source(
+        source_x, source_y = self.multi_lens_free_distance_ratios.image2source(
             x,
             y,
             kwargs_lens=self.kwargs_lens,
@@ -166,7 +184,7 @@ class TestMultiSourcePlane(object):
             "factor_beta_1_2": 1,
         }
         x, y = np.arange(10), np.arange(10)
-        flux, n = self.multi_free_multi.image_flux_split(
+        flux, n = self.multi_lens_free_distance_ratios.image_flux_split(
             x,
             y,
             kwargs_lens=self.kwargs_lens,
@@ -300,6 +318,18 @@ class TestMultiSourcePlane(object):
             x, y, kwargs_lens=self.kwargs_lens, index_source=0
         )
         npt.assert_almost_equal(beta_x0, beta_x, decimal=10)
+
+        npt.assert_almost_equal(
+            self.multi_lens_free_cosmology.image2source(
+                x, y, kwargs_lens=self.kwargs_lens, index_source=0,
+                kwargs_special={"H0": 70, "Om0": 0.3, "w0": -0.5}
+            ),
+            self.multi_lens_free_cosmology_2.image2source(
+                x, y, kwargs_lens=self.kwargs_lens, index_source=0,
+                kwargs_special={"H0": 70, "Om0": 0.3, "w0": -0.5}
+            ),  
+            decimal=10,
+        )
 
     def test__re_order_split(self):
         lens_model = LensModel(

--- a/test/test_ImSim/test_multi_plane_organizer.py
+++ b/test/test_ImSim/test_multi_plane_organizer.py
@@ -62,32 +62,29 @@ class TestMultiPlaneOrganizer(object):
             cosmo=Background(cosmo=self.cosmo),
         )
 
-    def test_extract_a_b_factors(self):
+    def test_extract_beta_factors(self):
         """Test MultiPlaneOrganizer._extract_a_b_factors()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 2.0,
-            "factor_a_3": 3.0,
-            "factor_a_4": 4.0,
-            "factor_b_2": 5.0,
-            "factor_b_3": 6.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 2.0,
+            "factor_beta_2_3": 3.0,
+            "factor_beta_1_4": 4.0,
+            "factor_beta_2_4": 5.0,
+            "factor_beta_3_4": 6.0,
         }
 
-        a_factor_list, b_factor_list = self.multi_plane_organizer._extract_a_b_factors(
-            kwargs_special
-        )
-        npt.assert_almost_equal(a_factor_list, [1.0, 2.0, 3.0, 4.0])
-        npt.assert_almost_equal(b_factor_list, [1.0, 5.0, 6.0, 4.0])
+        beta_factor_list = self.multi_plane_organizer._extract_beta_factors(kwargs_special)
+        npt.assert_almost_equal(beta_factor_list, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
 
     def test_update_lens_T_lists(self):
         """Test MultiPlaneOrganizer.update_lens_T_lists()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         fiducial_T_z_list = copy.deepcopy(
@@ -121,12 +118,12 @@ class TestMultiPlaneOrganizer(object):
     def test_update_source_mapping_T_lists(self):
         """Test MultiPlaneOrganizer.update_source_T_lists()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         fiducial_T_ij_start_list = copy.deepcopy(self.mapping.T_ij_start_list)
@@ -158,12 +155,12 @@ class TestMultiPlaneOrganizer(object):
     def test_get_lens_T_lists(self):
         """Test MultiPlaneOrganizer._get_lens_T_lists()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         T_z_list, T_ij_list = self.multi_plane_organizer._get_lens_T_lists(
@@ -206,54 +203,50 @@ class TestMultiPlaneOrganizer(object):
     def test_get_D_ij(self):
         """Test MultiPlaneOrganizer._get_D_ij()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         D_ij = self.multi_plane_organizer._get_D_ij(
             self.lens_redshift_list[1], self.lens_redshift_list[2], kwargs_special
         )
-        assert D_ij == 358.1158558418066
+        npt.assert_almost_equal(D_ij, 358.1158558418066, decimal=10)
+
+        D_ij = self.multi_plane_organizer._get_D_ij(
+            self.lens_redshift_list[2], self.lens_redshift_list[1], kwargs_special
+        )
+        npt.assert_almost_equal(D_ij, 358.1158558418066, decimal=10)
 
         D_ij = self.multi_plane_organizer._get_D_ij(
             self.source_redshift_list[2], self.source_redshift_list[3], kwargs_special
         )
-        assert D_ij == 175.31018095788596
+        npt.assert_almost_equal(D_ij, 175.31018095788596, decimal=10)
 
-        # test if an error is raised if the redshifts are not in the list
-        with pytest.raises(ValueError):
-            D_ij = self.multi_plane_organizer._get_D_ij(0.1, 0.2, kwargs_special)
-
-        # test if the redshifts are not consecutive
-        with pytest.raises(AssertionError):
-            D_ij = self.multi_plane_organizer._get_D_ij(
-                self.lens_redshift_list[0], self.lens_redshift_list[3], kwargs_special
-            )
 
     def test_get_D_i(self):
         """Test MultiPlaneOrganizer._get_D_i()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         D_i = self.multi_plane_organizer._get_D_i(
             self.lens_redshift_list[1], kwargs_special
         )
-        assert D_i == 1006.5247314933569
+        npt.assert_almost_equal(D_i, 1006.5247314933569, decimal=10)
 
         D_i = self.multi_plane_organizer._get_D_i(
             self.source_redshift_list[2], kwargs_special
         )
-        assert D_i == 1459.6840895330772
+        npt.assert_almost_equal(D_i, 1459.6840895330772, decimal=10)
 
         # test if an error is raised if the redshifts are not in the list
         with pytest.raises(ValueError):
@@ -267,15 +260,15 @@ class TestMultiPlaneOrganizer(object):
             == self.multi_plane_organizer._D_is_list_fiducial[0]
         )
 
-    def test_transver_distance_start_stop(self):
+    def test_transverse_distance_start_stop(self):
         """Test MultiPlaneOrganizer._transverse_distance_start_stop()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         (
@@ -285,18 +278,18 @@ class TestMultiPlaneOrganizer(object):
             self.lens_redshift_list[1], self.source_redshift_list[-2], kwargs_special
         )
 
-        assert T_ij_start == 572.9853693468906
-        assert T_ij_stop == 0.0
+        npt.assert_almost_equal(T_ij_start, 572.9853693468906, decimal=10)
+        npt.assert_almost_equal(T_ij_stop, 0.0, decimal=10)
 
     def test_get_source_T_start_end_lists(self):
         """Test MultiPlaneOrganizer._get_source_T_start_end_lists()"""
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         (
@@ -335,12 +328,12 @@ class TestMultiPlaneOrganizer(object):
         ]
 
         kwargs_special = {
-            "factor_a_1": 1.0,
-            "factor_a_2": 1.0,
-            "factor_a_3": 1.0,
-            "factor_a_4": 1.0,
-            "factor_b_2": 1.0,
-            "factor_b_3": 1.0,
+            "factor_beta_1_2": 1.0,
+            "factor_beta_1_3": 1.0,
+            "factor_beta_2_3": 1.0,
+            "factor_beta_1_4": 1.0,
+            "factor_beta_2_4": 1.0,
+            "factor_beta_3_4": 1.0,
         }
 
         x, y = np.meshgrid(np.arange(-4, 4, 0.05), np.arange(-4, 4, 0.05))

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane.py
@@ -4,6 +4,7 @@ import numpy.testing as npt
 import numpy as np
 import pytest
 import unittest
+from astropy.cosmology import FlatwCDM
 from lenstronomy.LensModel.MultiPlane.multi_plane import MultiPlane
 from lenstronomy.LensModel.MultiPlane.multi_plane_base import MultiPlaneBase
 from lenstronomy.LensModel.lens_model import LensModel
@@ -103,6 +104,32 @@ class TestMultiPlane(object):
         )
         lens_model_mutli.T_ij_stop = 1000
         assert lens_model_mutli.T_ij_stop == 1000
+
+    def test_set_T_ij_stop(self):
+        z_source = 1.5
+        lens_model_list = ["SIS"]
+        kwargs_lens = [{"theta_E": 1}]
+        redshift_list = [0.5]
+        cosmo = FlatwCDM(H0=70, Om0=0.3, w0=-0.8)
+        lens_model_mutli = MultiPlane(
+            z_source=z_source,
+            lens_model_list=lens_model_list,
+            lens_redshift_list=redshift_list,
+            z_interp_stop=3,
+            cosmo_interp=False,
+            z_lens_convention=0.5,
+            cosmo=cosmo
+        )
+        lens_model_mutli_2 = MultiPlane(
+            z_source=z_source,
+            lens_model_list=lens_model_list,
+            lens_redshift_list=redshift_list,
+            z_interp_stop=3,
+            cosmo_interp=False,
+            z_lens_convention=0.5,
+        )
+        lens_model_mutli_2.set_background_cosmo(cosmo)
+        assert lens_model_mutli._T_z_source == lens_model_mutli_2._T_z_source
 
     def test_sis_ray_tracing(self):
         z_source = 1.5

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane.py
@@ -21,6 +21,37 @@ class TestMultiPlane(object):
     def setup_method(self):
         pass
 
+    def test_init(self):
+        z_source = 1.5
+        lens_model_list = ["SIS"]
+        kwargs_lens = [{"theta_E": 1}]
+        redshift_list = [0.5]
+        cosmo = FlatwCDM(H0=70, Om0=0.3, w0=-0.8)
+        MultiPlane(
+            z_source=z_source,
+            lens_model_list=lens_model_list,
+            lens_redshift_list=redshift_list,
+            z_interp_stop=3,
+            cosmo_interp=True,
+            distance_ratio_sampling=True,
+            z_lens_convention=0.5,
+            cosmo=cosmo,
+            cosmology_sampling=True,
+        )
+        with pytest.raises(ValueError):
+            MultiPlane(
+                z_source=z_source,
+                lens_model_list=lens_model_list,
+                lens_redshift_list=redshift_list,
+                z_interp_stop=3,
+                cosmo_interp=True,
+                distance_ratio_sampling=True,
+                z_lens_convention=0.5,
+                cosmo=cosmo,
+                cosmology_sampling=True,
+                cosmology_model="stringTheory"
+            )
+
     def test_geo_shapiro_delay(self):
         z_source = 1.5
         lens_model_list = ["SIS", "SIS"]
@@ -105,7 +136,7 @@ class TestMultiPlane(object):
         lens_model_mutli.T_ij_stop = 1000
         assert lens_model_mutli.T_ij_stop == 1000
 
-    def test_set_T_ij_stop(self):
+    def test_set_background_cosmo(self):
         z_source = 1.5
         lens_model_list = ["SIS"]
         kwargs_lens = [{"theta_E": 1}]

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -22,6 +22,7 @@ class TestParam(object):
             "z_source": 2,
             "source_redshift_list": [0.5],
             "distance_ratio_sampling": None,
+            "cosmology_sampling": None
         }
         kwargs_param = {
             "num_point_source_list": [2],

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -115,6 +115,26 @@ class TestParam(object):
         assert kwargs_new["factor_beta_1_3"] == 1
         assert kwargs_new["factor_beta_2_3"] == 1
 
+    def test_cosmology_parameters(self):
+        kwargs_fixed = {"H0": 70}
+        param = SpecialParam(
+            cosmology_sampling=True,
+            cosmology_model="wCDM",
+            Ddt_sampling=True,
+            kinematic_sampling=True,
+            kwargs_fixed=kwargs_fixed,
+            num_z_sampling=3,
+            num_lens_planes=2,
+        )
+        kwargs = {"w0": -0.5, "Om0": 0.3, "Ode0": 0.7}
+
+        args = param.set_params(kwargs)
+        assert len(args) == 3
+        num_param, param_list = param.num_param()
+        assert num_param == 3
+        kwargs_new, _ = param.get_params(args, i=0)
+        assert kwargs_new["w0"] == -0.5
+
     def test_mass_scaling(self):
         kwargs_fixed = {}
         param = SpecialParam(

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -120,6 +120,7 @@ class TestParam(object):
         param = SpecialParam(
             cosmology_sampling=True,
             cosmology_model="wCDM",
+            distance_ratio_sampling=True,
             Ddt_sampling=True,
             kinematic_sampling=True,
             kwargs_fixed=kwargs_fixed,

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -71,7 +71,7 @@ class TestParam(object):
         num, list = self.param.num_param()
         assert num == 16
 
-    def test_distance_ratio_factors_ab(self):
+    def test_distance_ratio_factors_beta(self):
         kwargs_fixed = {}
         param = SpecialParam(
             distance_ratio_sampling=True,
@@ -81,17 +81,16 @@ class TestParam(object):
             num_z_sampling=3,
             num_lens_planes=2,
         )
-        kwargs = {"factor_a_1": 1, "factor_a_2": 1}
+        kwargs = {"factor_beta_1_2": 1}
 
         args = param.set_params(kwargs)
-        assert len(args) == 2
+        assert len(args) == 1
         num_param, param_list = param.num_param()
-        assert num_param == 2
+        assert num_param == 1
         kwargs_new, _ = param.get_params(args, i=0)
-        assert kwargs_new["factor_a_1"] == 1
-        assert kwargs_new["factor_a_2"] == 1
+        assert kwargs_new["factor_beta_1_2"] == 1
 
-        kwargs_fixed = {"factor_a_3": 1}
+        kwargs_fixed = {"factor_beta_1_3": 1}
         param = SpecialParam(
             distance_ratio_sampling=True,
             Ddt_sampling=False,
@@ -101,22 +100,20 @@ class TestParam(object):
             num_lens_planes=3,
         )
         kwargs = {
-            "factor_a_1": 1,
-            "factor_a_2": 1,
-            "factor_a_3": 1,
-            "factor_b_2": 1,
+            "factor_beta_1_2": 1,
+            "factor_beta_1_3": 1,
+            "factor_beta_2_3": 1,
         }
 
         args = param.set_params(kwargs)
-        assert len(args) == 3
+        assert len(args) == 2
         num_param, param_list = param.num_param()
-        assert num_param == 3
-        assert param_list == ["factor_a_1", "factor_a_2", "factor_b_2"]
+        assert num_param == 2
+        assert param_list == ["factor_beta_1_2", "factor_beta_2_3"]
         kwargs_new, _ = param.get_params(args, i=0)
-        assert kwargs_new["factor_a_1"] == 1
-        assert kwargs_new["factor_a_2"] == 1
-        assert kwargs_new["factor_a_3"] == 1
-        assert kwargs_new["factor_b_2"] == 1
+        assert kwargs_new["factor_beta_1_2"] == 1
+        assert kwargs_new["factor_beta_1_3"] == 1
+        assert kwargs_new["factor_beta_2_3"] == 1
 
     def test_mass_scaling(self):
         kwargs_fixed = {}

--- a/test/test_Util/test_cosmo_util.py
+++ b/test/test_Util/test_cosmo_util.py
@@ -1,6 +1,6 @@
 __author__ = "ajshajib"
 
-from lenstronomy.Util.cosmo_util import get_astropy_cosmo
+from lenstronomy.Util.cosmo_util import get_astropy_cosmology
 import numpy.testing as npt
 from astropy.cosmology import w0waCDM
 from astropy.cosmology import Flatw0waCDM
@@ -13,7 +13,7 @@ class TestCosmoUtil(object):
     def test_get_cosmology(self):
         fiducial_cosmo = w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.8, wa=0.2)
 
-        cosmo = get_astropy_cosmo(
+        cosmo = get_astropy_cosmology(
             "w0waCDM", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2}
         )
 
@@ -26,7 +26,7 @@ class TestCosmoUtil(object):
 
         fiducial_cosmo = Flatw0waCDM(H0=70, Om0=0.3, w0=-1, wa=0.0)
 
-        cosmo = get_astropy_cosmo(
+        cosmo = get_astropy_cosmology(
             "Flatw0waCDM", {"H0": 70, "Om0": 0.3, "w0": -1, "wa": 0.0}
         )
 
@@ -38,4 +38,4 @@ class TestCosmoUtil(object):
         )
 
         with pytest.raises(ValueError):
-            get_astropy_cosmo("FLRW", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2})
+            get_astropy_cosmology("FLRW", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2})

--- a/test/test_Util/test_cosmo_util.py
+++ b/test/test_Util/test_cosmo_util.py
@@ -4,7 +4,7 @@ from lenstronomy.Util.cosmo_util import get_astropy_cosmo
 import numpy.testing as npt
 from astropy.cosmology import w0waCDM
 from astropy.cosmology import Flatw0waCDM
-
+import pytest
 
 class TestCosmoUtil(object):
     def setup_method(self):
@@ -24,3 +24,6 @@ class TestCosmoUtil(object):
 
         npt.assert_almost_equal(cosmo.H0.value, fiducial_cosmo.H0.value, decimal=10)
         npt.assert_almost_equal(cosmo.angular_diameter_distance(1).value, fiducial_cosmo.angular_diameter_distance(1).value, decimal=10)
+
+        with pytest.raises(ValueError):
+            get_astropy_cosmo("FLRW", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2})

--- a/test/test_Util/test_cosmo_util.py
+++ b/test/test_Util/test_cosmo_util.py
@@ -1,6 +1,6 @@
 __author__ = "ajshajib"
 
-from lenstronomy.Util.cosmo_util import get_cosmology
+from lenstronomy.Util.cosmo_util import get_astropy_cosmo
 import numpy.testing as npt
 from astropy.cosmology import w0waCDM
 from astropy.cosmology import Flatw0waCDM
@@ -13,14 +13,14 @@ class TestCosmoUtil(object):
     def test_get_cosmology(self):
         fiducial_cosmo = w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.8, wa=0.2)
 
-        cosmo = get_cosmology("w0waCDM", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2})
+        cosmo = get_astropy_cosmo("w0waCDM", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2})
 
         npt.assert_almost_equal(cosmo.H0.value, fiducial_cosmo.H0.value, decimal=10)
         npt.assert_almost_equal(cosmo.angular_diameter_distance(1).value, fiducial_cosmo.angular_diameter_distance(1).value, decimal=10)
 
         fiducial_cosmo = Flatw0waCDM(H0=70, Om0=0.3, w0=-1, wa=0.0)
 
-        cosmo = get_cosmology("Flatw0waCDM", {"H0": 70, "Om0": 0.3, "w0": -1, "wa": 0.0})
+        cosmo = get_astropy_cosmo("Flatw0waCDM", {"H0": 70, "Om0": 0.3, "w0": -1, "wa": 0.0})
 
         npt.assert_almost_equal(cosmo.H0.value, fiducial_cosmo.H0.value, decimal=10)
         npt.assert_almost_equal(cosmo.angular_diameter_distance(1).value, fiducial_cosmo.angular_diameter_distance(1).value, decimal=10)

--- a/test/test_Util/test_cosmo_util.py
+++ b/test/test_Util/test_cosmo_util.py
@@ -1,0 +1,26 @@
+__author__ = "ajshajib"
+
+from lenstronomy.Util.cosmo_util import get_cosmology
+import numpy.testing as npt
+from astropy.cosmology import w0waCDM
+from astropy.cosmology import Flatw0waCDM
+
+
+class TestCosmoUtil(object):
+    def setup_method(self):
+        pass
+
+    def test_get_cosmology(self):
+        fiducial_cosmo = w0waCDM(H0=70, Om0=0.3, Ode0=0.7, w0=-0.8, wa=0.2)
+
+        cosmo = get_cosmology("w0waCDM", {"H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.8, "wa": 0.2})
+
+        npt.assert_almost_equal(cosmo.H0.value, fiducial_cosmo.H0.value, decimal=10)
+        npt.assert_almost_equal(cosmo.angular_diameter_distance(1).value, fiducial_cosmo.angular_diameter_distance(1).value, decimal=10)
+
+        fiducial_cosmo = Flatw0waCDM(H0=70, Om0=0.3, w0=-1, wa=0.0)
+
+        cosmo = get_cosmology("Flatw0waCDM", {"H0": 70, "Om0": 0.3, "w0": -1, "wa": 0.0})
+
+        npt.assert_almost_equal(cosmo.H0.value, fiducial_cosmo.H0.value, decimal=10)
+        npt.assert_almost_equal(cosmo.angular_diameter_distance(1).value, fiducial_cosmo.angular_diameter_distance(1).value, decimal=10)


### PR DESCRIPTION
This pull request includes the introduction of cosmology sampling and refactoring of distance calculations in multi-plane lensing scenarios.

* Added cosmology sampling functionality to the `image2source_mapping.py` by introducing the `_cosmology_sampling` attribute and updating the `__init__` method to handle cosmology sampling. (`lenstronomy/ImSim/image2source_mapping.py`) [[1]](diffhunk://#diff-47b1e62e722e6f93bff10e6f19f7e1aafac46d08881d733bf35f1c515d6c780cR43) [[2]](diffhunk://#diff-47b1e62e722e6f93bff10e6f19f7e1aafac46d08881d733bf35f1c515d6c780cR55-R57)

* Refactored the `MultiPlaneOrganizer` class to use `beta` parameters instead of `a` and `b` factors for distance calculations, and updated the relevant methods accordingly. (`lenstronomy/ImSim/multiplane_organizer.py`) [[1]](diffhunk://#diff-acb17c0080cd8f715ae22d72f2946c7b9da66dece76a1dc6bc85feef43a1bbabL16-R28) [[2]](diffhunk://#diff-acb17c0080cd8f715ae22d72f2946c7b9da66dece76a1dc6bc85feef43a1bbabR67-R78)