### PR TITLE
m=1 multipole (spherical/elliptical) + updated solution of m=3 multipole

### DIFF
--- a/lenstronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
+++ b/lenstronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
@@ -10,9 +10,8 @@ __all__ = ["EPL_MULTIPOLE_M1M3M4", "EPL_MULTIPOLE_M1M3M4_ELL"]
 
 
 class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
-    """EPL (Elliptical Power Law) mass profile combined with two elliptical multipole
-    terms of order m=3 and m=4 (exact for general axis ratio q) and a circular m=1
-    multipole.
+    """EPL (Elliptical Power Law) mass profile combined with three elliptical multipole
+    terms of order m=1, m=3 and m=4  (exact for general axis ratio q).
 
     See also documentation of EPL_BOXYDIKSY CLASS, lenstronomy.LensModel.Profiles.epl
     and lenstronomy.LensModel.Profiles.multipole for details. For an example of using
@@ -20,7 +19,6 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
     https://ui.adsabs.harvard.edu/abs/2024arXiv241012987L/abstract
     """
 
-    # TODO: update the m=1 multipole term to have elliptical symmetry when the solution for the m=1 elliptical multipole is implemented
     param_names = [
         "theta_E",
         "gamma",
@@ -66,7 +64,6 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
 
     def __init__(self):
         self._epl = EPL()
-        self._multipole_m1 = Multipole()
         self._multipole = EllipticalMultipole()
         super(EPL_MULTIPOLE_M1M3M4_ELL, self).__init__()
 
@@ -123,9 +120,11 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
         kwargs_multipole_m1 = {
             "m": 1,
             "a_m": a1_a * rescale_am,
+            "q": q,
             "phi_m": phi + delta_phi_m1,
             "center_x": center_x,
             "center_y": center_y,
+            "r_E": theta_E,
         }
         kwargs_multipole_m3 = {
             "m": 3,
@@ -134,6 +133,7 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
             "phi_m": phi + delta_phi_m3,
             "center_x": center_x,
             "center_y": center_y,
+            "r_E": theta_E,
         }
         kwargs_multipole_m4 = {
             "m": 4,
@@ -206,7 +206,7 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
         f_epl = self._epl.function(x, y, **kwargs_epl)
         f_multipole = self._multipole.function(x, y, **kwargs_multipole3)
         f_multipole += self._multipole.function(x, y, **kwargs_multipole4)
-        f_multipole += self._multipole_m1.function(x, y, **kwargs_multipole1)
+        f_multipole += self._multipole.function(x, y, **kwargs_multipole1)
         return f_epl + f_multipole
 
     def derivatives(
@@ -290,7 +290,7 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
         f_x_multipole4, f_y_multipole4 = self._multipole.derivatives(
             x, y, **kwargs_multipole4
         )
-        f_x_multipole1, f_y_multipole1 = self._multipole_m1.derivatives(
+        f_x_multipole1, f_y_multipole1 = self._multipole.derivatives(
             x, y, **kwargs_multipole1
         )
         f_x = f_x_epl + f_x_multipole3 + f_x_multipole4 + f_x_multipole1
@@ -374,7 +374,7 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
             f_xy_multipole1,
             f_yx_multipole1,
             f_yy_multipole1,
-        ) = self._multipole_m1.hessian(x, y, **kwargs_multipole1)
+        ) = self._multipole.hessian(x, y, **kwargs_multipole1)
         f_xx = f_xx_epl + f_xx_multipole3 + f_xx_multipole4 + f_xx_multipole1
         f_xy = f_xy_epl + f_xy_multipole3 + f_xy_multipole4 + f_xy_multipole1
         f_yx = f_yx_epl + f_yx_multipole3 + f_yx_multipole4 + f_yx_multipole1
@@ -513,6 +513,7 @@ class EPL_MULTIPOLE_M1M3M4(LensProfileBase):
             "phi_m": phi + delta_phi_m1,
             "center_x": center_x,
             "center_y": center_y,
+            "r_E": theta_E,
         }
         kwargs_multipole_m3 = {
             "m": 3,

--- a/lenstronomy/LensModel/Profiles/epl_multipole_m3m4.py
+++ b/lenstronomy/LensModel/Profiles/epl_multipole_m3m4.py
@@ -111,6 +111,7 @@ class EPL_MULTIPOLE_M3M4_ELL(LensProfileBase):
             "q": q,
             "center_x": center_x,
             "center_y": center_y,
+            "r_E": theta_E,
         }
         kwargs_multipole_m4 = {
             "m": 4,

--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -14,18 +14,19 @@ class Multipole(LensProfileBase):
     This uses the same definitions as Xu et al.(2013) in Appendix B3 https://arxiv.org/pdf/1307.4220.pdf, Equation B12
     Only the q=1 case (ie., spherical symmetry) makes this definition consistent with interpretation of multipoles as a deformation of the isophotes with an order m symmetry (eg., disky/boxy in the m=4 case).
 
-    m : int, multipole order, m>=2
+    m : int, multipole order, m>=1
     a_m : float, multipole strength
     phi_m : float, multipole orientation in radian
     """
 
-    param_names = ["m", "a_m", "phi_m", "center_x", "center_y"]
+    param_names = ["m", "a_m", "phi_m", "center_x", "center_y", "r_E"]
     lower_limit_default = {
-        "m": 2,
+        "m": 1,
         "a_m": 0,
         "phi_m": -np.pi,
         "center_x": -100,
         "center_y": -100,
+        "r_E": 0,
     }
     upper_limit_default = {
         "m": 100,
@@ -33,11 +34,12 @@ class Multipole(LensProfileBase):
         "phi_m": np.pi,
         "center_x": 100,
         "center_y": 100,
+        "r_E": 100,
     }
 
-    def function(self, x, y, m, a_m, phi_m, center_x=0, center_y=0):
+    def function(self, x, y, m, a_m, phi_m, center_x=0, center_y=0, r_E=1):
         """
-        Lensing potential of multipole contribution (for 1 component with m>=2)
+        Lensing potential of multipole contribution (for 1 component with m>=1)
         This uses the same definitions as Xu et al.(2013) in Appendix B3 https://arxiv.org/pdf/1307.4220.pdf
 
         :param x: x-coordinate to evaluate function
@@ -47,37 +49,41 @@ class Multipole(LensProfileBase):
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
         :param center_y: y-position
+        :param r_E: float, normalizing radius (only used for the m=1, Einstein radius by default)
         :return: lensing potential
         """
 
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        
         if m == 1:
-            f_ = r * a_m / 2 * phi * np.sin(phi - phi_m)
+            r = np.maximum(r, 0.000001)
+            f_ = r * np.log(r/r_E) * a_m / 2 * np.cos(phi - phi_m)
         else:
             f_ = r * a_m / (1 - m**2) * np.cos(m * (phi - phi_m))
         return f_
 
-    def derivatives(self, x, y, m, a_m, phi_m, center_x=0, center_y=0):
+    def derivatives(self, x, y, m, a_m, phi_m, center_x=0, center_y=0, r_E=1):
         """
-        Deflection of a multipole contribution (for 1 component with m>=2)
+        Deflection of a multipole contribution (for 1 component with m>=1)
         This uses the same definitions as Xu et al.(2013) in Appendix B3 https://arxiv.org/pdf/1307.4220.pdf
         Equation B12
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=2
+        :param m: int, multipole order, m>=&
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
         :param center_y: y-position
+        :param r_E: float, normalizing radius (only used for the m=1, Einstein radius by default)
         :return: deflection angles alpha_x, alpha_y
         """
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        
         if m == 1:
-            f_phi = a_m * phi * np.sin(phi - phi_m) / 2
-            df_dphi = (a_m * np.sin(phi - phi_m) + a_m * phi * np.cos(phi - phi_m)) / 2
-            f_x = np.cos(phi) * f_phi - df_dphi * np.sin(phi)
-            f_y = f_phi * np.sin(phi) + df_dphi * np.cos(phi)
+            r = np.maximum(r, 0.000001)
+            f_x = a_m/2 * (np.cos(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.cos(phi))
+            f_x = a_m/2 * (np.sin(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.sin(phi))
         else:
             f_x = np.cos(phi) * a_m / (1 - m**2) * np.cos(m * (phi - phi_m)) + np.sin(
                 phi
@@ -87,28 +93,28 @@ class Multipole(LensProfileBase):
             ) * m * a_m / (1 - m**2) * np.sin(m * (phi - phi_m))
         return f_x, f_y
 
-    def hessian(self, x, y, m, a_m, phi_m, center_x=0, center_y=0):
+    def hessian(self, x, y, m, a_m, phi_m, center_x=0, center_y=0, r_E=1):
         """
-        Hessian of a multipole contribution (for 1 component with m>=2)
+        Hessian of a multipole contribution (for 1 component with m>=1)
         This uses the same definitions as Xu et al.(2013) in Appendix B3 https://arxiv.org/pdf/1307.4220.pdf
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=2
+        :param m: int, multipole order, m>=1
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
         :param center_y: y-position
+        :param r_E: float, normalizing radius (not used for Hessian)
         :return: f_xx, f_xy, f_yx, f_yy
         """
 
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
         r = np.maximum(r, 0.000001)
         if m == 1:
-            g_phi = a_m * np.cos(phi - phi_m)
-            f_xx = np.sin(phi) ** 2 / r * g_phi
-            f_yy = np.cos(phi) ** 2 / r * g_phi
-            f_xy = -np.sin(2 * phi) / (2 * r) * g_phi
+            f_xx = a_m / (2 * r) * (2 * np.cos(phi_m) * np.cos(phi) - np.cos(phi - phi_m) * np.cos(2*phi))
+            f_yy = a_m / (2 * r) * (2 * np.sin(phi_m) * np.sin(phi) + np.cos(phi - phi_m) * np.cos(2*phi))
+            f_xy = a_m / (2 * r) * (np.sin(phi + phi_m) - np.cos(phi - phi_m) * np.sin(2*phi))
         else:
             f_xx = 1.0 / r * np.sin(phi) ** 2 * a_m * np.cos(m * (phi - phi_m))
             f_yy = 1.0 / r * np.cos(phi) ** 2 * a_m * np.cos(m * (phi - phi_m))
@@ -122,20 +128,21 @@ class EllipticalMultipole(LensProfileBase):
     """This class contains a multipole contribution that encode deviations from the
     elliptical isodensity contours of a SIE with any axis ratio q.
 
-    m : int, multipole order, m=3 or m=4
+    m : int, multipole order, (m=1, m=3 or m=4)
     a_m : float, multipole strength
     phi_m : float, multipole orientation in radian
     q : axis ratio of the reference ellipses
     """
 
-    param_names = ["m", "a_m", "phi_m", "q", "center_x", "center_y"]
+    param_names = ["m", "a_m", "phi_m", "q", "center_x", "center_y", "r_E"]
     lower_limit_default = {
-        "m": 2,
+        "m": 1,
         "a_m": 0,
         "phi_m": -np.pi,
         "q": 0.001,
         "center_x": -100,
         "center_y": -100,
+        "r_E": 0,
     }
     upper_limit_default = {
         "m": 100,
@@ -144,49 +151,40 @@ class EllipticalMultipole(LensProfileBase):
         "q": 1,
         "center_x": 100,
         "center_y": 100,
+        "r_E": 100,
     }
 
-    def function(self, x, y, m, a_m, phi_m, q, center_x=0, center_y=0):
-        """Lensing potential of multipole contribution (for 1 component with m=3 or m=4)
+    def function(self, x, y, m, a_m, phi_m, q, center_x=0, center_y=0, r_E=1):
+        """Lensing potential of multipole contribution (for 1 component with m=1, m=3 or m=4)
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=2
+        :param m: int, multipole order (m=1, m=3 or m=4)
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
         :param center_y: y-position
+        :param r_E: float, normalizing radius (only used for odd m, Einstein radius by default)
         :return: lensing potential
         """
 
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
 
-        if np.abs(1 - q) < 1e-4:  # avoid numerical instability when q is too close to 1
-            f_ = r * a_m / (1 - m**2) * np.cos(m * (phi - phi_m))
+        if np.abs(1 - q**2)**((m+1)/2) < 1e-8:  # avoid numerical instability when q is too close to 1
+            if m == 1:
+                f_ = r * np.log(r/r_E) * a_m / 2 * np.cos(phi - phi_m)
+            else:
+                f_ = r * a_m / (1 - m**2) * np.cos(m * (phi - phi_m))
 
         else:
-            if m == 3:
-                ### Symmetrize at this level to avoid discontinuities
-                phisymm = param_util.cart2polar(-r * np.cos(phi), r * np.sin(phi))[1]
-                phirot = (
-                    param_util.cart2polar(-r * np.sin(phi), r * np.cos(phi))[1]
-                    - np.pi / 2
-                )  # find angle corresponding to phi in (-3pi/2, pi/2]
-                phirotsymm = (
-                    param_util.cart2polar(r * np.sin(phi), r * np.cos(phi))[1]
-                    - np.pi / 2
-                )  # find angle corresponding to -phi in (-3pi/2, pi/2]
-                f_ = (
-                    a_m
-                    * np.sqrt(q)
-                    * r
-                    * (
-                        (_F_m3_1(phi, q) - _F_m3_1(phisymm, q)) / 2 * np.cos(m * phi_m)
-                        + (_F_m3_2(phirot, q) - _F_m3_2(phirotsymm, q))
-                        / 2
-                        * np.sin(m * phi_m)
-                    )
-                )
+            if m==1:
+                f_ = a_m * np.sqrt(q) * (np.cos(m * phi_m) * _potential_m1_1(r, phi, q, r_E) 
+                                         - (1/q) * np.sin(m * phi_m) * _potential_m1_1(r, phi+np.pi/2, 1/q, r_E)) 
+                
+            elif m == 3:
+                f_ = a_m * np.sqrt(q) * (np.cos(m * phi_m) * _potential_m3_1(r, phi, q, r_E) 
+                                         - (1/q) * np.sin(m * phi_m) * _potential_m3_1(r, phi+np.pi/2, 1/q, r_E))
 
             elif m == 4:
                 f_ = (
@@ -201,27 +199,29 @@ class EllipticalMultipole(LensProfileBase):
 
             else:
                 raise ValueError(
-                    "Implementation of multipoles perturbation with m>4 for general axis ratio q not available."
+                    "Implementation of multipoles perturbation for general axis ratio q only available for m=1, m=3 or m=4."
                 )
 
         return f_
 
-    def derivatives(self, x, y, m, a_m, phi_m, q, center_x=0, center_y=0):
-        """Deflection of a multipole contribution (for 1 component with m=3 or m=4)
+    def derivatives(self, x, y, m, a_m, phi_m, q, center_x=0, center_y=0, r_E=1):
+        """Deflection of a multipole contribution (for 1 component with m=1, m=3 or m=4)
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=2
+        :param m: int, multipole order (m=1, m=3 or m=4)
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
         :param center_y: y-position
+        :param r_E: float, normalizing radius (only used for odd m, Einstein radius by default)
         :return: deflection angles alpha_x, alpha_y
         """
 
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
+        r = np.maximum(r, 0.000001)
 
-        if np.abs(1 - q) < 1e-4:  # avoid numerical instability when q is too close to 1
+        if np.abs(1 - q**2)**((m+1)/2) < 1e-8: # avoid numerical instability when q is too close to 1
             f_x = np.cos(phi) * a_m / (1 - m**2) * np.cos(m * (phi - phi_m)) + np.sin(
                 phi
             ) * m * a_m / (1 - m**2) * np.sin(m * (phi - phi_m))
@@ -230,37 +230,17 @@ class EllipticalMultipole(LensProfileBase):
             ) * m * a_m / (1 - m**2) * np.sin(m * (phi - phi_m))
 
         else:
-            if m == 3:
-                ### Symmetrize at this level to avoid discontinuities
-                phisymm = param_util.cart2polar(-r * np.cos(phi), r * np.sin(phi))[1]
-                phirot = (
-                    param_util.cart2polar(-r * np.sin(phi), r * np.cos(phi))[1]
-                    - np.pi / 2
-                )  # find angle corresponding to phi in (-3pi/2, pi/2]
-                phirotsymm = (
-                    param_util.cart2polar(r * np.sin(phi), r * np.cos(phi))[1]
-                    - np.pi / 2
-                )  # find angle corresponding to -phi in (-3pi/2, pi/2]
-                alpha_x_1_pos, alpha_y_1_pos = _deflection_m3_base(
-                    r, phi, q, a_3=a_m, phi_3=0
-                )
-                alpha_x_1_neg, alpha_y_1_neg = _deflection_m3_base(
-                    r, phisymm, q, a_3=a_m, phi_3=0
-                )
-                alpha_x_2_pos, alpha_y_2_pos = _deflection_m3_base(
-                    r, phirot, q, a_3=a_m, phi_3=np.pi / 6
-                )
-                alpha_x_2_neg, alpha_y_2_neg = _deflection_m3_base(
-                    r, phirotsymm, q, a_3=a_m, phi_3=np.pi / 6
-                )
-                f_x = (
-                    np.cos(m * phi_m) * (alpha_x_1_pos + alpha_x_1_neg) / 2
-                    + np.sin(m * phi_m) * (alpha_x_2_pos - alpha_x_2_neg) / 2
-                )
-                f_y = (
-                    np.cos(m * phi_m) * (alpha_y_1_pos - alpha_y_1_neg) / 2
-                    + np.sin(m * phi_m) * (alpha_y_2_pos + alpha_y_2_neg) / 2
-                )
+            if m==1:
+                alpha_x_1, alpha_y_1 = _alpha_m1_1(r, phi, q, r_E)
+                alpha_x_2, alpha_y_2 = _alpha_m1_1(r, phi+np.pi/2, 1/q, r_E)
+                f_x = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_x_1 - (1/q) * np.sin(m * phi_m) * alpha_y_2)
+                f_y = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_y_1 + (1/q) * np.sin(m * phi_m) * alpha_x_2)
+
+            elif m == 3:
+                alpha_x_1, alpha_y_1 = _alpha_m3_1(r, phi, q, r_E)
+                alpha_x_2, alpha_y_2 = _alpha_m3_1(r, phi+np.pi/2, 1/q, r_E)
+                f_x = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_x_1 - (1/q) * np.sin(m * phi_m) * alpha_y_2)
+                f_y = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_y_1 + (1/q) * np.sin(m * phi_m) * alpha_x_2)
 
             elif m == 4:
                 F_m4 = _F_m4_1(phi, q=q) * np.cos(m * phi_m) + _F_m4_2(
@@ -274,32 +254,56 @@ class EllipticalMultipole(LensProfileBase):
 
             else:
                 raise ValueError(
-                    "Implementation of multipoles perturbation with m>4 for general axis ratio q not available."
+                    "Implementation of multipoles perturbation for general axis ratio q only available for m=1, m=3 or m=4."
                 )
 
         return f_x, f_y
 
-    def hessian(self, x, y, m, a_m, phi_m, q, center_x=0, center_y=0):
-        """Hessian of a multipole contribution (for 1 component with m=3 or m=4)
+    def hessian(self, x, y, m, a_m, phi_m, q, center_x=0, center_y=0, r_E=1):
+        """Hessian of a multipole contribution (for 1 component with m=1, m=3 or m=4)
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=2
+        :param m: int, multipole order (m=1, m=3 or m=4)
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
         :param center_y: y-position
+        :param r_E: float, normalizing radius (not used for Hessian)
         :return: f_xx, f_xy, f_yx, f_yy
         """
+
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
         r = np.maximum(r, 0.000001)
-        phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
-        R = np.sqrt(q * (r * np.cos(phi)) ** 2 + (r * np.sin(phi)) ** 2 / q)
+        
+        if m==1:
+            d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m1_1(r, phi, q)
+            d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m1_1(r, phi+np.pi/2, 1/q)
+            f_xx = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dx2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dy2_2)
+            f_yy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dy2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dx2_2)
+            f_xy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dxdy_1 + (1/q) * np.sin(m * phi_m) * d2psi_dxdy_2)
 
-        delta_r = a_m * np.cos(m * (phi_ell - phi_m)) * r / R
-        f_xx = np.sin(phi) ** 2 * delta_r / r
-        f_yy = np.cos(phi) ** 2 * delta_r / r
-        f_xy = -np.sin(phi) * np.cos(phi) * delta_r / r
+        elif m==3:
+            d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m3_1(r, phi, q)
+            d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m3_1(r, phi+np.pi/2, 1/q)
+            f_xx = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dx2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dy2_2)
+            f_yy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dy2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dx2_2)
+            f_xy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dxdy_1 + (1/q) * np.sin(m * phi_m) * d2psi_dxdy_2)
+            
+        elif (m%2)==0: #for m=4, will also work for any even m
+            phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
+            R = np.sqrt(q * (r * np.cos(phi)) ** 2 + (r * np.sin(phi)) ** 2 / q)
+    
+            delta_r = a_m * np.cos(m * (phi_ell - phi_m)) * r / R
+            f_xx = np.sin(phi) ** 2 * delta_r / r
+            f_yy = np.cos(phi) ** 2 * delta_r / r
+            f_xy = -np.sin(phi) * np.cos(phi) * delta_r / r
+
+        else:
+            raise ValueError(
+                    "Implementation of multipoles perturbation for general axis ratio q only available for m=1, m=3 or m=4."
+                )
+            
         return f_xx, f_xy, f_xy, f_yy
 
 
@@ -310,58 +314,74 @@ def _phi_ell(phi, q):
         + np.arctan2(np.sin(phi), q * np.cos(phi))
     )
 
+def _G_m_1(m, phi_m, phi, q):
+    return np.cos(m*np.arctan2(np.sin(phi), q*np.cos(phi)))/np.sqrt(q**2*np.cos(phi)**2+np.sin(phi)**2)
 
-def _F_m3_1(phi, q):
-    term1 = np.cos(phi) * (
-        q * (3 + q**2) * np.log(1 + q**2 + (q**2 - 1) * np.cos(2 * phi))
-        - (
-            np.log(2) * (1 + q) ** 2
-            - 2 * (1 - q) * (1 + q) ** 2 * (1 + np.log(2) / 4)
-            + (1 - q**2) ** 2 / 4
-        )
-    )
-    term2 = (
-        2 * np.sin(phi) * (q * (q**2 + 3) * phi - (1 + 3 * q**2) * _phi_ell(phi, q))
-    )  # Expression valid in (-pi, pi]
-    return (term1 + term2) / (2 * (1 - q**2) ** 2)
+def _F_m1_1_hat(phi, q):
+    term1 = np.cos(phi) * (q*np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - (np.log(2)*(1+q)/2 - (1-q**2)*(1+np.log(2)/4)))
+    term2 = 2 * np.sin(phi) * (phi - phi_ell(phi,q)) 
+    return -(term1+term2)/(2*(1-q**2))
 
+def _F_m1_1_hat_derivative(phi,q):
+    term1 = - np.cos(phi) *q * 2*(q**2-1)*np.sin(2*phi)/(1+q**2+(q**2-1)*np.cos(2*phi)) + np.sin(phi) * (
+        - q*np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + np.log(2)*(1+q)/2 - (1-q**2)*(1+np.log(2)/4))
+    term2 = 2 * np.cos(phi) * (phi - phi_ell(phi,q)) + 2 * np.sin(phi) * (1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
+    return -(term1+term2)/(2*(1-q**2))
 
-def _F_m3_1_derivative(phi, q):
-    term1 = -np.cos(phi) * q * (3 + q**2) * 2 * (q**2 - 1) * np.sin(2 * phi) / (
-        1 + q**2 + (q**2 - 1) * np.cos(2 * phi)
-    ) + np.sin(phi) * (
-        -q * (3 + q**2) * np.log(1 + q**2 + (q**2 - 1) * np.cos(2 * phi))
-        + np.log(2) * (1 + q) ** 2
-        - 2 * (1 - q) * (1 + q) ** 2 * (1 + np.log(2) / 4)
-        + (1 - q**2) ** 2 / 4
-    )
-    term2 = 2 * np.cos(phi) * (
-        q * (q**2 + 3) * phi - (1 + 3 * q**2) * _phi_ell(phi, q)
-    ) + 2 * np.sin(phi) * (
-        q * (q**2 + 3)
-        - (1 + 3 * q**2) * q / (q**2 * np.cos(phi) ** 2 + np.sin(phi) ** 2)
-    )  # Expression valid in (-pi, pi]
-    return (term1 + term2) / (2 * (1 - q**2) ** 2)
+def _potential_m1_1(r, phi, q, r_E):
+    lambda_m1 = 2/(1+q)
+    return (r*_F_m1_1_hat(phi, q) + lambda_m1/2 *r*np.log(r/r_E)*np.cos(phi))
 
-
-def _F_m3_2(phi, q):
-    # Expression valid in (-3*pi/2, pi/2]
-    return 1 / q * _F_m3_1(phi + np.pi / 2, 1 / q)
-
-
-def _F_m3_2_derivative(phi, q):
-    # Expression valid in (-3*pi/2, pi/2]
-    return 1 / q * _F_m3_1_derivative(phi + np.pi / 2, 1 / q)
-
-
-def _deflection_m3_base(r, phi, q, a_3, phi_3):
-    F_m3 = _F_m3_1(phi, q=q) * np.cos(3 * phi_3) + _F_m3_2(phi, q=q) * np.sin(3 * phi_3)
-    F_m3_prime = _F_m3_1_derivative(phi, q=q) * np.cos(3 * phi_3) + _F_m3_2_derivative(
-        phi, q=q
-    ) * np.sin(3 * phi_3)
-    alpha_x = a_3 * np.sqrt(q) * (F_m3 * np.cos(phi) - F_m3_prime * np.sin(phi))
-    alpha_y = a_3 * np.sqrt(q) * (F_m3 * np.sin(phi) + F_m3_prime * np.cos(phi))
+def _alpha_m1_1(r, phi, q, r_E):
+    lambda_m1 = 2/(1+q)
+    f_phi = _F_m1_1_hat(phi, q)
+    df_dphi = _F_m1_1_hat_derivative(phi,q)
+    alpha_x = f_phi*np.cos(phi) - df_dphi*np.sin(phi) + lambda_m1/2 * (np.log(r/r_E) + np.cos(phi)**2)
+    alpha_y = f_phi*np.sin(phi) + df_dphi*np.cos(phi) + lambda_m1/2 * np.cos(phi)*np.sin(phi)
     return alpha_x, alpha_y
+
+def _hessian_m1_1(r, phi, q):
+    lambda_m1 = 2/(1+q)
+    G_m1_1 = _G_m_1(1, phi, q)
+    d2psi_dx2 = (np.sin(phi)**2 * G_m1_1 + lambda_m1/2 * np.cos(phi))/r
+    d2psi_dy2 = (np.cos(phi)**2 * G_m1_1 - lambda_m1/2 * np.cos(phi))/r
+    d2psi_dxdy = (-np.cos(phi)*np.sin(phi) * G_m1_1 + lambda_m1/2 * np.sin(phi))/r
+    return d2psi_dx2, d2psi_dy2, d2psi_dxdy
+
+def _A_3_1(q):
+    return (np.log(2)*(1+q)**2 - 2*(1-q)*(1+q)**2*(1+np.log(2)/4) + (1-q**2)**2/4)
+
+def _F_m3_1_hat(phi,q): 
+    term1 = np.cos(phi) * (q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - A_3_1(q) )
+    term2 = 2 * np.sin(phi) * (1+3*q**2)*(phi -  phi_ell(phi,q))
+    return (term1+term2)/(2*(1-q**2)**2)
+
+def _F_m3_1_hat_derivative(phi,q): 
+    term1 = - np.cos(phi) *q*(3+q**2) * 2*(q**2-1)*np.sin(2*phi)/(1+q**2+(q**2-1)*np.cos(2*phi)) + np.sin(phi) * (
+        -q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + A_3_1(q))
+    term2 = 2 * np.cos(phi) * (1+3*q**2) * (phi - phi_ell(phi,q)) + 2 * np.sin(phi) * (1+3*q**2)* (
+        1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
+    return (term1+term2)/(2*(1-q**2)**2)
+
+def _potential_m3_1(r, phi, q, r_E):
+    lambda_m3 = -2*(1-q)/(1+q)**2
+    return (r*_F_m3_1_hat(phi, q) + lambda_m3/2 *r*np.log(r/r_E)*np.cos(phi))
+
+def _alpha_m3_1(r, phi, q, r_E):
+    lambda_m3 = -2*(1-q)/(1+q)**2
+    f_phi = _F_m3_1_hat(phi, q)
+    df_dphi = _F_m3_1_hat_derivative(phi,q)
+    alpha_x = f_phi*np.cos(phi) - df_dphi*np.sin(phi) + lambda_m3/2 * (np.log(r/r_E) + np.cos(phi)**2)
+    alpha_y = f_phi*np.sin(phi) + df_dphi*np.cos(phi) + lambda_m3/2 * np.cos(phi)*np.sin(phi)
+    return alpha_x, alpha_y
+
+def _hessian_m3_1(r, phi, q):
+    lambda_m3 = -2*(1-q)/(1+q)**2
+    G_m3_1 = _G_m_1(3, phi, q)
+    d2psi_dx2 = (np.sin(phi)**2 * G_m3_1 + lambda_m3/2 * np.cos(phi))/r
+    d2psi_dy2 = (np.cos(phi)**2 * G_m3_1 - lambda_m3/2 * np.cos(phi))/r
+    d2psi_dxdy = (-np.cos(phi)*np.sin(phi) * G_m3_1 + lambda_m3/2 * np.sin(phi))/r
+    return d2psi_dx2, d2psi_dy2, d2psi_dxdy
 
 
 def _F_m4_1(phi, q):

--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -83,7 +83,7 @@ class Multipole(LensProfileBase):
         if m == 1:
             r = np.maximum(r, 0.000001)
             f_x = a_m/2 * (np.cos(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.cos(phi))
-            f_y = a_m/2 * (np.sin(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.sin(phi))
+            f_x = a_m/2 * (np.sin(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.sin(phi))
         else:
             f_x = np.cos(phi) * a_m / (1 - m**2) * np.cos(m * (phi - phi_m)) + np.sin(
                 phi
@@ -184,7 +184,7 @@ class EllipticalMultipole(LensProfileBase):
                 
             elif m == 3:
                 f_ = a_m * np.sqrt(q) * (np.cos(m * phi_m) * _potential_m3_1(r, phi, q, r_E) 
-                                         + (1/q) * np.sin(m * phi_m) * _potential_m3_1(r, phi+np.pi/2, 1/q, r_E))
+                                         - (1/q) * np.sin(m * phi_m) * _potential_m3_1(r, phi+np.pi/2, 1/q, r_E))
 
             elif m == 4:
                 f_ = (
@@ -239,8 +239,8 @@ class EllipticalMultipole(LensProfileBase):
             elif m == 3:
                 alpha_x_1, alpha_y_1 = _alpha_m3_1(r, phi, q, r_E)
                 alpha_x_2, alpha_y_2 = _alpha_m3_1(r, phi+np.pi/2, 1/q, r_E)
-                f_x = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_x_1 + (1/q) * np.sin(m * phi_m) * alpha_y_2)
-                f_y = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_y_1 - (1/q) * np.sin(m * phi_m) * alpha_x_2)
+                f_x = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_x_1 - (1/q) * np.sin(m * phi_m) * alpha_y_2)
+                f_y = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_y_1 + (1/q) * np.sin(m * phi_m) * alpha_x_2)
 
             elif m == 4:
                 F_m4 = _F_m4_1(phi, q=q) * np.cos(m * phi_m) + _F_m4_2(
@@ -286,9 +286,9 @@ class EllipticalMultipole(LensProfileBase):
         elif m==3:
             d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m3_1(r, phi, q)
             d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m3_1(r, phi+np.pi/2, 1/q)
-            f_xx = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dx2_1 + (1/q) * np.sin(m * phi_m) * d2psi_dy2_2)
-            f_yy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dy2_1 + (1/q) * np.sin(m * phi_m) * d2psi_dx2_2)
-            f_xy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dxdy_1 - (1/q) * np.sin(m * phi_m) * d2psi_dxdy_2)
+            f_xx = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dx2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dy2_2)
+            f_yy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dy2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dx2_2)
+            f_xy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dxdy_1 + (1/q) * np.sin(m * phi_m) * d2psi_dxdy_2)
             
         elif (m%2)==0: #for m=4, will also work for any even m
             phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
@@ -314,18 +314,18 @@ def _phi_ell(phi, q):
         + np.arctan2(np.sin(phi), q * np.cos(phi))
     )
 
-def _G_m_1(m, phi, q):
+def _G_m_1(m, phi_m, phi, q):
     return np.cos(m*np.arctan2(np.sin(phi), q*np.cos(phi)))/np.sqrt(q**2*np.cos(phi)**2+np.sin(phi)**2)
 
 def _F_m1_1_hat(phi, q):
     term1 = np.cos(phi) * (q*np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - (np.log(2)*(1+q)/2 - (1-q**2)*(1+np.log(2)/4)))
-    term2 = 2 * np.sin(phi) * (phi - _phi_ell(phi,q)) 
+    term2 = 2 * np.sin(phi) * (phi - phi_ell(phi,q)) 
     return -(term1+term2)/(2*(1-q**2))
 
 def _F_m1_1_hat_derivative(phi,q):
     term1 = - np.cos(phi) *q * 2*(q**2-1)*np.sin(2*phi)/(1+q**2+(q**2-1)*np.cos(2*phi)) + np.sin(phi) * (
         - q*np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + np.log(2)*(1+q)/2 - (1-q**2)*(1+np.log(2)/4))
-    term2 = 2 * np.cos(phi) * (phi - _phi_ell(phi,q)) + 2 * np.sin(phi) * (1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
+    term2 = 2 * np.cos(phi) * (phi - phi_ell(phi,q)) + 2 * np.sin(phi) * (1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
     return -(term1+term2)/(2*(1-q**2))
 
 def _potential_m1_1(r, phi, q, r_E):
@@ -352,14 +352,14 @@ def _A_3_1(q):
     return (np.log(2)*(1+q)**2 - 2*(1-q)*(1+q)**2*(1+np.log(2)/4) + (1-q**2)**2/4)
 
 def _F_m3_1_hat(phi,q): 
-    term1 = np.cos(phi) * (q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - _A_3_1(q) )
-    term2 = 2 * np.sin(phi) * (1+3*q**2)*(phi - _phi_ell(phi,q))
+    term1 = np.cos(phi) * (q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - A_3_1(q) )
+    term2 = 2 * np.sin(phi) * (1+3*q**2)*(phi -  phi_ell(phi,q))
     return (term1+term2)/(2*(1-q**2)**2)
 
 def _F_m3_1_hat_derivative(phi,q): 
     term1 = - np.cos(phi) *q*(3+q**2) * 2*(q**2-1)*np.sin(2*phi)/(1+q**2+(q**2-1)*np.cos(2*phi)) + np.sin(phi) * (
-        -q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + _A_3_1(q))
-    term2 = 2 * np.cos(phi) * (1+3*q**2) * (phi -_phi_ell(phi,q)) + 2 * np.sin(phi) * (1+3*q**2)* (
+        -q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + A_3_1(q))
+    term2 = 2 * np.cos(phi) * (1+3*q**2) * (phi - phi_ell(phi,q)) + 2 * np.sin(phi) * (1+3*q**2)* (
         1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
     return (term1+term2)/(2*(1-q**2)**2)
 

--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -83,7 +83,7 @@ class Multipole(LensProfileBase):
         if m == 1:
             r = np.maximum(r, 0.000001)
             f_x = a_m/2 * (np.cos(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.cos(phi))
-            f_x = a_m/2 * (np.sin(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.sin(phi))
+            f_y = a_m/2 * (np.sin(phi_m) * np.log(r/r_E) + np.cos(phi - phi_m) * np.sin(phi))
         else:
             f_x = np.cos(phi) * a_m / (1 - m**2) * np.cos(m * (phi - phi_m)) + np.sin(
                 phi
@@ -184,7 +184,7 @@ class EllipticalMultipole(LensProfileBase):
                 
             elif m == 3:
                 f_ = a_m * np.sqrt(q) * (np.cos(m * phi_m) * _potential_m3_1(r, phi, q, r_E) 
-                                         - (1/q) * np.sin(m * phi_m) * _potential_m3_1(r, phi+np.pi/2, 1/q, r_E))
+                                         + (1/q) * np.sin(m * phi_m) * _potential_m3_1(r, phi+np.pi/2, 1/q, r_E))
 
             elif m == 4:
                 f_ = (
@@ -239,8 +239,8 @@ class EllipticalMultipole(LensProfileBase):
             elif m == 3:
                 alpha_x_1, alpha_y_1 = _alpha_m3_1(r, phi, q, r_E)
                 alpha_x_2, alpha_y_2 = _alpha_m3_1(r, phi+np.pi/2, 1/q, r_E)
-                f_x = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_x_1 - (1/q) * np.sin(m * phi_m) * alpha_y_2)
-                f_y = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_y_1 + (1/q) * np.sin(m * phi_m) * alpha_x_2)
+                f_x = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_x_1 + (1/q) * np.sin(m * phi_m) * alpha_y_2)
+                f_y = a_m * np.sqrt(q) * (np.cos(m * phi_m) * alpha_y_1 - (1/q) * np.sin(m * phi_m) * alpha_x_2)
 
             elif m == 4:
                 F_m4 = _F_m4_1(phi, q=q) * np.cos(m * phi_m) + _F_m4_2(
@@ -286,9 +286,9 @@ class EllipticalMultipole(LensProfileBase):
         elif m==3:
             d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m3_1(r, phi, q)
             d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m3_1(r, phi+np.pi/2, 1/q)
-            f_xx = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dx2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dy2_2)
-            f_yy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dy2_1 - (1/q) * np.sin(m * phi_m) * d2psi_dx2_2)
-            f_xy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dxdy_1 + (1/q) * np.sin(m * phi_m) * d2psi_dxdy_2)
+            f_xx = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dx2_1 + (1/q) * np.sin(m * phi_m) * d2psi_dy2_2)
+            f_yy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dy2_1 + (1/q) * np.sin(m * phi_m) * d2psi_dx2_2)
+            f_xy = a_m * np.sqrt(q) * (np.cos(m * phi_m) * d2psi_dxdy_1 - (1/q) * np.sin(m * phi_m) * d2psi_dxdy_2)
             
         elif (m%2)==0: #for m=4, will also work for any even m
             phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
@@ -314,18 +314,18 @@ def _phi_ell(phi, q):
         + np.arctan2(np.sin(phi), q * np.cos(phi))
     )
 
-def _G_m_1(m, phi_m, phi, q):
+def _G_m_1(m, phi, q):
     return np.cos(m*np.arctan2(np.sin(phi), q*np.cos(phi)))/np.sqrt(q**2*np.cos(phi)**2+np.sin(phi)**2)
 
 def _F_m1_1_hat(phi, q):
     term1 = np.cos(phi) * (q*np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - (np.log(2)*(1+q)/2 - (1-q**2)*(1+np.log(2)/4)))
-    term2 = 2 * np.sin(phi) * (phi - phi_ell(phi,q)) 
+    term2 = 2 * np.sin(phi) * (phi - _phi_ell(phi,q)) 
     return -(term1+term2)/(2*(1-q**2))
 
 def _F_m1_1_hat_derivative(phi,q):
     term1 = - np.cos(phi) *q * 2*(q**2-1)*np.sin(2*phi)/(1+q**2+(q**2-1)*np.cos(2*phi)) + np.sin(phi) * (
         - q*np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + np.log(2)*(1+q)/2 - (1-q**2)*(1+np.log(2)/4))
-    term2 = 2 * np.cos(phi) * (phi - phi_ell(phi,q)) + 2 * np.sin(phi) * (1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
+    term2 = 2 * np.cos(phi) * (phi - _phi_ell(phi,q)) + 2 * np.sin(phi) * (1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
     return -(term1+term2)/(2*(1-q**2))
 
 def _potential_m1_1(r, phi, q, r_E):
@@ -352,14 +352,14 @@ def _A_3_1(q):
     return (np.log(2)*(1+q)**2 - 2*(1-q)*(1+q)**2*(1+np.log(2)/4) + (1-q**2)**2/4)
 
 def _F_m3_1_hat(phi,q): 
-    term1 = np.cos(phi) * (q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - A_3_1(q) )
-    term2 = 2 * np.sin(phi) * (1+3*q**2)*(phi -  phi_ell(phi,q))
+    term1 = np.cos(phi) * (q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) - _A_3_1(q) )
+    term2 = 2 * np.sin(phi) * (1+3*q**2)*(phi - _phi_ell(phi,q))
     return (term1+term2)/(2*(1-q**2)**2)
 
 def _F_m3_1_hat_derivative(phi,q): 
     term1 = - np.cos(phi) *q*(3+q**2) * 2*(q**2-1)*np.sin(2*phi)/(1+q**2+(q**2-1)*np.cos(2*phi)) + np.sin(phi) * (
-        -q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + A_3_1(q))
-    term2 = 2 * np.cos(phi) * (1+3*q**2) * (phi - phi_ell(phi,q)) + 2 * np.sin(phi) * (1+3*q**2)* (
+        -q*(3+q**2) * np.log(1+q**2+(q**2-1)*np.cos(2*phi)) + _A_3_1(q))
+    term2 = 2 * np.cos(phi) * (1+3*q**2) * (phi -_phi_ell(phi,q)) + 2 * np.sin(phi) * (1+3*q**2)* (
         1 - q/(q**2*np.cos(phi)**2+np.sin(phi)**2))
     return (term1+term2)/(2*(1-q**2)**2)
 

--- a/test/test_LensModel/test_Profiles/test_epl_multipole_m3m4.py
+++ b/test/test_LensModel/test_Profiles/test_epl_multipole_m3m4.py
@@ -57,21 +57,21 @@ class TestEPL_MULTIPOLE_M3M4(object):
             kwargs_epl_multipole_m3m4[0]["e1"], kwargs_epl_multipole_m3m4[0]["e2"]
         )
         rescale = kwargs_epl_multipole_m3m4[0]["theta_E"] / np.sqrt(q)
-        kwargs_multliple_m3 = {
+        kwargs_multipole_m3 = {
             "m": 3,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a3_a * rescale,
             "phi_m": phi_q + delta_phi_m3,
         }
-        kwargs_multliple_m4 = {
+        kwargs_multipole_m4 = {
             "m": 4,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a4_a * rescale,
             "phi_m": phi_q + delta_phi_m4,
         }
-        kwargs_split = [kwargs_epl, kwargs_multliple_m3, kwargs_multliple_m4]
+        kwargs_split = [kwargs_epl, kwargs_multipole_m3, kwargs_multipole_m4]
         function_joint = self.lens_model.potential(
             self.x, self.y, kwargs_epl_multipole_m3m4
         )
@@ -128,21 +128,21 @@ class TestEPL_MULTIPOLE_M3M4(object):
             kwargs_epl_multipole_m3m4[0]["e1"], kwargs_epl_multipole_m3m4[0]["e2"]
         )
         rescale = kwargs_epl_multipole_m3m4[0]["theta_E"] / np.sqrt(q)
-        kwargs_multliple_m3 = {
+        kwargs_multipole_m3 = {
             "m": 3,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a3_a * rescale,
             "phi_m": phi_q + delta_phi_m3,
         }
-        kwargs_multliple_m4 = {
+        kwargs_multipole_m4 = {
             "m": 4,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a4_a * rescale,
             "phi_m": phi_q + delta_phi_m4,
         }
-        kwargs_split = [kwargs_epl, kwargs_multliple_m3, kwargs_multliple_m4]
+        kwargs_split = [kwargs_epl, kwargs_multipole_m3, kwargs_multipole_m4]
         alpha_x, alpha_y = self.lens_model.alpha(
             self.x, self.y, kwargs_epl_multipole_m3m4
         )
@@ -203,21 +203,21 @@ class TestEPL_MULTIPOLE_M3M4(object):
             kwargs_epl_multipole_m3m4[0]["e1"], kwargs_epl_multipole_m3m4[0]["e2"]
         )
         rescale = kwargs_epl_multipole_m3m4[0]["theta_E"] / np.sqrt(q)
-        kwargs_multliple_m3 = {
+        kwargs_multipole_m3 = {
             "m": 3,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a3_a * rescale,
             "phi_m": phi_q + delta_phi_m3,
         }
-        kwargs_multliple_m4 = {
+        kwargs_multipole_m4 = {
             "m": 4,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a4_a * rescale,
             "phi_m": phi_q + delta_phi_m4,
         }
-        kwargs_split = [kwargs_epl, kwargs_multliple_m3, kwargs_multliple_m4]
+        kwargs_split = [kwargs_epl, kwargs_multipole_m3, kwargs_multipole_m4]
         fxx, fxy, fyx, fyy = self.lens_model.hessian(
             self.x, self.y, kwargs_epl_multipole_m3m4
         )
@@ -298,15 +298,17 @@ class TestEPL_MULTIPOLE_M3M4_ELL(object):
             kwargs_epl_multipole_m3m4[0]["e1"], kwargs_epl_multipole_m3m4[0]["e2"]
         )
         rescale = kwargs_epl_multipole_m3m4[0]["theta_E"] / np.sqrt(q)
-        kwargs_multliple_m3 = {
+        kwargs_multipole_m3 = {
             "m": 3,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a3_a * rescale,
             "phi_m": phi_q + delta_phi_m3,
             "q": q,
+            "r_E": kwargs_epl_multipole_m3m4[0]["theta_E"],
+
         }
-        kwargs_multliple_m4 = {
+        kwargs_multipole_m4 = {
             "m": 4,
             "center_x": 0.1,
             "center_y": 0.0,
@@ -314,7 +316,7 @@ class TestEPL_MULTIPOLE_M3M4_ELL(object):
             "phi_m": phi_q + delta_phi_m4,
             "q": q,
         }
-        kwargs_split = [kwargs_epl, kwargs_multliple_m3, kwargs_multliple_m4]
+        kwargs_split = [kwargs_epl, kwargs_multipole_m3, kwargs_multipole_m4]
         function_joint = self.lens_model.potential(
             self.x, self.y, kwargs_epl_multipole_m3m4
         )
@@ -371,15 +373,17 @@ class TestEPL_MULTIPOLE_M3M4_ELL(object):
             kwargs_epl_multipole_m3m4[0]["e1"], kwargs_epl_multipole_m3m4[0]["e2"]
         )
         rescale = kwargs_epl_multipole_m3m4[0]["theta_E"] / np.sqrt(q)
-        kwargs_multliple_m3 = {
+        kwargs_multipole_m3 = {
             "m": 3,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a3_a * rescale,
             "phi_m": phi_q + delta_phi_m3,
             "q": q,
+            "r_E": kwargs_epl_multipole_m3m4[0]["theta_E"],
+
         }
-        kwargs_multliple_m4 = {
+        kwargs_multipole_m4 = {
             "m": 4,
             "center_x": 0.1,
             "center_y": 0.0,
@@ -387,7 +391,7 @@ class TestEPL_MULTIPOLE_M3M4_ELL(object):
             "phi_m": phi_q + delta_phi_m4,
             "q": q,
         }
-        kwargs_split = [kwargs_epl, kwargs_multliple_m3, kwargs_multliple_m4]
+        kwargs_split = [kwargs_epl, kwargs_multipole_m3, kwargs_multipole_m4]
         alpha_x, alpha_y = self.lens_model.alpha(
             self.x, self.y, kwargs_epl_multipole_m3m4
         )
@@ -448,15 +452,16 @@ class TestEPL_MULTIPOLE_M3M4_ELL(object):
             kwargs_epl_multipole_m3m4[0]["e1"], kwargs_epl_multipole_m3m4[0]["e2"]
         )
         rescale = kwargs_epl_multipole_m3m4[0]["theta_E"] / np.sqrt(q)
-        kwargs_multliple_m3 = {
+        kwargs_multipole_m3 = {
             "m": 3,
             "center_x": 0.1,
             "center_y": 0.0,
             "a_m": a3_a * rescale,
             "phi_m": phi_q + delta_phi_m3,
             "q": q,
+            "r_E": kwargs_epl_multipole_m3m4[0]["theta_E"],
         }
-        kwargs_multliple_m4 = {
+        kwargs_multipole_m4 = {
             "m": 4,
             "center_x": 0.1,
             "center_y": 0.0,
@@ -464,7 +469,7 @@ class TestEPL_MULTIPOLE_M3M4_ELL(object):
             "phi_m": phi_q + delta_phi_m4,
             "q": q,
         }
-        kwargs_split = [kwargs_epl, kwargs_multliple_m3, kwargs_multliple_m4]
+        kwargs_split = [kwargs_epl, kwargs_multipole_m3, kwargs_multipole_m4]
         fxx, fxy, fyx, fyy = self.lens_model.hessian(
             self.x, self.y, kwargs_epl_multipole_m3m4
         )

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -9,13 +9,13 @@ import pytest
 import numpy.testing as npt
 
 
-class TestMultipole(object): 
+class TestMultipole(object):
     """Tests the Gaussian methods."""
 
     def setup_method(self):
         self.Multipole = Multipole()
 
-    def test_function(self): 
+    def test_function(self):
         x = 1
         y = 2
         m = 4
@@ -35,8 +35,8 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[1], -0.009453038, decimal=6)
         npt.assert_almost_equal(values[2], -0.009910505, decimal=6)
 
-        m=1
-        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.)
+        m = 1
+        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.0)
         npt.assert_almost_equal(values[0], 0.04496838, decimal=6)
         npt.assert_almost_equal(values[1], 0.09042084, decimal=6)
         npt.assert_almost_equal(values[2], 0.14335526, decimal=6)
@@ -67,9 +67,9 @@ class TestMultipole(object):
         npt.assert_almost_equal(f_y[1], -0.006541883, decimal=6)
         npt.assert_almost_equal(f_y[2], 0.001649720, decimal=6)
 
-        m=1
-        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
-        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)   
+        m = 1
+        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.0)
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
         npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
         npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
@@ -103,10 +103,10 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[3][1], 0.012761602, decimal=6)
         npt.assert_almost_equal(values[1][1], -0.004253867, decimal=6)
 
-        m=1
-        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
-        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)  
-        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)   
+        m = 1
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.0)
+        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)
+        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)
         npt.assert_almost_equal(values[1][0], 0.00416999, decimal=6)
         npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
@@ -114,8 +114,9 @@ class TestMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
         r, phi = np.sqrt(x**2 + y**2), np.arctan2(y, x)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(phi-phi_m)/r, decimal=6)
-
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(phi - phi_m) / r, decimal=6
+        )
 
 
 class TestEllipticalMultipole(object):
@@ -249,17 +250,23 @@ class TestEllipticalMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
 
-        #Check convergence profiles
-        R, phi_ell = np.sqrt(q*x**2 + y**2/q), np.arctan2(y, q*x)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+        # Check convergence profiles
+        R, phi_ell = np.sqrt(q * x**2 + y**2 / q), np.arctan2(y, q * x)
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
+        )
 
-        m=3
+        m = 3
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
+        )
 
-        m=1
+        m = 1
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
+        )
 
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -282,8 +282,10 @@ class TestEllipticalMultipole(object):
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
-        f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = self.Multipole.hessian(
-            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
+        f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
+            self.Multipole.hessian(
+                self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
+            )
         )
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
@@ -293,8 +295,10 @@ class TestEllipticalMultipole(object):
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
 
-        f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = self.Multipole.hessian(
-            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
+        f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
+            self.Multipole.hessian(
+                self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
+            )
         )
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -9,13 +9,13 @@ import pytest
 import numpy.testing as npt
 
 
-class TestMultipole(object): 
+class TestMultipole(object):
     """Tests the Gaussian methods."""
 
     def setup_method(self):
         self.Multipole = Multipole()
 
-    def test_function(self): 
+    def test_function(self):
         x = 1
         y = 2
         m = 4
@@ -35,8 +35,8 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[1], -0.009453038, decimal=6)
         npt.assert_almost_equal(values[2], -0.009910505, decimal=6)
 
-        m=1
-        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.)
+        m = 1
+        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.0)
         npt.assert_almost_equal(values[0], 0.04496838, decimal=6)
         npt.assert_almost_equal(values[1], 0.09042084, decimal=6)
         npt.assert_almost_equal(values[2], 0.14335526, decimal=6)
@@ -60,16 +60,16 @@ class TestMultipole(object):
         x = np.array([2, 3, 1])
         y = np.array([1, 1, 4])
         f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m)
-        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)  
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
         npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
-        npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)   
+        npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
         npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
         npt.assert_almost_equal(f_y[2], 0.03024228, decimal=6)
 
-        m=1
-        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
-        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)    
+        m = 1
+        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.0)
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
         npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
         npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
@@ -103,10 +103,10 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[3][1], 0.012761602, decimal=6)
         npt.assert_almost_equal(values[1][1], -0.004253867, decimal=6)
 
-        m=1
-        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
-        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)  
-        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)   
+        m = 1
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.0)
+        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)
+        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)
         npt.assert_almost_equal(values[1][0], 0.00416999, decimal=6)
         npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
@@ -114,8 +114,9 @@ class TestMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
         r, phi = np.sqrt(x**2 + y**2), np.arctan2(y, x)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(phi-phi_m)/r, decimal=6)
-
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(phi - phi_m) / r, decimal=6
+        )
 
 
 class TestEllipticalMultipole(object):
@@ -249,17 +250,23 @@ class TestEllipticalMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
 
-        #Check convergence profiles
-        R, phi_ell = np.sqrt(q*x**2 + y**2/q), np.arctan2(y, q*x)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+        # Check convergence profiles
+        R, phi_ell = np.sqrt(q * x**2 + y**2 / q), np.arctan2(y, q * x)
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
+        )
 
-        m=3
+        m = 3
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
+        )
 
-        m=1
+        m = 1
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+        npt.assert_almost_equal(
+            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
+        )
 
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -9,13 +9,13 @@ import pytest
 import numpy.testing as npt
 
 
-class TestMultipole(object):
+class TestMultipole(object): 
     """Tests the Gaussian methods."""
 
     def setup_method(self):
         self.Multipole = Multipole()
 
-    def test_function(self):
+    def test_function(self): 
         x = 1
         y = 2
         m = 4
@@ -35,8 +35,8 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[1], -0.009453038, decimal=6)
         npt.assert_almost_equal(values[2], -0.009910505, decimal=6)
 
-        m = 1
-        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.0)
+        m=1
+        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.)
         npt.assert_almost_equal(values[0], 0.04496838, decimal=6)
         npt.assert_almost_equal(values[1], 0.09042084, decimal=6)
         npt.assert_almost_equal(values[2], 0.14335526, decimal=6)
@@ -60,16 +60,16 @@ class TestMultipole(object):
         x = np.array([2, 3, 1])
         y = np.array([1, 1, 4])
         f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m)
-        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)
-        npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
-        npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
-        npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
-        npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
-        npt.assert_almost_equal(f_y[2], 0.03024228, decimal=6)
+        npt.assert_almost_equal(f_x[0], -0.003613858, decimal=6)
+        npt.assert_almost_equal(f_x[1], -0.000970385, decimal=6)
+        npt.assert_almost_equal(f_x[2], 0.005970704, decimal=6)
+        npt.assert_almost_equal(f_y[0], -0.000181398, decimal=6)
+        npt.assert_almost_equal(f_y[1], -0.006541883, decimal=6)
+        npt.assert_almost_equal(f_y[2], 0.001649720, decimal=6)
 
-        m = 1
-        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.0)
-        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)
+        m=1
+        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)   
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
         npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
         npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
@@ -103,10 +103,10 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[3][1], 0.012761602, decimal=6)
         npt.assert_almost_equal(values[1][1], -0.004253867, decimal=6)
 
-        m = 1
-        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.0)
-        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)
-        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)
+        m=1
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
+        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)  
+        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)   
         npt.assert_almost_equal(values[1][0], 0.00416999, decimal=6)
         npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
@@ -114,9 +114,8 @@ class TestMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
         r, phi = np.sqrt(x**2 + y**2), np.arctan2(y, x)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(phi - phi_m) / r, decimal=6
-        )
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(phi-phi_m)/r, decimal=6)
+
 
 
 class TestEllipticalMultipole(object):
@@ -250,23 +249,17 @@ class TestEllipticalMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
 
-        # Check convergence profiles
-        R, phi_ell = np.sqrt(q * x**2 + y**2 / q), np.arctan2(y, q * x)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
-        )
+        #Check convergence profiles
+        R, phi_ell = np.sqrt(q*x**2 + y**2/q), np.arctan2(y, q*x)
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
 
-        m = 3
+        m=3
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
-        )
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
 
-        m = 1
+        m=1
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
-        )
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
 
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
@@ -288,10 +281,10 @@ class TestEllipticalMultipole(object):
         f_xx_sph, f_xy_sph, _, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
         f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -282,21 +282,21 @@ class TestEllipticalMultipole(object):
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
-        f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
+        f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = self.Multipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
         )
-        f_xx_sph, f_xy_sph, _, f_yy_sph = self.SphericalMultipole.hessian(
+        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
 
-        f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
+        f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = self.Multipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
         )
-        f_xx_sph, f_xy_sph, _, f_yy_sph = self.SphericalMultipole.hessian(
+        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
         )
         npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-7, atol=1e-7)

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -71,10 +71,10 @@ class TestMultipole(object):
         f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
         npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)    
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
-        npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
+        npt.assert_almost_equal(f_x[2], 0.05590792, decimal=6)
         npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
         npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
-        npt.assert_almost_equal(f_y[2], 0.03024228, decimal=6)
+        npt.assert_almost_equal(f_y[2], 0.02091982, decimal=6)
 
     def test_hessian(self):
         x = 1
@@ -105,9 +105,9 @@ class TestMultipole(object):
 
         m=1
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
-        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)  
-        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)   
-        npt.assert_almost_equal(values[1][0], 0.00416999, decimal=6)
+        npt.assert_almost_equal(values[0][0], 0.01142045, decimal=6)  
+        npt.assert_almost_equal(values[3][0], 0.01093188, decimal=6)   
+        npt.assert_almost_equal(values[1][0], -0.00018321, decimal=6)
         npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
         npt.assert_almost_equal(values[1][1], 0.00072309, decimal=6)
@@ -138,7 +138,7 @@ class TestEllipticalMultipole(object):
         x = np.array([0])
         y = np.array([0])
         values = self.Multipole.function(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal(values[0], 0.0, decimal=6)
+        assert values[0] == 0
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
@@ -270,10 +270,10 @@ class TestEllipticalMultipole(object):
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=5e-5)
 
         f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -71,10 +71,10 @@ class TestMultipole(object):
         f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
         npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)    
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
-        npt.assert_almost_equal(f_x[2], 0.05590792, decimal=6)
+        npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
         npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
         npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
-        npt.assert_almost_equal(f_y[2], 0.02091982, decimal=6)
+        npt.assert_almost_equal(f_y[2], 0.03024228, decimal=6)
 
     def test_hessian(self):
         x = 1
@@ -105,9 +105,9 @@ class TestMultipole(object):
 
         m=1
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
-        npt.assert_almost_equal(values[0][0], 0.01142045, decimal=6)  
-        npt.assert_almost_equal(values[3][0], 0.01093188, decimal=6)   
-        npt.assert_almost_equal(values[1][0], -0.00018321, decimal=6)
+        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)  
+        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)   
+        npt.assert_almost_equal(values[1][0], 0.00416999, decimal=6)
         npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
         npt.assert_almost_equal(values[1][1], 0.00072309, decimal=6)
@@ -138,7 +138,7 @@ class TestEllipticalMultipole(object):
         x = np.array([0])
         y = np.array([0])
         values = self.Multipole.function(x, y, m, a_m, phi_m, q)
-        assert values[0] == 0
+        npt.assert_almost_equal(values[0], 0.0, decimal=6)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
@@ -270,10 +270,10 @@ class TestEllipticalMultipole(object):
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
         f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -9,13 +9,13 @@ import pytest
 import numpy.testing as npt
 
 
-class TestMultipole(object):
+class TestMultipole(object): 
     """Tests the Gaussian methods."""
 
     def setup_method(self):
         self.Multipole = Multipole()
 
-    def test_function(self):
+    def test_function(self): 
         x = 1
         y = 2
         m = 4
@@ -34,6 +34,12 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[0], -0.007409114, decimal=6)
         npt.assert_almost_equal(values[1], -0.009453038, decimal=6)
         npt.assert_almost_equal(values[2], -0.009910505, decimal=6)
+
+        m=1
+        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.)
+        npt.assert_almost_equal(values[0], 0.04496838, decimal=6)
+        npt.assert_almost_equal(values[1], 0.09042084, decimal=6)
+        npt.assert_almost_equal(values[2], 0.14335526, decimal=6)
 
     def test_derivatives(self):
         x = 1
@@ -61,6 +67,15 @@ class TestMultipole(object):
         npt.assert_almost_equal(f_y[1], -0.006541883, decimal=6)
         npt.assert_almost_equal(f_y[2], 0.001649720, decimal=6)
 
+        m=1
+        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)    
+        npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
+        npt.assert_almost_equal(f_x[2], 0.05590792, decimal=6)
+        npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
+        npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
+        npt.assert_almost_equal(f_y[2], 0.02091982, decimal=6)
+
     def test_hessian(self):
         x = 1
         y = 2
@@ -78,8 +93,8 @@ class TestMultipole(object):
         npt.assert_almost_equal(f_xx[0], -0.016042338, decimal=6)
         npt.assert_almost_equal(f_yy[0], -0.004010584, decimal=6)
         npt.assert_almost_equal(f_xy[0], 0.008021169, decimal=6)
-        x = np.array([1, 3, 4])
-        y = np.array([2, 1, 1])
+        x = np.array([1, 3])
+        y = np.array([2, 1])
         values = self.Multipole.hessian(x, y, m, a_m, phi_m)
         npt.assert_almost_equal(values[0][0], -0.016042338, decimal=6)
         npt.assert_almost_equal(values[3][0], -0.004010584, decimal=6)
@@ -87,6 +102,20 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[0][1], 0.001417956, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.012761602, decimal=6)
         npt.assert_almost_equal(values[1][1], -0.004253867, decimal=6)
+
+        m=1
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
+        npt.assert_almost_equal(values[0][0], 0.01142045, decimal=6)  
+        npt.assert_almost_equal(values[3][0], 0.01093188, decimal=6)   
+        npt.assert_almost_equal(values[1][0], -0.00018321, decimal=6)
+        npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
+        npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
+        npt.assert_almost_equal(values[1][1], 0.00072309, decimal=6)
+
+        npt.assert_almost_equal(values[2], values[1], decimal=8)
+        r, phi = np.sqrt(x**2 + y**2), np.arctan2(y, x)
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(phi-phi_m)/r, decimal=6)
+
 
 
 class TestEllipticalMultipole(object):
@@ -120,20 +149,28 @@ class TestEllipticalMultipole(object):
 
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         function_ell_limit = self.Multipole.function(
-            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.99989
+            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
         )
         function_sph = self.SphericalMultipole.function(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(function_ell_limit, function_sph, rtol=1e-5, atol=5e-5)
+        npt.assert_allclose(function_ell_limit, function_sph, rtol=1e-4, atol=5e-5)
 
         function_ell_limit = self.Multipole.function(
-            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.99989
+            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
         )
         function_sph = self.SphericalMultipole.function(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(function_ell_limit, function_sph, rtol=1e-5, atol=5e-5)
+        npt.assert_allclose(function_ell_limit, function_sph, rtol=5e-5, atol=5e-5)
+
+        function_ell_limit = self.Multipole.function(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
+        )
+        function_sph = self.SphericalMultipole.function(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
+        )
+        npt.assert_allclose(function_ell_limit, function_sph, rtol=1e-7, atol=1e-7)
 
     def test_derivatives(self):
         x = 1
@@ -158,22 +195,31 @@ class TestEllipticalMultipole(object):
 
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         alpha_x_ell_limit, alpha_y_ell_limit = self.Multipole.derivatives(
-            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.99989
+            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
         )
         alpha_x_sph, alpha_y_sph = self.SphericalMultipole.derivatives(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=1e-5, atol=5e-5)
+        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=1e-4, atol=5e-5)
 
         alpha_x_ell_limit, alpha_y_ell_limit = self.Multipole.derivatives(
-            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.99989
+            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
         )
         alpha_x_sph, alpha_y_sph = self.SphericalMultipole.derivatives(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=1e-5, atol=5e-5)
+        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=5e-5, atol=5e-5)
+
+        alpha_x_ell_limit, alpha_y_ell_limit = self.Multipole.derivatives(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
+        )
+        alpha_x_sph, alpha_y_sph = self.SphericalMultipole.derivatives(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
+        )
+        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=1e-7, atol=1e-7)
 
     def test_hessian(self):
         x = 1
@@ -201,30 +247,55 @@ class TestEllipticalMultipole(object):
         npt.assert_almost_equal(values[1][1], -0.004833545, decimal=6)
         npt.assert_almost_equal(values[1][2], -0.003698142, decimal=6)
 
+        npt.assert_almost_equal(values[2], values[1], decimal=8)
+
+        #Check convergence profiles
+        R, phi_ell = np.sqrt(q*x**2 + y**2/q), np.arctan2(y, q*x)
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+
+        m=3
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+
+        m=1
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
+
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
             self.Multipole.hessian(
-                self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.99989
+                self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
             )
         )
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-5, atol=5e-5)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=5e-5)
 
         f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
-            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.99989
+            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
         )
         f_xx_sph, f_xy_sph, _, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-5, atol=5e-5)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-5, atol=5e-5)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
+
+        f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
+        )
+        f_xx_sph, f_xy_sph, _, f_yy_sph = self.SphericalMultipole.hessian(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
+        )
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-7, atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -9,13 +9,13 @@ import pytest
 import numpy.testing as npt
 
 
-class TestMultipole(object):
+class TestMultipole(object): 
     """Tests the Gaussian methods."""
 
     def setup_method(self):
         self.Multipole = Multipole()
 
-    def test_function(self):
+    def test_function(self): 
         x = 1
         y = 2
         m = 4
@@ -35,8 +35,8 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[1], -0.009453038, decimal=6)
         npt.assert_almost_equal(values[2], -0.009910505, decimal=6)
 
-        m = 1
-        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.0)
+        m=1
+        values = self.Multipole.function(x, y, m, a_m, phi_m, r_E=1.)
         npt.assert_almost_equal(values[0], 0.04496838, decimal=6)
         npt.assert_almost_equal(values[1], 0.09042084, decimal=6)
         npt.assert_almost_equal(values[2], 0.14335526, decimal=6)
@@ -60,21 +60,21 @@ class TestMultipole(object):
         x = np.array([2, 3, 1])
         y = np.array([1, 1, 4])
         f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m)
-        npt.assert_almost_equal(f_x[0], -0.003613858, decimal=6)
-        npt.assert_almost_equal(f_x[1], -0.000970385, decimal=6)
-        npt.assert_almost_equal(f_x[2], 0.005970704, decimal=6)
-        npt.assert_almost_equal(f_y[0], -0.000181398, decimal=6)
-        npt.assert_almost_equal(f_y[1], -0.006541883, decimal=6)
-        npt.assert_almost_equal(f_y[2], 0.001649720, decimal=6)
-
-        m = 1
-        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.0)
-        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)  
         npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
-        npt.assert_almost_equal(f_x[2], 0.05590792, decimal=6)
+        npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
+        npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)   
+        npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
+        npt.assert_almost_equal(f_y[2], 0.03024228, decimal=6)
+
+        m=1
+        f_x, f_y = self.Multipole.derivatives(x, y, m, a_m, phi_m, r_E=1.)
+        npt.assert_almost_equal(f_x[0], 0.04058541, decimal=6)    
+        npt.assert_almost_equal(f_x[1], 0.0496472, decimal=6)
+        npt.assert_almost_equal(f_x[2], 0.03591584, decimal=6)
         npt.assert_almost_equal(f_y[0], 0.01967839, decimal=6)
         npt.assert_almost_equal(f_y[1], 0.02001779, decimal=6)
-        npt.assert_almost_equal(f_y[2], 0.02091982, decimal=6)
+        npt.assert_almost_equal(f_y[2], 0.03024228, decimal=6)
 
     def test_hessian(self):
         x = 1
@@ -103,20 +103,19 @@ class TestMultipole(object):
         npt.assert_almost_equal(values[3][1], 0.012761602, decimal=6)
         npt.assert_almost_equal(values[1][1], -0.004253867, decimal=6)
 
-        m = 1
-        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.0)
-        npt.assert_almost_equal(values[0][0], 0.01142045, decimal=6)
-        npt.assert_almost_equal(values[3][0], 0.01093188, decimal=6)
-        npt.assert_almost_equal(values[1][0], -0.00018321, decimal=6)
+        m=1
+        values = self.Multipole.hessian(x, y, m, a_m, phi_m, r_E=1.)  
+        npt.assert_almost_equal(values[0][0], 0.01431771, decimal=6)  
+        npt.assert_almost_equal(values[3][0], 0.00319773, decimal=6)   
+        npt.assert_almost_equal(values[1][0], 0.00416999, decimal=6)
         npt.assert_almost_equal(values[0][1], 0.00731153, decimal=6)
         npt.assert_almost_equal(values[3][1], 0.00839617, decimal=6)
         npt.assert_almost_equal(values[1][1], 0.00072309, decimal=6)
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
         r, phi = np.sqrt(x**2 + y**2), np.arctan2(y, x)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(phi - phi_m) / r, decimal=6
-        )
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(phi-phi_m)/r, decimal=6)
+
 
 
 class TestEllipticalMultipole(object):
@@ -139,7 +138,7 @@ class TestEllipticalMultipole(object):
         x = np.array([0])
         y = np.array([0])
         values = self.Multipole.function(x, y, m, a_m, phi_m, q)
-        assert values[0] == 0
+        npt.assert_almost_equal(values[0], 0.0, decimal=6)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
@@ -250,23 +249,17 @@ class TestEllipticalMultipole(object):
 
         npt.assert_almost_equal(values[2], values[1], decimal=8)
 
-        # Check convergence profiles
-        R, phi_ell = np.sqrt(q * x**2 + y**2 / q), np.arctan2(y, q * x)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
-        )
+        #Check convergence profiles
+        R, phi_ell = np.sqrt(q*x**2 + y**2/q), np.arctan2(y, q*x)
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
 
-        m = 3
+        m=3
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
-        )
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
 
-        m = 1
+        m=1
         values = self.Multipole.hessian(x, y, m, a_m, phi_m, q)
-        npt.assert_almost_equal(
-            (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
-        )
+        npt.assert_almost_equal((values[0]+values[3]), a_m*np.cos(m*(phi_ell-phi_m))/R, decimal=6)
 
         # Test that the limit q-> 1 is consistent with the spherical multipoles
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
@@ -277,10 +270,10 @@ class TestEllipticalMultipole(object):
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
         f_xx_ell_limit, f_xy_ell_limit, _, f_yy_ell_limit = self.Multipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -479,7 +479,7 @@ class TestNumericsProfile(object):
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "q": 0.5, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
+        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -452,14 +452,7 @@ class TestNumericsProfile(object):
         lens_model = ["MULTIPOLE"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {
-            "m": 1,
-            "a_m": 0.1,
-            "phi_m": 0.3,
-            "center_x": 0.0,
-            "center_y": 0.0,
-            "r_E": 1.0,
-        }
+        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
         lens_model = ["MULTIPOLE"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
@@ -481,19 +474,12 @@ class TestNumericsProfile(object):
             "q": 0.5,
             "center_x": -0.01,
             "center_y": -0.5,
-            "r_E": 1.0,
+            "r_E":1.0,
         }
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {
-            "m": 1,
-            "a_m": 0.1,
-            "phi_m": 0.3,
-            "center_x": 0.0,
-            "center_y": 0.0,
-            "r_E": 1.0,
-        }
+        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "q": 0.5, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -479,7 +479,7 @@ class TestNumericsProfile(object):
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
+        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "q": 0.5, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -452,7 +452,7 @@ class TestNumericsProfile(object):
         lens_model = ["MULTIPOLE"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0}
+        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
         lens_model = ["MULTIPOLE"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
@@ -474,7 +474,12 @@ class TestNumericsProfile(object):
             "q": 0.5,
             "center_x": -0.01,
             "center_y": -0.5,
+            "r_E":1.0,
         }
+        lens_model = ["MULTIPOLE_ELL"]
+        self.assert_differentials(lens_model, kwargs, potential=True)
+
+        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
@@ -806,6 +811,23 @@ class TestNumericsProfile(object):
             "center_y": -0.01,
         }
         lens_model = ["EPL_MULTIPOLE_M3M4_ELL"]
+        self.assert_differentials(lens_model, kwargs)
+
+    def test_epl_m1m3m4_ell(self):
+
+        kwargs = {
+            "theta_E": 2.0,
+            "e1": 0.1,
+            "e2": 0.2,
+            "gamma": 2.13,
+            "a1_a": 0.1,
+            "delta_phi_m1": -0.2,
+            "a4_a": 0.1,
+            "delta_phi_m4": 0.2,
+            "a3_a": -0.2,
+            "delta_phi_m3": -0.3,
+        }
+        lens_model = ["EPL_MULTIPOLE_M1M3M4_ELL"]
         self.assert_differentials(lens_model, kwargs)
 
 

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -452,7 +452,14 @@ class TestNumericsProfile(object):
         lens_model = ["MULTIPOLE"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
+        kwargs = {
+            "m": 1,
+            "a_m": 0.1,
+            "phi_m": 0.3,
+            "center_x": 0.0,
+            "center_y": 0.0,
+            "r_E": 1.0,
+        }
         lens_model = ["MULTIPOLE"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
@@ -474,12 +481,20 @@ class TestNumericsProfile(object):
             "q": 0.5,
             "center_x": -0.01,
             "center_y": -0.5,
-            "r_E":1.0,
+            "r_E": 1.0,
         }
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 
-        kwargs = {"m": 1, "a_m": 0.1, "phi_m": 0.3, "q": 0.5, "center_x": 0.0, "center_y": 0.0, "r_E":1.0}
+        kwargs = {
+            "m": 1,
+            "a_m": 0.1,
+            "phi_m": 0.3,
+            "q": 0.5,
+            "center_x": 0.0,
+            "center_y": 0.0,
+            "r_E": 1.0,
+        }
         lens_model = ["MULTIPOLE_ELL"]
         self.assert_differentials(lens_model, kwargs, potential=True)
 


### PR DESCRIPTION
Implements solutions for the spherical m=1, elliptical m=1 and elliptical m=3 that have fully continuous deflection fields (old m=3 version had discontinuities).