### PR TITLE
Changes to q=1 case handling for elliptical multipoles

### DIFF
--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -44,7 +44,7 @@ class Multipole(LensProfileBase):
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=2
+        :param m: int, multipole order, m>=1
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
@@ -70,7 +70,7 @@ class Multipole(LensProfileBase):
 
         :param x: x-coordinate to evaluate function
         :param y: y-coordinate to evaluate function
-        :param m: int, multipole order, m>=&
+        :param m: int, multipole order, m>=1
         :param a_m: float, multipole strength
         :param phi_m: float, multipole orientation in radian
         :param center_x: x-position
@@ -201,11 +201,9 @@ class EllipticalMultipole(LensProfileBase):
 
         if (
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
-        ):  # avoid numerical instability when q is too close to 1
-            if m == 1:
-                f_ = r * np.log(r / r_E) * a_m / 2 * np.cos(phi - phi_m)
-            else:
-                f_ = r * a_m / (1 - m**2) * np.cos(m * (phi - phi_m))
+        ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
+            sph_multipole = Multipole()
+            f_ = sph_multipole.function(x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E)
 
         else:
             if m == 1:
@@ -270,13 +268,9 @@ class EllipticalMultipole(LensProfileBase):
 
         if (
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
-        ):  # avoid numerical instability when q is too close to 1
-            f_x = np.cos(phi) * a_m / (1 - m**2) * np.cos(m * (phi - phi_m)) + np.sin(
-                phi
-            ) * m * a_m / (1 - m**2) * np.sin(m * (phi - phi_m))
-            f_y = np.sin(phi) * a_m / (1 - m**2) * np.cos(m * (phi - phi_m)) - np.cos(
-                phi
-            ) * m * a_m / (1 - m**2) * np.sin(m * (phi - phi_m))
+        ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
+            sph_multipole = Multipole()
+            f_x, f_y = sph_multipole.derivatives(x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E)
 
         else:
             if m == 1:
@@ -353,79 +347,86 @@ class EllipticalMultipole(LensProfileBase):
         r, phi = param_util.cart2polar(x, y, center_x=center_x, center_y=center_y)
         r = np.maximum(r, 0.000001)
 
-        if m == 1:
-            d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m1_1(r, phi, q)
-            d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m1_1(
-                r, phi + np.pi / 2, 1 / q
-            )
-            f_xx = (
-                a_m
-                * np.sqrt(q)
-                * (
-                    np.cos(m * phi_m) * d2psi_dx2_1
-                    - (1 / q) * np.sin(m * phi_m) * d2psi_dy2_2
-                )
-            )
-            f_yy = (
-                a_m
-                * np.sqrt(q)
-                * (
-                    np.cos(m * phi_m) * d2psi_dy2_1
-                    - (1 / q) * np.sin(m * phi_m) * d2psi_dx2_2
-                )
-            )
-            f_xy = (
-                a_m
-                * np.sqrt(q)
-                * (
-                    np.cos(m * phi_m) * d2psi_dxdy_1
-                    + (1 / q) * np.sin(m * phi_m) * d2psi_dxdy_2
-                )
-            )
-
-        elif m == 3:
-            d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m3_1(r, phi, q)
-            d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m3_1(
-                r, phi + np.pi / 2, 1 / q
-            )
-            f_xx = (
-                a_m
-                * np.sqrt(q)
-                * (
-                    np.cos(m * phi_m) * d2psi_dx2_1
-                    + (1 / q) * np.sin(m * phi_m) * d2psi_dy2_2
-                )
-            )
-            f_yy = (
-                a_m
-                * np.sqrt(q)
-                * (
-                    np.cos(m * phi_m) * d2psi_dy2_1
-                    + (1 / q) * np.sin(m * phi_m) * d2psi_dx2_2
-                )
-            )
-            f_xy = (
-                a_m
-                * np.sqrt(q)
-                * (
-                    np.cos(m * phi_m) * d2psi_dxdy_1
-                    - (1 / q) * np.sin(m * phi_m) * d2psi_dxdy_2
-                )
-            )
-
-        elif (m % 2) == 0:  # for m=4, will also work for any even m
-            phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
-            R = np.sqrt(q * (r * np.cos(phi)) ** 2 + (r * np.sin(phi)) ** 2 / q)
-
-            delta_r = a_m * np.cos(m * (phi_ell - phi_m)) * r / R
-            f_xx = np.sin(phi) ** 2 * delta_r / r
-            f_yy = np.cos(phi) ** 2 * delta_r / r
-            f_xy = -np.sin(phi) * np.cos(phi) * delta_r / r
+        if (
+            np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
+        ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
+            sph_multipole = Multipole()
+            f_xx, f_xy, f_xy, f_yy = sph_multipole.hessian(x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E)
 
         else:
-            raise ValueError(
-                "Implementation of multipoles perturbation for general axis ratio q only available for m=1, m=3 or m=4."
-            )
+            if m == 1:
+                d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m1_1(r, phi, q)
+                d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m1_1(
+                    r, phi + np.pi / 2, 1 / q
+                )
+                f_xx = (
+                    a_m
+                    * np.sqrt(q)
+                    * (
+                        np.cos(m * phi_m) * d2psi_dx2_1
+                        - (1 / q) * np.sin(m * phi_m) * d2psi_dy2_2
+                    )
+                )
+                f_yy = (
+                    a_m
+                    * np.sqrt(q)
+                    * (
+                        np.cos(m * phi_m) * d2psi_dy2_1
+                        - (1 / q) * np.sin(m * phi_m) * d2psi_dx2_2
+                    )
+                )
+                f_xy = (
+                    a_m
+                    * np.sqrt(q)
+                    * (
+                        np.cos(m * phi_m) * d2psi_dxdy_1
+                        + (1 / q) * np.sin(m * phi_m) * d2psi_dxdy_2
+                    )
+                )
+    
+            elif m == 3:
+                d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m3_1(r, phi, q)
+                d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m3_1(
+                    r, phi + np.pi / 2, 1 / q
+                )
+                f_xx = (
+                    a_m
+                    * np.sqrt(q)
+                    * (
+                        np.cos(m * phi_m) * d2psi_dx2_1
+                        + (1 / q) * np.sin(m * phi_m) * d2psi_dy2_2
+                    )
+                )
+                f_yy = (
+                    a_m
+                    * np.sqrt(q)
+                    * (
+                        np.cos(m * phi_m) * d2psi_dy2_1
+                        + (1 / q) * np.sin(m * phi_m) * d2psi_dx2_2
+                    )
+                )
+                f_xy = (
+                    a_m
+                    * np.sqrt(q)
+                    * (
+                        np.cos(m * phi_m) * d2psi_dxdy_1
+                        - (1 / q) * np.sin(m * phi_m) * d2psi_dxdy_2
+                    )
+                )
+    
+            elif (m % 2) == 0:  # for m=4, will also work for any even m
+                phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
+                R = np.sqrt(q * (r * np.cos(phi)) ** 2 + (r * np.sin(phi)) ** 2 / q)
+    
+                delta_r = a_m * np.cos(m * (phi_ell - phi_m)) * r / R
+                f_xx = np.sin(phi) ** 2 * delta_r / r
+                f_yy = np.cos(phi) ** 2 * delta_r / r
+                f_xy = -np.sin(phi) * np.cos(phi) * delta_r / r
+    
+            else:
+                raise ValueError(
+                    "Implementation of multipoles perturbation for general axis ratio q only available for m=1, m=3 or m=4."
+                )
 
         return f_xx, f_xy, f_xy, f_yy
 

--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -203,7 +203,9 @@ class EllipticalMultipole(LensProfileBase):
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
         ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
             sph_multipole = Multipole()
-            f_ = sph_multipole.function(x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E)
+            f_ = sph_multipole.function(
+                x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E
+            )
 
         else:
             if m == 1:
@@ -270,7 +272,9 @@ class EllipticalMultipole(LensProfileBase):
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
         ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
             sph_multipole = Multipole()
-            f_x, f_y = sph_multipole.derivatives(x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E)
+            f_x, f_y = sph_multipole.derivatives(
+                x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E
+            )
 
         else:
             if m == 1:
@@ -351,7 +355,9 @@ class EllipticalMultipole(LensProfileBase):
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
         ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
             sph_multipole = Multipole()
-            f_xx, f_xy, f_xy, f_yy = sph_multipole.hessian(x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E)
+            f_xx, f_xy, f_xy, f_yy = sph_multipole.hessian(
+                x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E
+            )
 
         else:
             if m == 1:
@@ -383,7 +389,7 @@ class EllipticalMultipole(LensProfileBase):
                         + (1 / q) * np.sin(m * phi_m) * d2psi_dxdy_2
                     )
                 )
-    
+
             elif m == 3:
                 d2psi_dx2_1, d2psi_dy2_1, d2psi_dxdy_1 = _hessian_m3_1(r, phi, q)
                 d2psi_dx2_2, d2psi_dy2_2, d2psi_dxdy_2 = _hessian_m3_1(
@@ -413,16 +419,16 @@ class EllipticalMultipole(LensProfileBase):
                         - (1 / q) * np.sin(m * phi_m) * d2psi_dxdy_2
                     )
                 )
-    
+
             elif (m % 2) == 0:  # for m=4, will also work for any even m
                 phi_ell = np.angle(q * r * np.cos(phi) + 1j * r * np.sin(phi))
                 R = np.sqrt(q * (r * np.cos(phi)) ** 2 + (r * np.sin(phi)) ** 2 / q)
-    
+
                 delta_r = a_m * np.cos(m * (phi_ell - phi_m)) * r / R
                 f_xx = np.sin(phi) ** 2 * delta_r / r
                 f_yy = np.cos(phi) ** 2 * delta_r / r
                 f_xy = -np.sin(phi) * np.cos(phi) * delta_r / r
-    
+
             else:
                 raise ValueError(
                     "Implementation of multipoles perturbation for general axis ratio q only available for m=1, m=3 or m=4."

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -268,45 +268,77 @@ class TestEllipticalMultipole(object):
             (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
         )
 
-        # Test that the limit q-> 1 is consistent with the spherical multipoles
+        # Test that the limit q-> 1 is consistent with the spherical multipoles and that q=1 gives exactly the spherical multipoles
+        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
+            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
+        )
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
             self.Multipole.hessian(
                 self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
             )
-        )
-        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
-            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
         npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
+        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = (
+            self.Multipole.hessian(
+                self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=1.0
+            )
+        )
+        npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
+        npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
+        npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
+        npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
+        
+        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
+            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
+        )
+        
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
             self.Multipole.hessian(
                 self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
             )
         )
-        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
-            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
-        )
         npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=5e-5, atol=5e-5)
         npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=5e-5, atol=5e-5)
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
-
+        
+        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = (
+            self.Multipole.hessian(
+                self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=1.0
+            )
+        )
+        npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
+        npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
+        npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
+        npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
+        
+        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
+        )
+        
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
             self.Multipole.hessian(
                 self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
             )
         )
-        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
-            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
-        )
         npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-7, atol=1e-7)
         npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-7, atol=1e-7)
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-7, atol=1e-7)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-7, atol=1e-7)
+
+        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = (
+            self.Multipole.hessian(
+                self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=1.0
+            )
+        )
+        npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
+        npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
+        npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
+        npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -282,20 +282,18 @@ class TestEllipticalMultipole(object):
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
 
-        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = (
-            self.Multipole.hessian(
-                self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=1.0
-            )
+        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = self.Multipole.hessian(
+            self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=1.0
         )
         npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
         npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
         npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
         npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
-        
+
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        
+
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
             self.Multipole.hessian(
                 self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
@@ -305,21 +303,19 @@ class TestEllipticalMultipole(object):
         npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=5e-5, atol=5e-5)
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
-        
-        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = (
-            self.Multipole.hessian(
-                self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=1.0
-            )
+
+        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = self.Multipole.hessian(
+            self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=1.0
         )
         npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
         npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
         npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
         npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
-        
+
         f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
         )
-        
+
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
             self.Multipole.hessian(
                 self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
@@ -330,10 +326,8 @@ class TestEllipticalMultipole(object):
         npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-7, atol=1e-7)
         npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-7, atol=1e-7)
 
-        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = (
-            self.Multipole.hessian(
-                self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=1.0
-            )
+        f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = self.Multipole.hessian(
+            self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=1.0
         )
         npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
         npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)


### PR DESCRIPTION
Explicitely use spherical multipole class for elliptical multipoles when q is dangerously close to 1+ add a test of this in test_multipoles.py