### PR TITLE
Initialize T_ij_list and T_z_list in MultiPlaneBase class

### DIFF
--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -97,6 +97,9 @@ class MultiPlaneBase(ProfileListBase):
             self._reduced2physical_factor = self._cosmo_bkg.d_xy(
                 0, self._z_source_convention
             ) / self._cosmo_bkg.d_xy(z_sort, z_source_array)
+
+        self._T_ij_list = []
+        self._T_z_list = []
         for idex in self._sorted_redshift_index:
             z_lens = self._lens_redshift_list[idex]
             if z_before == z_lens:


### PR DESCRIPTION
This fixes a bug that @martin-millon pointed out in #687; many thanks! Although @martin-millon included the bugfix in #687, I am pushing it here already so that the currently implemented multi-plane feature can be used by other users.