### PR TITLE
Lens model cosmology refactoring

### DIFF
--- a/lenstronomy/Analysis/lens_profile.py
+++ b/lenstronomy/Analysis/lens_profile.py
@@ -86,7 +86,7 @@ class LensProfileAnalysis(object):
 
         # Define the integrand function for the 1D numerical integration: this is the surface mass density
         # kappa at a given radius r, multiplied by 2*pi*r to account for the circular geometry.
-        kappa_r = self.radial_lens_profile(r_array, kwargs_lens, center_x=0, center_y=0)
+        kappa_r = self.radial_lens_profile(r_array, kwargs_lens, center_x=None, center_y=None)
 
         # here we make a finer grid interpolation in log-log space
         k_interp = scipy.interpolate.interp1d(np.log10(r_array), np.log10(kappa_r))

--- a/lenstronomy/Cosmo/background.py
+++ b/lenstronomy/Cosmo/background.py
@@ -91,6 +91,8 @@ class Background(object):
         :param cosmo: ~astropy.cosmology instance
         :return: beta
         """
+        if z_source_1 == z_source_2:
+            return 1
         ds1 = self.cosmo.angular_diameter_distance(z=z_source_1).value
         dds1 = self.cosmo.angular_diameter_distance_z1z2(z1=z_lens, z2=z_source_1).value
         ds2 = self.cosmo.angular_diameter_distance(z=z_source_2).value
@@ -107,4 +109,6 @@ class Background(object):
         :param z_source_2: new source redshift
         :return: Ddt to z_source_2
         """
+        if z_source_1 == z_source_2:
+            return 1
         return 1.0 / self.ddt(z_lens, z_source_1) * self.ddt(z_lens, z_source_2)

--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -501,3 +501,24 @@ class LensCosmo(object):
         return self.background.beta_double_source_plane(
             z_lens=z_lens, z_source_1=z_source_1, z_source_2=z_source_2
         )
+
+    def theta_E_power_law_scaling(self, theta_E_convention, kappa_ext_convention, gamma_pl,
+                                  z_lens, z_source_convention, z_source):
+
+        if z_source == z_source_convention:
+            theta_E = theta_E_convention
+            kappa_ext = kappa_ext_convention
+        else:
+            beta = self.beta_double_source_plane(
+                z_lens=z_lens,
+                z_source_2=z_source_convention,
+                z_source_1=z_source,
+            )
+            #theta_E = theta_E_convention * beta ** (1.0 / (gamma_pl - 1))
+            kappa_ext = kappa_ext_convention * beta
+            theta_E = theta_E_convention * beta ** (1. / (gamma_pl - 1.))
+            # theta_E = theta_E_convention * (beta + kappa_ext_convention * (1 - beta)) ** (1. / (gamma_pl - 1.))
+            # β − (1 − λ)(1 − β) ** (1.0 / (gamma_pl - 1))
+
+        theta_E /= (1 - kappa_ext) ** (1.0 / (gamma_pl - 1))
+        return theta_E

--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -511,6 +511,18 @@ class LensCosmo(object):
         z_source_convention,
         z_source,
     ):
+        """
+        maps Einstein radius of a power-law profile with external convergence to different source redshifts
+
+        :param theta_E_convention: Einstein radius for the lens when a source is at z_source_conventions coming from
+         the main deflector (excluding external convergence)
+        :param kappa_ext_convention: external convergence for z_source_convention
+        :param gamma_pl: power-law slope of the deflector
+        :param z_lens: lens redshift
+        :param z_source_convention: source redshift for lens model conventions
+        :param z_source: source redshift
+        :return: Einstein radius for a source at redshift z_source
+        """
 
         if z_source == z_source_convention:
             theta_E = theta_E_convention

--- a/lenstronomy/Cosmo/lens_cosmo.py
+++ b/lenstronomy/Cosmo/lens_cosmo.py
@@ -514,7 +514,6 @@ class LensCosmo(object):
                 z_source_2=z_source_convention,
                 z_source_1=z_source,
             )
-            #theta_E = theta_E_convention * beta ** (1.0 / (gamma_pl - 1))
             kappa_ext = kappa_ext_convention * beta
             theta_E = theta_E_convention * beta ** (1. / (gamma_pl - 1.))
             # theta_E = theta_E_convention * (beta + kappa_ext_convention * (1 - beta)) ** (1. / (gamma_pl - 1.))

--- a/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -18,11 +18,15 @@ class MultiPlaneDecoupled(MultiPlane):
         observed_convention_index=None,
         ignore_observed_positions=False,
         z_source_convention=None,
+        z_lens_convention=None,
         cosmo_interp=False,
         z_interp_stop=None,
         num_z_interp=100,
         kwargs_interp=None,
         kwargs_synthesis=None,
+        distance_ratio_sampling=False,
+        cosmology_sampling=False,
+        cosmology_model="FlatLambdaCDM",
         x0_interp=None,
         y0_interp=None,
         alpha_x_interp_foreground=None,
@@ -72,20 +76,27 @@ class MultiPlaneDecoupled(MultiPlane):
         self._y0_interp = y0_interp
         self._z_split = z_split
         super(MultiPlaneDecoupled, self).__init__(
-            z_source,
-            lens_model_list,
-            lens_redshift_list,
-            cosmo,
-            numerical_alpha_class,
-            observed_convention_index,
-            ignore_observed_positions,
-            z_source_convention,
-            cosmo_interp,
-            z_interp_stop,
-            num_z_interp,
-            kwargs_interp,
-            kwargs_synthesis,
+            z_source=z_source,
+            lens_model_list=lens_model_list,
+            lens_redshift_list=lens_redshift_list,
+            cosmo=cosmo,
+            numerical_alpha_class=numerical_alpha_class,
+            observed_convention_index=observed_convention_index,
+            ignore_observed_positions=ignore_observed_positions,
+            z_source_convention=z_source_convention,
+            z_lens_convention=z_lens_convention,
+            cosmo_interp=cosmo_interp,
+            z_interp_stop=z_interp_stop,
+            num_z_interp=num_z_interp,
+            kwargs_interp=kwargs_interp,
+            kwargs_synthesis=kwargs_synthesis,
+            distance_ratio_sampling=distance_ratio_sampling,
+            cosmology_sampling=cosmology_sampling,
+            cosmology_model=cosmology_model,
         )
+
+
+
 
         cosmo_bkg = Background(cosmo)
         d_xy_source = cosmo_bkg.d_xy(0, z_source)

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -85,6 +85,7 @@ class MultiPlane(object):
                 )
                 cosmo_interp = False
 
+        # TODO update kwargs_class with new cosmology
         self.kwargs_class = {
             "z_source": z_source,
             "lens_model_list": lens_model_list,

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -85,7 +85,6 @@ class MultiPlane(object):
                 )
                 cosmo_interp = False
 
-        # TODO update kwargs_class with new cosmology
         self.kwargs_class = {
             "z_source": z_source,
             "lens_model_list": lens_model_list,

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -543,6 +543,7 @@ class LensModel(object):
             else:
                 # TODO: is it possible to not re-initialize it for performance improvements?
                 kwargs_lens_class = self.lens_model.kwargs_class
+                kwargs_lens_class["cosmo"] = self.cosmo
                 kwargs_lens_class["z_source"] = z_source
                 self.lens_model = MultiPlane(**kwargs_lens_class)
         else:
@@ -566,6 +567,14 @@ class LensModel(object):
                 )
                 self._ddt_scaling = ddt_scaling
         self.z_source = z_source
+
+    def update_cosmology(self, cosmo):
+        """
+
+        :param cosmo: ~astropy.cosmology instance
+        :return: updated LensModel class with new cosmology
+        """
+        self.lens_model.update_cosmology
 
     @property
     def ddt_scaling(self):

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -548,15 +548,14 @@ class LensModel(object):
         else:
             if self._los_effects is True:
                 raise NotImplementedError(
-                    "SinglePlaneLOS lens model does not support change in source redshift"
+                    "SinglePlaneLOS lens model does not support change in redshift"
                 )
-            else:
-                alpha_scaling = self._lensCosmo.beta_double_source_plane(
-                    z_lens=self.z_lens,
-                    z_source_1=z_source,
-                    z_source_2=self._z_source_convention,
-                )
-                self.lens_model.change_redshift_scaling(alpha_scaling)
+            alpha_scaling = self._lensCosmo.beta_double_source_plane(
+                z_lens=self.z_lens,
+                z_source_1=z_source,
+                z_source_2=self._z_source_convention,
+            )
+            self.lens_model.change_redshift_scaling(alpha_scaling)
 
         if self.z_lens is not None:
             self._lensCosmo = LensCosmo(self.z_lens, z_source, cosmo=self.cosmo)
@@ -584,28 +583,24 @@ class LensModel(object):
                 self._ddt_scaling = ddt_scaling
         if self.multi_plane is True:
             if self._decouple_multi_plane:
-                # TODO: re-initialize MultiPlaneDecoupled model
-                raise NotImplementedError(
-                    "MultiPlaneDecoupled lens model does not support change in cosmology redshift"
-                )
+                kwargs_lens_class = self.lens_model.kwargs_class
+                kwargs_decoupled = self.lens_model.kwargs_multiplane_model
+                kwargs_lens_class["cosmo"] = cosmo
+                kwargs_class = {**kwargs_lens_class, **kwargs_decoupled}
+                self.lens_model = MultiPlaneDecoupled(**kwargs_class)
             else:
                 # TODO: is it possible to not re-initialize it for performance improvements?
                 kwargs_lens_class = self.lens_model.kwargs_class
                 kwargs_lens_class["cosmo"] = cosmo
                 self.lens_model = MultiPlane(**kwargs_lens_class)
         else:
-            if self._los_effects is True:
-                raise NotImplementedError(
-                    "SinglePlaneLOS lens model does not support change in cosmology"
+            if self.z_lens is not None and self.z_source is not None:
+                alpha_scaling = self._lensCosmo.beta_double_source_plane(
+                    z_lens=self.z_lens,
+                    z_source_1=self.z_source,
+                    z_source_2=self._z_source_convention,
                 )
-            else:
-                if self.z_lens is not None and self.z_source is not None:
-                    alpha_scaling = self._lensCosmo.beta_double_source_plane(
-                        z_lens=self.z_lens,
-                        z_source_1=self.z_source,
-                        z_source_2=self._z_source_convention,
-                    )
-                    self.lens_model.change_redshift_scaling(alpha_scaling)
+                self.lens_model.change_redshift_scaling(alpha_scaling)
 
     @property
     def ddt_scaling(self):

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -76,12 +76,12 @@ class LensModel(object):
         """
         self.lens_model_list = lens_model_list
         self.z_lens = z_lens
-        self.z_source = z_source
         if z_source_convention is None and z_source is not None:
             z_source_convention = z_source
         if z_source is None and z_source_convention is not None:
             z_source = z_source_convention
         self._z_source_convention = z_source_convention
+        self.z_source = z_source
         self.redshift_list = lens_redshift_list
 
         if cosmo is None:
@@ -543,7 +543,6 @@ class LensModel(object):
             else:
                 # TODO: is it possible to not re-initialize it for performance improvements?
                 kwargs_lens_class = self.lens_model.kwargs_class
-                kwargs_lens_class["cosmo"] = self.cosmo
                 kwargs_lens_class["z_source"] = z_source
                 self.lens_model = MultiPlane(**kwargs_lens_class)
         else:
@@ -574,7 +573,39 @@ class LensModel(object):
         :param cosmo: ~astropy.cosmology instance
         :return: updated LensModel class with new cosmology
         """
-        self.lens_model.update_cosmology
+        self.cosmo = cosmo
+
+        if self.z_lens is not None and self.z_source is not None:
+            self._lensCosmo = LensCosmo(self.z_lens, self.z_source, cosmo=cosmo)
+            if self._z_source_convention is not None:
+                ddt_scaling = self._lensCosmo.background.ddt_scaling(
+                    self.z_lens, self._z_source_convention, self.z_source
+                )
+                self._ddt_scaling = ddt_scaling
+        if self.multi_plane is True:
+            if self._decouple_multi_plane:
+                # TODO: re-initialize MultiPlaneDecoupled model
+                raise NotImplementedError(
+                    "MultiPlaneDecoupled lens model does not support change in cosmology redshift"
+                )
+            else:
+                # TODO: is it possible to not re-initialize it for performance improvements?
+                kwargs_lens_class = self.lens_model.kwargs_class
+                kwargs_lens_class["cosmo"] = cosmo
+                self.lens_model = MultiPlane(**kwargs_lens_class)
+        else:
+            if self._los_effects is True:
+                raise NotImplementedError(
+                    "SinglePlaneLOS lens model does not support change in cosmology"
+                )
+            else:
+                if self.z_lens is not None and self.z_source is not None:
+                    alpha_scaling = self._lensCosmo.beta_double_source_plane(
+                        z_lens=self.z_lens,
+                        z_source_1=self.z_source,
+                        z_source_2=self._z_source_convention,
+                    )
+                    self.lens_model.change_redshift_scaling(alpha_scaling)
 
     @property
     def ddt_scaling(self):

--- a/test/test_Cosmo/test_lens_cosmo.py
+++ b/test/test_Cosmo/test_lens_cosmo.py
@@ -207,7 +207,6 @@ class TestLensCosmo(object):
 
     def test_vel_disp_dPIED_sigma0(self):
         from lenstronomy.LensModel.lens_model import LensModel
-        import matplotlib.pyplot as plt
         from astropy.cosmology import FlatLambdaCDM
 
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
@@ -227,7 +226,6 @@ class TestLensCosmo(object):
         Ra_list = [0.1, 0.01, 0.001, 0.0001, 0.00001]
         for Ra in Ra_list:
             sigma0 = lensCosmo.vel_disp_dPIED_sigma0(vel_disp, Ra=Ra, Rs=Rs)
-            print(sigma0, theta_E_sis, "test")
             kwargs_lens = [
                 {"sigma0": sigma0, "Ra": Ra, "Rs": Rs, "center_x": 0, "center_y": 0}
             ]
@@ -251,6 +249,72 @@ class TestLensCosmo(object):
             z_lens=0.5, z_source_1=1, z_source_2=2
         )
         npt.assert_almost_equal(beta, beta_true, decimal=5)
+
+    def test_theta_E_power_law_scaling(self):
+        theta_E_convention = 1
+        kappa_ext_convention = 0.0
+        gamma_pl = 2.3
+        z_lens = 0.5
+        z_source_convention = 5
+        z_source = 1
+        theta_E_conversion = self.lensCosmo.theta_E_power_law_scaling(theta_E_convention, kappa_ext_convention, gamma_pl,
+                                  z_lens, z_source_convention, z_source)
+        # numerical solution for the Einstein radius
+        from lenstronomy.LensModel.lens_model import LensModel
+        from lenstronomy.Analysis.lens_profile import LensProfileAnalysis
+        lens_model = LensModel(
+            lens_model_list=["EPL", "CONVERGENCE"],
+            z_lens=z_lens,
+            z_source_convention=z_source_convention,
+            multi_plane=False,
+            z_source=z_source,
+        )
+        kwargs_lens = [{"theta_E": theta_E_convention, "gamma": gamma_pl, "e1": 0, "e2": 0,
+                        "center_x": 0, "center_y": 0}, {"kappa": kappa_ext_convention}]
+
+        lens_analysis = LensProfileAnalysis(lens_model=lens_model)
+        theta_E = lens_analysis.effective_einstein_radius(
+            kwargs_lens, r_min=1e-5, r_max=5e1, num_points=100
+        )
+        npt.assert_almost_equal(theta_E_conversion, theta_E, decimal=3)
+        # and here we test no alterations
+        theta_E_conversion = self.lensCosmo.theta_E_power_law_scaling(theta_E_convention, 0,
+                                                                      gamma_pl,
+                                                                      z_lens, z_source_convention, z_source_convention)
+        npt.assert_almost_equal(theta_E_conversion, theta_E_convention, decimal=8)
+
+        theta_E_convention = 1
+        kappa_ext_convention = 0.2
+        gamma_pl = 2
+        z_lens = 0.5
+        z_source_convention = 5
+        z_source = 1
+        theta_E_conversion = self.lensCosmo.theta_E_power_law_scaling(theta_E_convention, kappa_ext_convention,
+                                                                      gamma_pl,
+                                                                      z_lens, z_source_convention, z_source)
+        # numerical solution for the Einstein radius
+        from lenstronomy.LensModel.lens_model import LensModel
+        from lenstronomy.Analysis.lens_profile import LensProfileAnalysis
+        lens_model = LensModel(
+            lens_model_list=["EPL", "CONVERGENCE"],
+            z_lens=z_lens,
+            z_source_convention=z_source_convention,
+            multi_plane=False,
+            z_source=z_source,
+        )
+        kwargs_lens = [{"theta_E": theta_E_convention, "gamma": gamma_pl, "e1": 0, "e2": 0,
+                        "center_x": 0, "center_y": 0}, {"kappa": kappa_ext_convention}]
+
+        lens_analysis = LensProfileAnalysis(lens_model=lens_model)
+        theta_E = lens_analysis.effective_einstein_radius(
+            kwargs_lens, r_min=1e-5, r_max=5e1, num_points=100
+        )
+        npt.assert_almost_equal(theta_E_conversion, theta_E, decimal=3)
+        # and here we test no alterations
+        theta_E_conversion = self.lensCosmo.theta_E_power_law_scaling(theta_E_convention, 0,
+                                                                      gamma_pl,
+                                                                      z_lens, z_source_convention, z_source_convention)
+        npt.assert_almost_equal(theta_E_conversion, theta_E_convention, decimal=8)
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane_decoupled.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane_decoupled.py
@@ -1,5 +1,7 @@
 __author__ = "dangilman"
 
+import copy
+
 import numpy.testing as npt
 from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.LensModel.Util.decouple_multi_plane_util import (
@@ -607,6 +609,49 @@ class TestMultiPlaneDecoupled(object):
             )
             npt.assert_almost_equal(beta_x, beta_x_true)
             npt.assert_almost_equal(beta_y, beta_y_true)
+
+    def test_change_cosmology(self):
+        from astropy.cosmology import FlatwCDM
+        cosmo = FlatwCDM(H0=67, Om0=0.3, w0=-0.8)
+        cosmo_new = FlatwCDM(H0=73, Om0=0.3, w0=-1)
+
+        z_lens = 0.5
+        z_source_convention = 2
+        z_source_new = 1
+        kwargs_lens = [{"theta_E": 1, "center_x": 0, "center_y": 0}]
+        print(self.kwargs_multiplane_model_grid)
+        kwargs_multiplane_model_grid_ = copy.deepcopy(self.kwargs_multiplane_model_grid)
+        lens_model_list = self.kwargs_multiplane_model_grid["lens_model_list"]
+        kwargs_multiplane_model_grid_.pop("cosmo")
+        kwargs_multiplane_model_grid_.pop("lens_model_list")
+        lens_model = LensModel(
+            lens_model_list=lens_model_list,
+            z_lens=z_lens,
+            # lens_redshift_list=[z_lens],
+            z_source_convention=z_source_convention,
+            # z_source=z_source_new,
+            # multi_plane=True,
+            cosmo=cosmo,
+            # kwargs_multiplane_model=kwargs_multiplane_model_grid_,
+            # decouple_multi_plane=True,
+            **kwargs_multiplane_model_grid_,
+        )
+        lens_model_new = LensModel(
+            lens_model_list=lens_model_list,
+            z_lens=z_lens,
+            # lens_redshift_list=[z_lens],
+            z_source_convention=z_source_convention,
+            # z_source=z_source_new,
+            # multi_plane=True,
+            cosmo=cosmo_new,
+            # kwargs_multiplane_model=kwargs_multiplane_model_grid_,
+            # decouple_multi_plane=True,
+            **kwargs_multiplane_model_grid_,
+        )
+        lens_model.update_cosmology(cosmo=cosmo_new)
+        alpha_x, alpha_y = lens_model.alpha(1, 1, kwargs=self.kwargs_lens_free)
+        alpha_x_new, alpha_y_new = lens_model_new.alpha(1, 1, kwargs=self.kwargs_lens_free)
+        npt.assert_almost_equal(alpha_x, alpha_x_new, decimal=5)
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -409,8 +409,6 @@ class TestLensModel(object):
         dt_new = lens_model_new.arrival_time(1, 1, kwargs_lens=kwargs_lens)
         npt.assert_almost_equal(dt, dt_new, decimal=5)
 
-        # TODO: raise testing
-
 
 class TestRaise(unittest.TestCase):
     def test_raise(self):

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -354,6 +354,63 @@ class TestLensModel(object):
         npt.assert_almost_equal(dt_sp, dt_mp, decimal=5)
         lens_model_mp_new.change_source_redshift(z_source=z_source_new)
 
+    def test_update_cosmology(self):
+        from astropy.cosmology import FlatwCDM
+        cosmo = FlatwCDM(H0=67, Om0=0.3, w0=-0.8)
+        cosmo_new = FlatwCDM(H0=73, Om0=0.3, w0=-1)
+
+        z_lens = 0.5
+        z_source_convention = 2
+        z_source_new = 1
+        kwargs_lens = [{"theta_E": 1, "center_x": 0, "center_y": 0}]
+        # multi-plane lens model
+        lens_model = LensModel(
+            lens_model_list=["SIS"],
+            z_lens=z_lens,
+            lens_redshift_list=[z_lens],
+            z_source_convention=z_source_convention,
+            z_source=z_source_new,
+            multi_plane=True,
+            cosmo=cosmo,
+        )
+        lens_model_new = LensModel(
+            lens_model_list=["SIS"],
+            z_lens=z_lens,
+            lens_redshift_list=[z_lens],
+            z_source_convention=z_source_convention,
+            z_source=z_source_new,
+            multi_plane=True,
+            cosmo=cosmo_new,
+        )
+        lens_model.update_cosmology(cosmo=cosmo_new)
+        dt = lens_model.arrival_time(1, 1, kwargs_lens=kwargs_lens)
+        dt_new = lens_model_new.arrival_time(1, 1, kwargs_lens=kwargs_lens)
+        npt.assert_almost_equal(dt, dt_new, decimal=5)
+
+        # single-plane lens model
+        lens_model = LensModel(
+            lens_model_list=["SIS"],
+            z_lens=z_lens,
+            z_source_convention=z_source_convention,
+            multi_plane=False,
+            z_source=z_source_convention,
+            cosmo=cosmo
+        )
+        lens_model_new = LensModel(
+            lens_model_list=["SIS"],
+            z_lens=z_lens,
+            z_source_convention=z_source_convention,
+            multi_plane=False,
+            z_source=z_source_convention,
+            cosmo=cosmo_new
+        )
+        lens_model.update_cosmology(cosmo=cosmo_new)
+        dt = lens_model.arrival_time(1, 1, kwargs_lens=kwargs_lens)
+        dt_new = lens_model_new.arrival_time(1, 1, kwargs_lens=kwargs_lens)
+        npt.assert_almost_equal(dt, dt_new, decimal=5)
+
+        # TODO: raise testing
+
 
 class TestRaise(unittest.TestCase):
     def test_raise(self):


### PR DESCRIPTION
This PR adds a definition in LensModel to update the cosmology instance. The idea is that the API should support all downstream cosmology definitions and serves as a single point to update the cosmology of the lens model configuration.