### PR TITLE
Update numba req. for np.nan_to_num() usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ mpmath
 emcee>=3.0.0
 matplotlib
 scikit-learn
-numba
+numba>=0.57.0
 dynesty
 pymultinest
 nestcheck


### PR DESCRIPTION
in the epl_numba profile, there is a call to np.nan_to_num() at line 190. 

Based on looking through numba documentation, this function is only supported for numba>=0.57.0. (https://numba.readthedocs.io/en/stable/release-notes.html#version-0-57-0-1-may-2023)

function call in epl_numba: https://github.com/lenstronomy/lenstronomy/blob/b44bcc008ae4d760cec94c77c9c810756b41b0fa/lenstronomy/LensModel/Profiles/epl_numba.py#L190

Note to use numba>=0.57.0, it seems numpy>=1.21 must also be true.