### PR TITLE
reorganized imsim classes

### DIFF
--- a/lenstronomy/Analysis/multi_patch_reconstruction.py
+++ b/lenstronomy/Analysis/multi_patch_reconstruction.py
@@ -127,7 +127,7 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
             if model_band is not None:
                 image_model = model_band.image_model_class
                 kwargs_params = model_band.kwargs_model
-                model = image_model._image(
+                model = image_model.image(
                     **kwargs_params
                 )  # TODO: avoid using private definitions uses sub-set of the model parameters
                 data_class_i = image_model.Data

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -1,12 +1,15 @@
 from lenstronomy.ImSim.image_linear_solve import ImageLinearFit
+from lenstronomy.ImSim.image_model import ImageModel
 from lenstronomy.Data.imaging_data import ImageData
 from lenstronomy.Data.psf import PSF
 from lenstronomy.Util import class_creator
 
+import numpy as np
+
 __all__ = ["SingleBandMultiModel"]
 
 
-class SingleBandMultiModel(ImageLinearFit):
+class SingleBandMultiModel(ImageLinearFit, ImageModel):
     """Class to simulate/reconstruct images in multi-band option. This class calls
     functions of image_model.py with different bands with decoupled linear parameters
     and the option to pass/select different light models for the different bands.
@@ -80,8 +83,15 @@ class SingleBandMultiModel(ImageLinearFit):
             [None for _ in range(len(multi_band_list))],
         )
         self._index_optical_depth = index_optical_depth[band_index]
+        self.linear_solver = linear_solver
 
-        super(SingleBandMultiModel, self).__init__(
+        if linear_solver:
+            imageClass = ImageLinearFit
+        else:
+            imageClass = ImageModel
+        
+        imageClass.__init__(
+            self,
             data_i,
             psf_i,
             lens_model_class,
@@ -92,7 +102,6 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_numerics=kwargs_numerics,
             likelihood_mask=likelihood_mask_list[band_index],
             kwargs_pixelbased=kwargs_pixelbased,
-            linear_solver=linear_solver,
         )
 
     def image(
@@ -134,7 +143,8 @@ class SingleBandMultiModel(ImageLinearFit):
         ) = self.select_kwargs(
             kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction
         )
-        return self._image(
+        return ImageModel.image(
+            self,
             kwargs_lens_i,
             kwargs_source_i,
             kwargs_lens_light_i,
@@ -179,7 +189,8 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps=None,
             kwargs_extinction=kwargs_extinction,
         )
-        return self._source_surface_brightness(
+        return ImageModel.source_surface_brightness(
+            self,
             kwargs_source_i,
             kwargs_lens_i,
             kwargs_extinction=kwargs_extinction_i,
@@ -206,8 +217,8 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps=None,
             kwargs_extinction=None,
         )
-        return self._lens_surface_brightness(
-            kwargs_lens_light_i, unconvolved=unconvolved, k=k
+        return ImageModel.lens_surface_brightness(
+            self, kwargs_lens_light_i, unconvolved=unconvolved, k=k
         )
 
     def point_source(
@@ -220,11 +231,10 @@ class SingleBandMultiModel(ImageLinearFit):
     ):
         """Computes the point source positions and paints PSF convolutions on them.
 
-        :param kwargs_ps:
-        :param kwargs_lens:
-        :param kwargs_special:
-        :param unconvolved:
-        :param k:
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param unconvolved: bool, if False, applies convolution
+        :param k: int or tuple, only evaluate the k-th point source model
         :return:
         """
         kwargs_lens_i, _, _, kwargs_ps_i, _ = self.select_kwargs(
@@ -234,7 +244,8 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps=kwargs_ps,
             kwargs_extinction=None,
         )
-        return self._point_source(
+        return ImageModel.point_source(
+            self,
             kwargs_ps=kwargs_ps_i,
             kwargs_lens=kwargs_lens_i,
             kwargs_special=kwargs_special,
@@ -266,6 +277,8 @@ class SingleBandMultiModel(ImageLinearFit):
             lens light surface brightness profiles
         :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as
             external shear and point source image positions
+        :param kwargs_extinction: keyword arguments corresponding to dust extinction
+        :param kwargs_special: keyword arguments corresponding to "special" parameters
         :param inv_bool: if True, invert the full linear solver Matrix Ax = y for the
             purpose of the covariance matrix.
         :return: 1d array of surface brightness pixels of the optimal solution of the
@@ -280,7 +293,8 @@ class SingleBandMultiModel(ImageLinearFit):
         ) = self.select_kwargs(
             kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction
         )
-        wls_model, error_map, cov_param, param = self._image_linear_solve(
+        wls_model, error_map, cov_param, param = ImageLinearFit.image_linear_solve(
+            self,
             kwargs_lens_i,
             kwargs_source_i,
             kwargs_lens_light_i,
@@ -306,18 +320,22 @@ class SingleBandMultiModel(ImageLinearFit):
         source_marg=False,
         linear_prior=None,
         check_positive_flux=False,
-        linear_solver=True,
+        linear_solver=None
     ):
         """Computes the likelihood of the data given a model This is specified with the
         non-linear parameters and a linear inversion and prior marginalisation.
 
-        :param kwargs_lens:
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param kwargs_extinction: keyword arguments corresponding to dust extinction
+        :param kwargs_special: keyword arguments corresponding to "special" parameters
         :param check_positive_flux: bool, if True, checks whether the linear inversion
             resulted in non-negative flux components and applies a punishment in the
             likelihood if so.
+        :param linear_solver: bool or None. If None, uses self.linear_solver by default.
+            Allows the user to deactivate or activate linear solve if desired.
         :return: log likelihood (natural logarithm) (sum of the log likelihoods of the
             individual images)
         """
@@ -331,18 +349,32 @@ class SingleBandMultiModel(ImageLinearFit):
         ) = self.select_kwargs(
             kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction
         )
-        logL, param = self._likelihood_data_given_model(
-            kwargs_lens_i,
-            kwargs_source_i,
-            kwargs_lens_light_i,
-            kwargs_ps_i,
-            kwargs_extinction_i,
-            kwargs_special,
-            source_marg=source_marg,
-            linear_prior=linear_prior,
-            check_positive_flux=check_positive_flux,
-            linear_solver=self._linear_solver,
-        )
+        if linear_solver is None:
+            linear_solver = self.linear_solver
+        if linear_solver:
+            logL, param = ImageLinearFit.likelihood_data_given_model(
+                self,
+                kwargs_lens_i,
+                kwargs_source_i,
+                kwargs_lens_light_i,
+                kwargs_ps_i,
+                kwargs_extinction_i,
+                kwargs_special,
+                source_marg=source_marg,
+                linear_prior=linear_prior,
+                check_positive_flux=check_positive_flux,
+            )
+        else:
+            logL = ImageModel.likelihood_data_given_model(
+                self,
+                kwargs_lens_i,
+                kwargs_source_i,
+                kwargs_lens_light_i,
+                kwargs_ps_i,
+                kwargs_extinction_i,
+                kwargs_special,
+            )
+            param = None
         return logL, param
 
     def update_linear_kwargs(
@@ -357,10 +389,10 @@ class SingleBandMultiModel(ImageLinearFit):
         """Links linear parameters to kwargs arguments.
 
         :param param: linear parameter vector corresponding to the response matrix
-        :param kwargs_lens:
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: updated list of kwargs with linear parameter values
         """
         (
@@ -376,9 +408,10 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps,
             kwargs_extinction=None,
         )
-        self._update_linear_kwargs(
-            param, kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
-        )
+        if self.linear_solver:
+            kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i = ImageLinearFit.update_linear_kwargs(
+                self, param, kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
+            )
         return kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
 
     def num_param_linear(
@@ -389,7 +422,10 @@ class SingleBandMultiModel(ImageLinearFit):
         kwargs_ps=None,
     ):
         """
-
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: number of linear coefficients to be solved for in the linear inversion
         """
         (
@@ -399,9 +435,13 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps_i,
             kwargs_extinction_i,
         ) = self.select_kwargs(kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps)
-        num = self._num_param_linear(
-            kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
-        )
+
+        if self.linear_solver:
+            num = ImageLinearFit.num_param_linear(
+                self, kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
+            )
+        else:
+            num = 0
         return num
 
     def linear_response_matrix(
@@ -416,10 +456,13 @@ class SingleBandMultiModel(ImageLinearFit):
         """Computes the linear response matrix (m x n), with n beeing the data size and
         m being the coefficients.
 
-        :param kwargs_lens:
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param kwargs_extinction: list of keyword arguments corresponding to the optical
+            depth models tau, such that extinction is exp(-tau)
+        :param kwargs_special: keyword arguments corresponding to "special" parameters
         :return:
         """
         (
@@ -431,7 +474,8 @@ class SingleBandMultiModel(ImageLinearFit):
         ) = self.select_kwargs(
             kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_extinction
         )
-        A = self._linear_response_matrix(
+        A = ImageLinearFit.linear_response_matrix(
+            self,
             kwargs_lens_i,
             kwargs_source_i,
             kwargs_lens_light_i,
@@ -461,12 +505,19 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_source_i = kwargs_source
         else:
             kwargs_source_i = [kwargs_source[k] for k in self._index_source]
-        return self._error_map_source(kwargs_source_i, x_grid, y_grid, cov_param)
+        if self.linear_solver:
+            return ImageLinearFit.error_map_source(self, kwargs_source_i, x_grid, y_grid, cov_param)
+        else:
+            return np.zeros_like(x_grid)
 
     def error_response(self, kwargs_lens, kwargs_ps, kwargs_special):
         """Returns the 1d array of the error estimate corresponding to the data
         response.
 
+        
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param kwargs_special: keyword arguments corresponding to "special" parameters
         :return: 1d numpy array of response, 2d array of additional errors (e.g. point
             source uncertainties)
         """
@@ -483,8 +534,8 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps=kwargs_ps,
             kwargs_extinction=None,
         )
-        return self._error_response(
-            kwargs_lens_i, kwargs_ps_i, kwargs_special=kwargs_special
+        return ImageModel.error_response(
+            self, kwargs_lens_i, kwargs_ps_i, kwargs_special=kwargs_special
         )
 
     def extinction_map(self, kwargs_extinction=None, kwargs_special=None):
@@ -492,21 +543,21 @@ class SingleBandMultiModel(ImageLinearFit):
 
         :param kwargs_extinction: list of keyword arguments corresponding to the optical
             depth models tau, such that extinction is exp(-tau)
-        :param kwargs_special: keyword arguments, additional parameter to the extinction
+        :param kwargs_special: keyword arguments corresponding to "special" parameters
         :return: 2d array of size of the image
         """
         _, _, _, _, kwargs_extinction_i = self.select_kwargs(
             kwargs_extinction=kwargs_extinction
         )
-        return self._extinction_map(kwargs_extinction_i, kwargs_special)
+        return ImageModel.extinction_map(self, kwargs_extinction_i, kwargs_special)
 
     def linear_param_from_kwargs(self, kwargs_source, kwargs_lens_light, kwargs_ps):
         """Inverse function of update_linear() returning the linear amplitude list for
         the keyword argument list.
 
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: list of linear coefficients
         """
         _, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i, _ = self.select_kwargs(
@@ -516,9 +567,12 @@ class SingleBandMultiModel(ImageLinearFit):
             kwargs_ps=kwargs_ps,
             kwargs_extinction=None,
         )
-        return self._linear_param_from_kwargs(
-            kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
-        )
+        if self.linear_solver:
+            return ImageLinearFit.linear_param_from_kwargs(
+                self, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
+            )
+        else:
+            return []
 
     def select_kwargs(
         self,
@@ -531,11 +585,12 @@ class SingleBandMultiModel(ImageLinearFit):
     ):
         """Select subset of kwargs lists referenced to this imaging band.
 
-        :param kwargs_lens:
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
-        :return:
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param kwargs_extinction: list of keyword arguments of extinction model
+        :return: downselected list of kwargs corresponding to the index lists
         """
         if self._index_lens_model is None or kwargs_lens is None:
             kwargs_lens_i = kwargs_lens

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -341,7 +341,6 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
         :return: log likelihood (natural logarithm) (sum of the log likelihoods of the
             individual images)
         """
-        # generate image
         (
             kwargs_lens_i,
             kwargs_source_i,

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -89,7 +89,7 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
             imageClass = ImageLinearFit
         else:
             imageClass = ImageModel
-        
+
         imageClass.__init__(
             self,
             data_i,
@@ -320,14 +320,15 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
         source_marg=False,
         linear_prior=None,
         check_positive_flux=False,
-        linear_solver=None
+        linear_solver=None,
     ):
         """Computes the likelihood of the data given a model This is specified with the
         non-linear parameters and a linear inversion and prior marginalisation.
 
         :param kwargs_lens: list of dicts containing lens model keyword arguments
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :param kwargs_extinction: keyword arguments corresponding to dust extinction
         :param kwargs_special: keyword arguments corresponding to "special" parameters
@@ -391,7 +392,8 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
         :param param: linear parameter vector corresponding to the response matrix
         :param kwargs_lens: list of dicts containing lens model keyword arguments
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: updated list of kwargs with linear parameter values
         """
@@ -409,8 +411,15 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
             kwargs_extinction=None,
         )
         if self.linear_solver:
-            kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i = ImageLinearFit.update_linear_kwargs(
-                self, param, kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
+            kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i = (
+                ImageLinearFit.update_linear_kwargs(
+                    self,
+                    param,
+                    kwargs_lens_i,
+                    kwargs_source_i,
+                    kwargs_lens_light_i,
+                    kwargs_ps_i,
+                )
             )
         return kwargs_lens_i, kwargs_source_i, kwargs_lens_light_i, kwargs_ps_i
 
@@ -458,7 +467,8 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
 
         :param kwargs_lens: list of dicts containing lens model keyword arguments
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :param kwargs_extinction: list of keyword arguments corresponding to the optical
             depth models tau, such that extinction is exp(-tau)
@@ -506,7 +516,9 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
         else:
             kwargs_source_i = [kwargs_source[k] for k in self._index_source]
         if self.linear_solver:
-            return ImageLinearFit.error_map_source(self, kwargs_source_i, x_grid, y_grid, cov_param)
+            return ImageLinearFit.error_map_source(
+                self, kwargs_source_i, x_grid, y_grid, cov_param
+            )
         else:
             return np.zeros_like(x_grid)
 
@@ -514,7 +526,6 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
         """Returns the 1d array of the error estimate corresponding to the data
         response.
 
-        
         :param kwargs_lens: list of dicts containing lens model keyword arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :param kwargs_special: keyword arguments corresponding to "special" parameters
@@ -556,7 +567,8 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
         the keyword argument list.
 
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: list of linear coefficients
         """
@@ -587,7 +599,8 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
 
         :param kwargs_lens: list of dicts containing lens model keyword arguments
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :param kwargs_extinction: list of keyword arguments of extinction model
         :return: downselected list of kwargs corresponding to the index lists

--- a/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/lenstronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -233,9 +233,10 @@ class SingleBandMultiModel(ImageLinearFit, ImageModel):
 
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_special: list of dicts containing "special" keywords
         :param unconvolved: bool, if False, applies convolution
         :param k: int or tuple, only evaluate the k-th point source model
-        :return:
+        :return: image of point source
         """
         kwargs_lens_i, _, _, kwargs_ps_i, _ = self.select_kwargs(
             kwargs_lens=kwargs_lens,

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -410,7 +410,8 @@ class ImageLinearFit(ImageModel):
         :param param: linear parameter vector corresponding to the response matrix
         :param kwargs_lens: list of dicts containing lens model keyword arguments
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: updated list of kwargs with linear parameter values
         """
@@ -429,7 +430,8 @@ class ImageLinearFit(ImageModel):
         the keyword argument list.
 
         :param kwargs_source: list of dicts containing source model keyword arguments
-        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword
+            arguments
         :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: list of linear coefficients
         """

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -220,7 +220,7 @@ class ImageLinearFit(ImageModel):
             likelihood if so.
         :return: log likelihood (natural logarithm), linear parameter list
         """
-        
+
         im_sim, model_error, cov_matrix, param = ImageLinearFit.image_linear_solve(
             self,
             kwargs_lens,
@@ -413,9 +413,7 @@ class ImageLinearFit(ImageModel):
         kwargs_lens_light, i = self.LensLightModel.update_linear(
             param, i, kwargs_list=kwargs_lens_light
         )
-        kwargs_ps, i = self.PointSource.update_linear(
-            param, i, kwargs_ps, kwargs_lens
-        )
+        kwargs_ps, i = self.PointSource.update_linear(param, i, kwargs_ps, kwargs_lens)
         return kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
 
     def linear_param_from_kwargs(self, kwargs_source, kwargs_lens_light, kwargs_ps):

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -302,6 +302,10 @@ class ImageLinearFit(ImageModel):
         self, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
     ):
         """
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
 
         :return: number of linear coefficients to be solved for in the linear inversion
         """
@@ -404,6 +408,10 @@ class ImageLinearFit(ImageModel):
         """Links linear parameters to kwargs arguments.
 
         :param param: linear parameter vector corresponding to the response matrix
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: updated list of kwargs with linear parameter values
         """
         i = 0
@@ -420,9 +428,9 @@ class ImageLinearFit(ImageModel):
         """Inverse function of update_linear() returning the linear amplitude list for
         the keyword argument list.
 
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
         :return: list of linear coefficients
         """
         param = []

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -28,7 +28,6 @@ class ImageLinearFit(ImageModel):
         likelihood_mask=None,
         psf_error_map_bool_list=None,
         kwargs_pixelbased=None,
-        linear_solver=True,
     ):
         """
 
@@ -45,8 +44,6 @@ class ImageLinearFit(ImageModel):
          Indicates whether PSF error map is used for the point source model stated as the index.
         :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver
          (see SLITronomy documentation) being applied to the point sources.
-        :param linear_solver: bool, if True (default) fixes the linear amplitude parameters 'amp' (avoid sampling) such
-         that they get overwritten by the linear solver solution.
         """
         super(ImageLinearFit, self).__init__(
             data_class,
@@ -57,21 +54,10 @@ class ImageLinearFit(ImageModel):
             point_source_class=point_source_class,
             extinction_class=extinction_class,
             kwargs_numerics=kwargs_numerics,
+            likelihood_mask=likelihood_mask,
+            psf_error_map_bool_list=psf_error_map_bool_list,
             kwargs_pixelbased=kwargs_pixelbased,
         )
-        self._linear_solver = linear_solver
-        if psf_error_map_bool_list is None:
-            psf_error_map_bool_list = [True] * len(
-                self.PointSource.point_source_type_list
-            )
-        self._psf_error_map_bool_list = psf_error_map_bool_list
-        if likelihood_mask is None:
-            likelihood_mask = np.ones_like(data_class.data)
-        self.likelihood_mask = np.array(likelihood_mask, dtype=bool)
-        self._mask1d = util.image2array(self.likelihood_mask)
-        if self._pixelbased_bool is True:
-            # update the pixel-based solver with the likelihood mask
-            self.PixelSolver.set_likelihood_mask(self.likelihood_mask)
 
         # prepare to use fft convolution for the natwt linear solver
         if self.Data.likelihood_method() == "interferometry_natwt":
@@ -80,45 +66,6 @@ class ImageLinearFit(ImageModel):
             )
 
     def image_linear_solve(
-        self,
-        kwargs_lens=None,
-        kwargs_source=None,
-        kwargs_lens_light=None,
-        kwargs_ps=None,
-        kwargs_extinction=None,
-        kwargs_special=None,
-        inv_bool=False,
-    ):
-        """Computes the image (lens and source surface brightness with a given lens
-        model). The linear parameters are computed with a weighted linear least square
-        optimization (i.e. flux normalization of the brightness profiles) However in
-        case of pixel-based modelling, pixel values are constrained by an external
-        solver (e.g. SLITronomy).
-
-        :param kwargs_lens: list of keyword arguments corresponding to the superposition
-            of different lens profiles
-        :param kwargs_source: list of keyword arguments corresponding to the
-            superposition of different source light profiles
-        :param kwargs_lens_light: list of keyword arguments corresponding to different
-            lens light surface brightness profiles
-        :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as
-            external shear and point source image positions
-        :param inv_bool: if True, invert the full linear solver Matrix Ax = y for the
-            purpose of the covariance matrix.
-        :return: 2d array of surface brightness pixels of the optimal solution of the
-            linear parameters to match the data
-        """
-        return self._image_linear_solve(
-            kwargs_lens,
-            kwargs_source,
-            kwargs_lens_light,
-            kwargs_ps,
-            kwargs_extinction,
-            kwargs_special,
-            inv_bool=inv_bool,
-        )
-
-    def _image_linear_solve(
         self,
         kwargs_lens=None,
         kwargs_source=None,
@@ -158,7 +105,8 @@ class ImageLinearFit(ImageModel):
                 kwargs_special,
             )
         elif self.Data.likelihood_method() == "diagonal":
-            A = self._linear_response_matrix(
+            A = ImageLinearFit.linear_response_matrix(
+                self,
                 kwargs_lens,
                 kwargs_source,
                 kwargs_lens_light,
@@ -166,16 +114,16 @@ class ImageLinearFit(ImageModel):
                 kwargs_extinction,
                 kwargs_special,
             )
-            C_D_response, model_error = self._error_response(
-                kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
+            C_D_response, model_error = ImageModel.error_response(
+                self, kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
             )
             d = self.data_response
             param, cov_param, wls_model = de_lens.get_param_WLS(
                 A.T, 1 / C_D_response, d, inv_bool=inv_bool
             )
             model = self.array_masked2image(wls_model)
-            _, _, _, _ = self._update_linear_kwargs(
-                param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
+            _, _, _, _ = ImageLinearFit.update_linear_kwargs(
+                self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
             )
         elif self.Data.likelihood_method() == "interferometry_natwt":
             (
@@ -224,8 +172,8 @@ class ImageLinearFit(ImageModel):
         :return: 2d array of surface brightness pixels of the optimal solution of the
             linear parameters to match the data
         """
-        _, model_error = self._error_response(
-            kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
+        _, model_error = ImageModel.error_response(
+            self, kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
         )
         model, param, _ = self.PixelSolver.solve(
             kwargs_lens,
@@ -237,75 +185,10 @@ class ImageLinearFit(ImageModel):
         )
         cov_param = None
         _, _ = self.update_pixel_kwargs(kwargs_source, kwargs_lens_light)
-        _, _, _, _ = self._update_linear_kwargs(
-            param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
+        _, _, _, _ = ImageLinearFit.update_linear_kwargs(
+            self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
         )
         return model, model_error, cov_param, param
-
-    def linear_response_matrix(
-        self,
-        kwargs_lens=None,
-        kwargs_source=None,
-        kwargs_lens_light=None,
-        kwargs_ps=None,
-        kwargs_extinction=None,
-        kwargs_special=None,
-    ):
-        """Computes the linear response matrix (m x n), with n being the data size and m
-        being the coefficients.
-
-        :param kwargs_lens: lens model keyword argument list
-        :param kwargs_source: extended source model keyword argument list
-        :param kwargs_lens_light: lens light model keyword argument list
-        :param kwargs_ps: point source model keyword argument list
-        :param kwargs_extinction: extinction model keyword argument list
-        :param kwargs_special: special keyword argument list
-        :return: linear response matrix
-        """
-        A = self._linear_response_matrix(
-            kwargs_lens,
-            kwargs_source,
-            kwargs_lens_light,
-            kwargs_ps,
-            kwargs_extinction,
-            kwargs_special,
-        )
-        return A
-
-    @property
-    def data_response(self):
-        """Returns the 1d array of the data element that is fitted for (including
-        masking)
-
-        :return: 1d numpy array
-        """
-        d = self.image2array_masked(self.Data.data)
-        return d
-
-    def error_response(self, kwargs_lens, kwargs_ps, kwargs_special):
-        """Returns the 1d array of the error estimate corresponding to the data
-        response.
-
-        :return: 1d numpy array of response, 2d array of additional errors (e.g. point
-            source uncertainties)
-        """
-        return self._error_response(
-            kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
-        )
-
-    def _error_response(self, kwargs_lens, kwargs_ps, kwargs_special):
-        """Returns the 1d array of the error estimate corresponding to the data
-        response.
-
-        :return: 1d numpy array of response, 2d array of additional errors (e.g. point
-            source uncertainties)
-        """
-        model_error = self._error_map_model(
-            kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
-        )
-        # adding the uncertainties estimated from the data with the ones from the model
-        C_D_response = self.image2array_masked(self.Data.C_D + model_error)
-        return C_D_response, model_error
 
     def likelihood_data_given_model(
         self,
@@ -318,7 +201,6 @@ class ImageLinearFit(ImageModel):
         source_marg=False,
         linear_prior=None,
         check_positive_flux=False,
-        linear_solver=True,
     ):
         """Computes the likelihood of the data given a model This is specified with the
         non-linear parameters and a linear inversion and prior marginalisation.
@@ -331,89 +213,24 @@ class ImageLinearFit(ImageModel):
             lens light surface brightness profiles
         :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as
             external shear and point source image positions
-        :param kwargs_extinction:
-        :param kwargs_special:
         :param source_marg: bool, performs a marginalization over the linear parameters
         :param linear_prior: linear prior width in eigenvalues
         :param check_positive_flux: bool, if True, checks whether the linear inversion
             resulted in non-negative flux components and applies a punishment in the
             likelihood if so.
-        :param linear_solver: bool, if True (default) fixes the linear amplitude
-            parameters 'amp' (avoid sampling) such that they get overwritten by the
-            linear solver solution.
-        :return: log likelihood (natural logarithm)
+        :return: log likelihood (natural logarithm), linear parameter list
         """
-        return self._likelihood_data_given_model(
+        
+        im_sim, model_error, cov_matrix, param = ImageLinearFit.image_linear_solve(
+            self,
             kwargs_lens,
             kwargs_source,
             kwargs_lens_light,
             kwargs_ps,
             kwargs_extinction,
             kwargs_special,
-            source_marg,
-            linear_prior=linear_prior,
-            check_positive_flux=check_positive_flux,
-            linear_solver=linear_solver,
+            inv_bool=source_marg,
         )
-
-    def _likelihood_data_given_model(
-        self,
-        kwargs_lens=None,
-        kwargs_source=None,
-        kwargs_lens_light=None,
-        kwargs_ps=None,
-        kwargs_extinction=None,
-        kwargs_special=None,
-        source_marg=False,
-        linear_prior=None,
-        check_positive_flux=False,
-        linear_solver=True,
-    ):
-        """Computes the likelihood of the data given a model This is specified with the
-        non-linear parameters and a linear inversion and prior marginalisation.
-
-        :param kwargs_lens: list of keyword arguments corresponding to the superposition
-            of different lens profiles
-        :param kwargs_source: list of keyword arguments corresponding to the
-            superposition of different source light profiles
-        :param kwargs_lens_light: list of keyword arguments corresponding to different
-            lens light surface brightness profiles
-        :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as
-            external shear and point source image positions
-        :param source_marg: bool, performs a marginalization over the linear parameters
-        :param linear_prior: linear prior width in eigenvalues
-        :param check_positive_flux: bool, if True, checks whether the linear inversion
-            resulted in non-negative flux components and applies a punishment in the
-            likelihood if so.
-        :param linear_solver: bool, if True (default) fixes the linear amplitude
-            parameters 'amp' (avoid sampling) such that they get overwritten by the
-            linear solver solution.
-        :return: log likelihood (natural logarithm), linear parameter list
-        """
-        # generate image
-        if linear_solver is False:
-            im_sim = self.image(
-                kwargs_lens,
-                kwargs_source,
-                kwargs_lens_light,
-                kwargs_ps,
-                kwargs_extinction,
-                kwargs_special,
-            )
-            cov_matrix, param = None, None
-            model_error = self._error_map_model(
-                kwargs_lens, kwargs_ps=kwargs_ps, kwargs_special=kwargs_special
-            )
-        else:
-            im_sim, model_error, cov_matrix, param = self._image_linear_solve(
-                kwargs_lens,
-                kwargs_source,
-                kwargs_lens_light,
-                kwargs_ps,
-                kwargs_extinction,
-                kwargs_special,
-                inv_bool=source_marg,
-            )
         # compute X^2
         logL = self.likelihood_data_given_model_solution(
             im_sim,
@@ -446,18 +263,20 @@ class ImageLinearFit(ImageModel):
     ):
         """
 
-        :param model:
-        :param model_error:
-        :param cov_matrix:
-        :param param:
-        :param kwargs_lens:
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
-        :param source_marg:
-        :param linear_prior:
-        :param check_positive_flux:
-        :return:
+        :param model: 2d array, image model
+        :param model_error: 2d array, uncertainties in each pixel
+        :param cov_matrix: 2d array, covariance matrix
+        :param param: linear parameter vector corresponding to the response matrix
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_source: list of dicts containing source model keyword arguments
+        :param kwargs_lens_light: list of dicts containing lens light model keyword arguments
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param source_marg: bool, performs a marginalization over the linear parameters
+        :param linear_prior: linear prior width in eigenvalues
+        :param check_positive_flux: bool, if True, checks whether the linear inversion
+            resulted in non-negative flux components and applies a punishment in the
+            likelihood if so.
+        :return: float, likelihood data given model
         """
 
         logL = self.Data.log_likelihood(model, self.likelihood_mask, model_error)
@@ -469,8 +288,8 @@ class ImageLinearFit(ImageModel):
                 )
                 logL += marg_const
         if check_positive_flux is True:
-            _, _, _, _ = self._update_linear_kwargs(
-                param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
+            _, _, _, _ = ImageLinearFit.update_linear_kwargs(
+                self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
             )
             bool_ = self.check_positive_flux(
                 kwargs_source, kwargs_lens_light, kwargs_ps
@@ -486,27 +305,15 @@ class ImageLinearFit(ImageModel):
 
         :return: number of linear coefficients to be solved for in the linear inversion
         """
-        return self._num_param_linear(
-            kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
-        )
-
-    def _num_param_linear(
-        self, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
-    ):
-        """
-
-        :return: number of linear coefficients to be solved for in the linear inversion
-        """
         num = 0
 
-        if self._pixelbased_bool is False and self._linear_solver is True:
+        if self._pixelbased_bool is False:
             num += self.SourceModel.num_param_linear(kwargs_source)
             num += self.LensLightModel.num_param_linear(kwargs_lens_light)
-        if self._linear_solver is True:
-            num += self.PointSource.num_basis(kwargs_ps, kwargs_lens)
+        num += self.PointSource.num_basis(kwargs_ps, kwargs_lens)
         return num
 
-    def _linear_response_matrix(
+    def linear_response_matrix(
         self,
         kwargs_lens,
         kwargs_source,
@@ -599,29 +406,16 @@ class ImageLinearFit(ImageModel):
         :param param: linear parameter vector corresponding to the response matrix
         :return: updated list of kwargs with linear parameter values
         """
-        return self._update_linear_kwargs(
-            param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
+        i = 0
+        kwargs_source, i = self.SourceModel.update_linear(
+            param, i, kwargs_list=kwargs_source
         )
-
-    def _update_linear_kwargs(
-        self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
-    ):
-        """Links linear parameters to kwargs arguments.
-
-        :param param: linear parameter vector corresponding to the response matrix
-        :return: updated list of kwargs with linear parameter values
-        """
-        if self._linear_solver is True:
-            i = 0
-            kwargs_source, i = self.SourceModel.update_linear(
-                param, i, kwargs_list=kwargs_source
-            )
-            kwargs_lens_light, i = self.LensLightModel.update_linear(
-                param, i, kwargs_list=kwargs_lens_light
-            )
-            kwargs_ps, i = self.PointSource.update_linear(
-                param, i, kwargs_ps, kwargs_lens
-            )
+        kwargs_lens_light, i = self.LensLightModel.update_linear(
+            param, i, kwargs_list=kwargs_lens_light
+        )
+        kwargs_ps, i = self.PointSource.update_linear(
+            param, i, kwargs_ps, kwargs_lens
+        )
         return kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
 
     def linear_param_from_kwargs(self, kwargs_source, kwargs_lens_light, kwargs_ps):
@@ -633,24 +427,10 @@ class ImageLinearFit(ImageModel):
         :param kwargs_ps:
         :return: list of linear coefficients
         """
-        return self._linear_param_from_kwargs(
-            kwargs_source, kwargs_lens_light, kwargs_ps
-        )
-
-    def _linear_param_from_kwargs(self, kwargs_source, kwargs_lens_light, kwargs_ps):
-        """Inverse function of update_linear() returning the linear amplitude list for
-        the keyword argument list.
-
-        :param kwargs_source:
-        :param kwargs_lens_light:
-        :param kwargs_ps:
-        :return: list of linear coefficients
-        """
         param = []
-        if self._linear_solver is True:
-            param += self.SourceModel.linear_param_from_kwargs(kwargs_source)
-            param += self.LensLightModel.linear_param_from_kwargs(kwargs_lens_light)
-            param += self.PointSource.linear_param_from_kwargs(kwargs_ps)
+        param += self.SourceModel.linear_param_from_kwargs(kwargs_source)
+        param += self.LensLightModel.linear_param_from_kwargs(kwargs_lens_light)
+        param += self.PointSource.linear_param_from_kwargs(kwargs_ps)
         return param
 
     def update_pixel_kwargs(self, kwargs_source, kwargs_lens_light):
@@ -682,114 +462,7 @@ class ImageLinearFit(ImageModel):
             kwargs_lens_light[0]["center_y"] = 0
         return kwargs_source, kwargs_lens_light
 
-    def reduced_residuals(self, model, error_map=0):
-        """
-
-        :param model: 2d numpy array of the modeled image
-        :param error_map: 2d numpy array of additional noise/error terms from model components (such as PSF model uncertainties)
-        :return: 2d numpy array of reduced residuals per pixel
-        """
-        mask = self.likelihood_mask
-        C_D = self.Data.C_D_model(model)
-        residual = (model - self.Data.data) / np.sqrt(C_D + np.abs(error_map)) * mask
-        return residual
-
-    def reduced_chi2(self, model, error_map=0):
-        """Returns reduced chi2 :param model: 2d numpy array of a model predicted image
-        :param error_map: same format as model, additional error component (such as PSF
-        errors) :return: reduced chi2."""
-        norm_res = self.reduced_residuals(model, error_map)
-        return np.sum(norm_res**2) / self.num_data_evaluate
-
-    @property
-    def num_data_evaluate(self):
-        """Number of data points to be used in the linear solver :return: number of
-        evaluated data points :rtype: int."""
-        return int(np.sum(self.likelihood_mask))
-
-    def update_data(self, data_class):
-        """
-
-        :param data_class: instance of Data() class
-        :return: no return. Class is updated.
-        """
-        self.Data = data_class
-        self.ImageNumerics._PixelGrid = data_class
-
-    def image2array_masked(self, image):
-        """Returns 1d array of values in image that are not masked out for the
-        likelihood computation/linear minimization :param image: 2d numpy array of full
-        image :return: 1d array."""
-        array = util.image2array(image)
-        return array[self._mask1d]
-
-    def array_masked2image(self, array):
-        """
-
-        :param array: 1d array of values not masked out (part of linear fitting)
-        :return: 2d array of full image
-        """
-        nx, ny = self.Data.num_pixel_axes
-        grid1d = np.zeros(nx * ny)
-        grid1d[self._mask1d] = array
-        grid2d = util.array2image(grid1d, nx, ny)
-        return grid2d
-
-    def _error_map_model(self, kwargs_lens, kwargs_ps, kwargs_special=None):
-        """Noise estimate (variances as diagonal of the pixel covariance matrix)
-        resulted from inherent model uncertainties This term is currently the psf error
-        map.
-
-        :param kwargs_lens: lens model keyword arguments
-        :param kwargs_ps: point source keyword arguments
-        :param kwargs_special: special parameter keyword arguments
-        :return: 2d array corresponding to the pixels in terms of variance in noise
-        """
-        return self._error_map_psf(kwargs_lens, kwargs_ps, kwargs_special)
-
-    def _error_map_psf(self, kwargs_lens, kwargs_ps, kwargs_special=None):
-        """Map of image with error terms (sigma**2) expected from inaccuracies in the
-        PSF modeling.
-
-        :param kwargs_lens: lens model keyword arguments
-        :param kwargs_ps: point source keyword arguments
-        :param kwargs_special: special parameter keyword arguments
-        :return: 2d array of size of the image
-        """
-        error_map = np.zeros(self.Data.num_pixel_axes)
-        if self._psf_error_map is True:
-            for k, bool_ in enumerate(self._psf_error_map_bool_list):
-                if bool_ is True:
-                    ra_pos, dec_pos, _ = self.PointSource.point_source_list(
-                        kwargs_ps, kwargs_lens=kwargs_lens, k=k, with_amp=False
-                    )
-                    if len(ra_pos) > 0:
-                        ra_pos, dec_pos = self._displace_astrometry(
-                            ra_pos, dec_pos, kwargs_special=kwargs_special
-                        )
-                        error_map += self.ImageNumerics.psf_error_map(
-                            ra_pos,
-                            dec_pos,
-                            None,
-                            self.Data.data,
-                            fix_psf_error_map=False,
-                        )
-        return error_map
-
     def error_map_source(self, kwargs_source, x_grid, y_grid, cov_param):
-        """Variance of the linear source reconstruction in the source plane coordinates,
-        computed by the diagonal elements of the covariance matrix of the source
-        reconstruction as a sum of the errors of the basis set.
-
-        :param kwargs_source: keyword arguments of source model
-        :param x_grid: x-axis of positions to compute error map
-        :param y_grid: y-axis of positions to compute error map
-        :param cov_param: covariance matrix of liner inversion parameters
-        :return: diagonal covariance errors at the positions (x_grid, y_grid)
-        """
-        return self._error_map_source(kwargs_source, x_grid, y_grid, cov_param)
-
-    def _error_map_source(self, kwargs_source, x_grid, y_grid, cov_param):
         """Variance of the linear source reconstruction in the source plane coordinates,
         computed by the diagonal elements of the covariance matrix of the source
         reconstruction as a sum of the errors of the basis set.
@@ -898,7 +571,8 @@ class ImageLinearFit(ImageModel):
         model and param are the same returns of self._image_linear_solve_interferometry_natwt_solving(A, d) function
         model_error =0 and cov_param = None for the interferometric method.
         """
-        A = self._linear_response_matrix(
+        A = ImageLinearFit.linear_response_matrix(
+            self,
             kwargs_lens,
             kwargs_source,
             kwargs_lens_light,
@@ -911,8 +585,8 @@ class ImageLinearFit(ImageModel):
         model, param = self._image_linear_solve_interferometry_natwt_solving(A, d)
         model_error = 0  # just a place holder
         cov_param = None  # just a place holder
-        _, _, _, _ = self._update_linear_kwargs(
-            param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
+        _, _, _, _ = ImageLinearFit.update_linear_kwargs(
+            self, param, kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps
         )
         return model, model_error, cov_param, param
 

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -562,6 +562,9 @@ class ImageModel(object):
         """Returns the 1d array of the error estimate corresponding to the data
         response.
 
+        :param kwargs_lens: list of dicts, keyword arguments corresponding to the lens profiles
+        :param kwargs_ps: list of dicts, keyword arguments corresponding to the point source models
+        :param kwargs_special: list of dicts, special parameter keyword arguments
         :return: 1d numpy array of response, 2d array of additional errors (e.g. point
             source uncertainties)
         """
@@ -586,7 +589,7 @@ class ImageModel(object):
         """Update the instance of the class with a new instance of PSF() with a
         potentially different point spread function.
 
-        :param psf_class:
+        :param psi_class: instance of lenstronomy.Data.psf.PSF class
         :return: no return. Class is updated.
         """
         self.PSF = psf_class

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -188,7 +188,6 @@ class ImageModel(object):
         logL = self.Data.log_likelihood(im_sim, self.likelihood_mask, model_error)
         return logL
 
-
     def source_surface_brightness(
         self,
         kwargs_source,
@@ -548,7 +547,7 @@ class ImageModel(object):
             / self.ImageNumerics.grid_class.pixel_width**2
         )
         return extinction
-    
+
     @property
     def data_response(self):
         """Returns the 1d array of the data element that is fitted for (including
@@ -604,16 +603,16 @@ class ImageModel(object):
         """
         self.Data = data_class
         self.ImageNumerics._PixelGrid = data_class
-    
+
     @property
     def num_data_evaluate(self):
-        """Number of data points to be used in the likelihood calculation
+        """Number of data points to be used in the likelihood calculation.
 
         :return: number of evaluated data points
         :rtype: int.
         """
         return int(np.sum(self.likelihood_mask))
-    
+
     def reduced_residuals(self, model, error_map=0):
         """
 
@@ -627,19 +626,19 @@ class ImageModel(object):
         return residual
 
     def reduced_chi2(self, model, error_map=0):
-        """Returns reduced chi2
+        """Returns reduced chi2.
 
         :param model: 2d numpy array of a model predicted image
         :param error_map: same format as model, additional error component (such as PSF
-        errors)
+            errors)
         :return: reduced chi2.
         """
         norm_res = self.reduced_residuals(model, error_map)
         return np.sum(norm_res**2) / self.num_data_evaluate
-    
+
     def image2array_masked(self, image):
         """Returns 1d array of values in image that are not masked out for the
-        likelihood computation/linear minimization
+        likelihood computation/linear minimization.
 
         :param image: 2d numpy array of full image
         :return: 1d array.
@@ -658,7 +657,7 @@ class ImageModel(object):
         grid1d[self._mask1d] = array
         grid2d = util.array2image(grid1d, nx, ny)
         return grid2d
-    
+
     def _error_map_model(self, kwargs_lens, kwargs_ps, kwargs_special=None):
         """Noise estimate (variances as diagonal of the pixel covariance matrix)
         resulted from inherent model uncertainties This term is currently the psf error

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -445,12 +445,12 @@ class ImageModel(object):
     ):
         """Computes the point source positions and paints PSF convolutions on them.
 
-        :param kwargs_ps:
-        :param kwargs_lens:
-        :param kwargs_special:
-        :param unconvolved:
-        :param k:
-        :return:
+        :param kwargs_ps: list of dicts containing point source keyword arguments
+        :param kwargs_lens: list of dicts containing lens model keyword arguments
+        :param kwargs_special: list of dicts containing "special" keywords
+        :param unconvolved: bool, if False, applies convolution
+        :param k: int or tuple, only evaluate the k-th point source model
+        :return: image of point source
         """
         point_source_image = np.zeros((self.Data.num_pixel_axes))
         if unconvolved or self.PointSource is None:

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -27,6 +27,8 @@ class ImageModel(object):
         point_source_class=None,
         extinction_class=None,
         kwargs_numerics=None,
+        likelihood_mask=None,
+        psf_error_map_bool_list=None,
         kwargs_pixelbased=None,
     ):
         """
@@ -75,6 +77,10 @@ class ImageModel(object):
             only_from_unspecified=True,
         )
         self._psf_error_map = self.PSF.psf_error_map_bool
+        if likelihood_mask is None:
+            likelihood_mask = np.ones(data_class.num_pixel_axes)
+        self.likelihood_mask = np.array(likelihood_mask, dtype=bool)
+        self._mask1d = util.image2array(self.likelihood_mask)
 
         if source_model_class is None:
             source_model_class = LightModel(light_model_list=[])
@@ -111,6 +117,8 @@ class ImageModel(object):
                 self._extinction,
                 kwargs_pixelbased,
             )
+            # update the pixel-based solver with the likelihood mask
+            self.PixelSolver.set_likelihood_mask(self.likelihood_mask)
             self.source_mapping = None  # handled with pixelated operator
         else:
             self.source_mapping = Image2SourceMapping(
@@ -123,66 +131,65 @@ class ImageModel(object):
         else:
             self._pb_1d = None
 
-    def reset_point_source_cache(self, cache=True):
-        """Deletes all the cache in the point source class and saves it from then on.
+        if psf_error_map_bool_list is None:
+            psf_error_map_bool_list = [True] * len(
+                self.PointSource.point_source_type_list
+            )
+        self._psf_error_map_bool_list = psf_error_map_bool_list
 
-        :param cache: boolean, if True, saves the next occuring point source positions
-            in the cache
-        :return: None
-        """
-        self.PointSource.delete_lens_model_cache()
-        self.PointSource.set_save_cache(cache)
-
-    def update_psf(self, psf_class):
-        """Update the instance of the class with a new instance of PSF() with a
-        potentially different point spread function.
-
-        :param psf_class:
-        :return: no return. Class is updated.
-        """
-        self.PSF = psf_class
-        self.PSF.set_pixel_size(self.Data.pixel_width)
-        self.ImageNumerics = NumericsSubFrame(
-            pixel_grid=self.Data, psf=self.PSF, **self._kwargs_numerics
-        )
-
-    def source_surface_brightness(
+    def likelihood_data_given_model(
         self,
-        kwargs_source,
         kwargs_lens=None,
+        kwargs_source=None,
+        kwargs_lens_light=None,
+        kwargs_ps=None,
         kwargs_extinction=None,
         kwargs_special=None,
-        unconvolved=False,
-        de_lensed=False,
-        k=None,
-        update_pixelbased_mapping=True,
+        linear_prior=None,
+        source_marg=False,
+        check_positive_flux=False,
     ):
-        """Computes the source surface brightness distribution.
+        """Computes the likelihood of the data given a model This is specified with the
+        non-linear parameters and a linear inversion and prior marginalisation.
 
-        :param kwargs_source: list of keyword arguments corresponding to the
-            superposition of different source light profiles
         :param kwargs_lens: list of keyword arguments corresponding to the superposition
             of different lens profiles
-        :param kwargs_extinction: list of keyword arguments of extinction model
-        :param unconvolved: if True: returns the unconvolved light distribution (prefect
-            seeing)
-        :param de_lensed: if True: returns the un-lensed source surface brightness
-            profile, otherwise the lensed.
-        :param k: integer, if set, will only return the model of the specific index
-        :return: 2d array of surface brightness pixels
+        :param kwargs_source: list of keyword arguments corresponding to the
+            superposition of different source light profiles
+        :param kwargs_lens_light: list of keyword arguments corresponding to different
+            lens light surface brightness profiles
+        :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as
+            external shear and point source image positions
+        :param source_marg: bool, performs a marginalization over the linear parameters
+        :param linear_prior: linear prior width in eigenvalues
+        :param check_positive_flux: bool, if True, checks whether the linear inversion
+            resulted in non-negative flux components and applies a punishment in the
+            likelihood if so.
+        :param linear_solver: bool, if True (default) fixes the linear amplitude
+            parameters 'amp' (avoid sampling) such that they get overwritten by the
+            linear solver solution.
+        :return: log likelihood (natural logarithm), linear parameter list
         """
-        return self._source_surface_brightness(
-            kwargs_source,
+        # generate image
+        im_sim = ImageModel.image(
+            self,
             kwargs_lens,
-            kwargs_extinction=kwargs_extinction,
-            kwargs_special=kwargs_special,
-            unconvolved=unconvolved,
-            de_lensed=de_lensed,
-            k=k,
-            update_pixelbased_mapping=update_pixelbased_mapping,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
+            kwargs_extinction,
+            kwargs_special,
+        )
+        model_error = self._error_map_model(
+            kwargs_lens, kwargs_ps=kwargs_ps, kwargs_special=kwargs_special
         )
 
-    def _source_surface_brightness(
+        # compute X^2
+        logL = self.Data.log_likelihood(im_sim, self.likelihood_mask, model_error)
+        return logL
+
+
+    def source_surface_brightness(
         self,
         kwargs_source,
         kwargs_lens=None,
@@ -377,19 +384,6 @@ class ImageModel(object):
             seeing), otherwise convolved with PSF kernel
         :return: 2d array of surface brightness pixels
         """
-        return self._lens_surface_brightness(
-            kwargs_lens_light, unconvolved=unconvolved, k=k
-        )
-
-    def _lens_surface_brightness(self, kwargs_lens_light, unconvolved=False, k=None):
-        """Computes the lens surface brightness distribution.
-
-        :param kwargs_lens_light: list of keyword arguments corresponding to different
-            lens light surface brightness profiles
-        :param unconvolved: if True, returns unconvolved surface brightness (perfect
-            seeing), otherwise convolved with PSF kernel
-        :return: 2d array of surface brightness pixels
-        """
         if self._pixelbased_bool is True:
             if unconvolved is True:
                 raise ValueError(
@@ -459,31 +453,6 @@ class ImageModel(object):
         :param k:
         :return:
         """
-        return self._point_source(
-            kwargs_ps=kwargs_ps,
-            kwargs_lens=kwargs_lens,
-            kwargs_special=kwargs_special,
-            unconvolved=unconvolved,
-            k=k,
-        )
-
-    def _point_source(
-        self,
-        kwargs_ps,
-        kwargs_lens=None,
-        kwargs_special=None,
-        unconvolved=False,
-        k=None,
-    ):
-        """Computes the point source positions and paints PSF convolutions on them.
-
-        :param kwargs_ps:
-        :param kwargs_lens:
-        :param kwargs_special:
-        :param unconvolved:
-        :param k:
-        :return:
-        """
         point_source_image = np.zeros((self.Data.num_pixel_axes))
         if unconvolved or self.PointSource is None:
             return point_source_image
@@ -533,52 +502,10 @@ class ImageModel(object):
         :param point_source_add: if True, add point sources, otherwise without
         :return: 2d array of surface brightness pixels of the simulation
         """
-        return self._image(
-            kwargs_lens,
-            kwargs_source,
-            kwargs_lens_light,
-            kwargs_ps,
-            kwargs_extinction,
-            kwargs_special,
-            unconvolved,
-            source_add,
-            lens_light_add,
-            point_source_add,
-        )
-
-    def _image(
-        self,
-        kwargs_lens=None,
-        kwargs_source=None,
-        kwargs_lens_light=None,
-        kwargs_ps=None,
-        kwargs_extinction=None,
-        kwargs_special=None,
-        unconvolved=False,
-        source_add=True,
-        lens_light_add=True,
-        point_source_add=True,
-    ):
-        """Make an image with a realisation of linear parameter values "param".
-
-        :param kwargs_lens: list of keyword arguments corresponding to the superposition
-            of different lens profiles
-        :param kwargs_source: list of keyword arguments corresponding to the
-            superposition of different source light profiles
-        :param kwargs_lens_light: list of keyword arguments corresponding to different
-            lens light surface brightness profiles
-        :param kwargs_ps: keyword arguments corresponding to "other" parameters, such as
-            external shear and point source image positions
-        :param unconvolved: if True: returns the unconvolved light distribution (prefect
-            seeing)
-        :param source_add: if True, compute source, otherwise without
-        :param lens_light_add: if True, compute lens light, otherwise without
-        :param point_source_add: if True, add point sources, otherwise without
-        :return: 2d array of surface brightness pixels of the simulation
-        """
         model = np.zeros(self.Data.num_pixel_axes)
         if source_add is True:
-            model += self._source_surface_brightness(
+            model += ImageModel.source_surface_brightness(
+                self,
                 kwargs_source,
                 kwargs_lens,
                 kwargs_extinction=kwargs_extinction,
@@ -586,11 +513,12 @@ class ImageModel(object):
                 unconvolved=unconvolved,
             )
         if lens_light_add is True:
-            model += self._lens_surface_brightness(
-                kwargs_lens_light, unconvolved=unconvolved
+            model += ImageModel.lens_surface_brightness(
+                self, kwargs_lens_light, unconvolved=unconvolved
             )
         if point_source_add is True:
-            model += self._point_source(
+            model += ImageModel.point_source(
+                self,
                 kwargs_ps,
                 kwargs_lens,
                 kwargs_special=kwargs_special,
@@ -599,16 +527,6 @@ class ImageModel(object):
         return model
 
     def extinction_map(self, kwargs_extinction=None, kwargs_special=None):
-        """Differential extinction per pixel.
-
-        :param kwargs_extinction: list of keyword arguments corresponding to the optical
-            depth models tau, such that extinction is exp(-tau)
-        :param kwargs_special: keyword arguments, additional parameter to the extinction
-        :return: 2d array of size of the image
-        """
-        return self._extinction_map(kwargs_extinction, kwargs_special)
-
-    def _extinction_map(self, kwargs_extinction=None, kwargs_special=None):
         """Differential extinction per pixel.
 
         :param kwargs_extinction: list of keyword arguments corresponding to the optical
@@ -630,6 +548,157 @@ class ImageModel(object):
             / self.ImageNumerics.grid_class.pixel_width**2
         )
         return extinction
+    
+    @property
+    def data_response(self):
+        """Returns the 1d array of the data element that is fitted for (including
+        masking)
+
+        :return: 1d numpy array
+        """
+        d = self.image2array_masked(self.Data.data)
+        return d
+
+    def error_response(self, kwargs_lens, kwargs_ps, kwargs_special):
+        """Returns the 1d array of the error estimate corresponding to the data
+        response.
+
+        :return: 1d numpy array of response, 2d array of additional errors (e.g. point
+            source uncertainties)
+        """
+        model_error = self._error_map_model(
+            kwargs_lens, kwargs_ps, kwargs_special=kwargs_special
+        )
+        # adding the uncertainties estimated from the data with the ones from the model
+        C_D_response = self.image2array_masked(self.Data.C_D + model_error)
+        return C_D_response, model_error
+
+    def reset_point_source_cache(self, cache=True):
+        """Deletes all the cache in the point source class and saves it from then on.
+
+        :param cache: boolean, if True, saves the next occuring point source positions
+            in the cache
+        :return: None
+        """
+        self.PointSource.delete_lens_model_cache()
+        self.PointSource.set_save_cache(cache)
+
+    def update_psf(self, psf_class):
+        """Update the instance of the class with a new instance of PSF() with a
+        potentially different point spread function.
+
+        :param psf_class:
+        :return: no return. Class is updated.
+        """
+        self.PSF = psf_class
+        self.PSF.set_pixel_size(self.Data.pixel_width)
+        self.ImageNumerics = NumericsSubFrame(
+            pixel_grid=self.Data, psf=self.PSF, **self._kwargs_numerics
+        )
+
+    def update_data(self, data_class):
+        """
+
+        :param data_class: instance of Data() class
+        :return: no return. Class is updated.
+        """
+        self.Data = data_class
+        self.ImageNumerics._PixelGrid = data_class
+    
+    @property
+    def num_data_evaluate(self):
+        """Number of data points to be used in the likelihood calculation
+
+        :return: number of evaluated data points
+        :rtype: int.
+        """
+        return int(np.sum(self.likelihood_mask))
+    
+    def reduced_residuals(self, model, error_map=0):
+        """
+
+        :param model: 2d numpy array of the modeled image
+        :param error_map: 2d numpy array of additional noise/error terms from model components (such as PSF model uncertainties)
+        :return: 2d numpy array of reduced residuals per pixel
+        """
+        mask = self.likelihood_mask
+        C_D = self.Data.C_D_model(model)
+        residual = (model - self.Data.data) / np.sqrt(C_D + np.abs(error_map)) * mask
+        return residual
+
+    def reduced_chi2(self, model, error_map=0):
+        """Returns reduced chi2
+
+        :param model: 2d numpy array of a model predicted image
+        :param error_map: same format as model, additional error component (such as PSF
+        errors)
+        :return: reduced chi2.
+        """
+        norm_res = self.reduced_residuals(model, error_map)
+        return np.sum(norm_res**2) / self.num_data_evaluate
+    
+    def image2array_masked(self, image):
+        """Returns 1d array of values in image that are not masked out for the
+        likelihood computation/linear minimization
+
+        :param image: 2d numpy array of full image
+        :return: 1d array.
+        """
+        array = util.image2array(image)
+        return array[self._mask1d]
+
+    def array_masked2image(self, array):
+        """
+
+        :param array: 1d array of values not masked out (part of linear fitting)
+        :return: 2d array of full image
+        """
+        nx, ny = self.Data.num_pixel_axes
+        grid1d = np.zeros(nx * ny)
+        grid1d[self._mask1d] = array
+        grid2d = util.array2image(grid1d, nx, ny)
+        return grid2d
+    
+    def _error_map_model(self, kwargs_lens, kwargs_ps, kwargs_special=None):
+        """Noise estimate (variances as diagonal of the pixel covariance matrix)
+        resulted from inherent model uncertainties This term is currently the psf error
+        map.
+
+        :param kwargs_lens: lens model keyword arguments
+        :param kwargs_ps: point source keyword arguments
+        :param kwargs_special: special parameter keyword arguments
+        :return: 2d array corresponding to the pixels in terms of variance in noise
+        """
+        return self._error_map_psf(kwargs_lens, kwargs_ps, kwargs_special)
+
+    def _error_map_psf(self, kwargs_lens, kwargs_ps, kwargs_special=None):
+        """Map of image with error terms (sigma**2) expected from inaccuracies in the
+        PSF modeling.
+
+        :param kwargs_lens: lens model keyword arguments
+        :param kwargs_ps: point source keyword arguments
+        :param kwargs_special: special parameter keyword arguments
+        :return: 2d array of size of the image
+        """
+        error_map = np.zeros(self.Data.num_pixel_axes)
+        if self._psf_error_map is True:
+            for k, bool_ in enumerate(self._psf_error_map_bool_list):
+                if bool_ is True:
+                    ra_pos, dec_pos, _ = self.PointSource.point_source_list(
+                        kwargs_ps, kwargs_lens=kwargs_lens, k=k, with_amp=False
+                    )
+                    if len(ra_pos) > 0:
+                        ra_pos, dec_pos = self._displace_astrometry(
+                            ra_pos, dec_pos, kwargs_special=kwargs_special
+                        )
+                        error_map += self.ImageNumerics.psf_error_map(
+                            ra_pos,
+                            dec_pos,
+                            None,
+                            self.Data.data,
+                            fix_psf_error_map=False,
+                        )
+        return error_map
 
     @staticmethod
     def _displace_astrometry(x_pos, y_pos, kwargs_special=None):

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -562,8 +562,10 @@ class ImageModel(object):
         """Returns the 1d array of the error estimate corresponding to the data
         response.
 
-        :param kwargs_lens: list of dicts, keyword arguments corresponding to the lens profiles
-        :param kwargs_ps: list of dicts, keyword arguments corresponding to the point source models
+        :param kwargs_lens: list of dicts, keyword arguments corresponding to the lens
+            profiles
+        :param kwargs_ps: list of dicts, keyword arguments corresponding to the point
+            source models
         :param kwargs_special: list of dicts, special parameter keyword arguments
         :return: 1d numpy array of response, 2d array of additional errors (e.g. point
             source uncertainties)

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -1089,7 +1089,7 @@ class ModelBandPlot(ModelBand):
         :param kwargs: kwargs to send matplotlib.pyplot.matshow()
         :return:
         """
-        model = self._bandmodel._image(
+        model = self._bandmodel.image(
             self._kwargs_lens_partial,
             self._kwargs_source_partial,
             self._kwargs_lens_light_partial,
@@ -1149,7 +1149,7 @@ class ModelBandPlot(ModelBand):
         lens_light_add=False,
         font_size=15,
     ):
-        model = self._bandmodel._image(
+        model = self._bandmodel.image(
             self._kwargs_lens_partial,
             self._kwargs_source_partial,
             self._kwargs_lens_light_partial,
@@ -1303,7 +1303,7 @@ class ModelBandPlot(ModelBand):
         :param v_max:
         :return:
         """
-        model = self._bandmodel._extinction_map(
+        model = self._bandmodel.extinction_map(
             self._kwargs_extinction_partial, self._kwargs_special_partial
         )
         if v_min is None:

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -246,5 +246,6 @@ class TestSingleBandMultiModel(object):
         for kwargs in kwargs_tuple:
             assert kwargs is None
 
+
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -248,19 +248,15 @@ class TestSingleBandMultiModel(object):
         )
         npt.assert_array_equal(error, np.zeros(100))
 
-        kwargs_source = self.kwargs_params['kwargs_source']
-        error = self.single_band.error_map_source(
-            kwargs_source, x_grid, y_grid, None
-        )
-        error2 = self.imageModel.error_map_source(
-            kwargs_source, x_grid, y_grid, None
-        )
+        kwargs_source = self.kwargs_params["kwargs_source"]
+        error = self.single_band.error_map_source(kwargs_source, x_grid, y_grid, None)
+        error2 = self.imageModel.error_map_source(kwargs_source, x_grid, y_grid, None)
         npt.assert_array_almost_equal(error, error2, decimal=8)
 
     def test_linear_param_from_kwargs(self):
-        kwargs_source = self.kwargs_params['kwargs_source']
-        kwargs_lens_light = self.kwargs_params['kwargs_lens_light']
-        kwargs_ps = self.kwargs_params['kwargs_ps']
+        kwargs_source = self.kwargs_params["kwargs_source"]
+        kwargs_lens_light = self.kwargs_params["kwargs_lens_light"]
+        kwargs_ps = self.kwargs_params["kwargs_ps"]
 
         linear_params = self.single_band.linear_param_from_kwargs(
             kwargs_source, kwargs_lens_light, kwargs_ps
@@ -269,6 +265,7 @@ class TestSingleBandMultiModel(object):
             kwargs_source, kwargs_lens_light, kwargs_ps
         )
         npt.assert_array_almost_equal(linear_params, linear_params2, decimal=8)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -99,7 +99,11 @@ class TestSingleBandMultiModel(object):
         )
         self.imageModel = imageModel
         image_sim = simulation_util.simulate_simple(
-            imageModel, kwargs_lens_imageModel, kwargs_source, kwargs_lens_light, kwargs_ps
+            imageModel,
+            kwargs_lens_imageModel,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
         )
 
         data_class.update_data(image_sim)
@@ -153,7 +157,9 @@ class TestSingleBandMultiModel(object):
         npt.assert_almost_equal(logl / logl_no_linear, 1, decimal=4)
 
         # Tests the feature to deactivate/activate linear_solver
-        logl_no_linear2, _ = self.single_band.likelihood_data_given_model(linear_solver=False, **self.kwargs_params)
+        logl_no_linear2, _ = self.single_band.likelihood_data_given_model(
+            linear_solver=False, **self.kwargs_params
+        )
         npt.assert_almost_equal(logl_no_linear2, logl_no_linear, decimal=8)
 
         logl2, _ = self.single_band_no_linear.likelihood_data_given_model(

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -241,6 +241,10 @@ class TestSingleBandMultiModel(object):
         )
         npt.assert_almost_equal(extinction_map, 1)
 
+    def test_select_kwargs(self):
+        kwargs_tuple = self.single_band.select_kwargs()
+        for kwargs in kwargs_tuple:
+            assert kwargs is None
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_ImSim/test_image_linear_solve_with_interferometric_changes.py
+++ b/test/test_ImSim/test_image_linear_solve_with_interferometric_changes.py
@@ -137,12 +137,12 @@ def test_image_linear_solve_with_primary_beam_and_interferometry_psf():
         lens_light_model_class,
         kwargs_numerics=kwargs_numerics,
     )
-    model, _, _, amps = imageLinearFit._image_linear_solve(
+    model, _, _, amps = imageLinearFit.image_linear_solve(
         kwargs_lens, kwargs_source, kwargs_lens_light
     )
 
-    # execute the same linear solving outside of the _image_linear_solve function
-    A = imageLinearFit._linear_response_matrix(
+    # execute the same linear solving outside of the image_linear_solve function
+    A = imageLinearFit.linear_response_matrix(
         kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps=None, unconvolved=True
     )
     A0 = util.array2image(A[0])

--- a/test/test_ImSim/test_image_model.py
+++ b/test/test_ImSim/test_image_model.py
@@ -164,7 +164,7 @@ class TestImageModel(object):
         npt.assert_almost_equal(
             lens_flux[50, 50], 4.7310552067454452 * 0.05**2, decimal=4
         )
-        
+
     def test_image_with_params(self):
         model = self.imageModel.image(
             self.kwargs_lens,

--- a/test/test_ImSim/test_image_model.py
+++ b/test/test_ImSim/test_image_model.py
@@ -107,7 +107,8 @@ class TestImageModel(object):
             "supersampling_factor": 2,
             "supersampling_convolution": False,
         }
-        imageModel = ImageModel(
+
+        self.imageModel = ImageModel(
             data_class,
             psf_class,
             lens_model_class,
@@ -117,7 +118,7 @@ class TestImageModel(object):
             kwargs_numerics=kwargs_numerics,
         )
         image_sim = sim_util.simulate_simple(
-            imageModel,
+            self.imageModel,
             self.kwargs_lens,
             self.kwargs_source,
             self.kwargs_lens_light,
@@ -125,15 +126,6 @@ class TestImageModel(object):
         )
         data_class.update_data(image_sim)
 
-        self.imageModel = ImageLinearFit(
-            data_class,
-            psf_class,
-            lens_model_class,
-            source_model_class,
-            lens_light_model_class,
-            point_source_class,
-            kwargs_numerics=kwargs_numerics,
-        )
         self.solver = LensEquationSolver(lensModel=self.imageModel.LensModel)
 
     def test_source_surface_brightness(self):
@@ -172,26 +164,7 @@ class TestImageModel(object):
         npt.assert_almost_equal(
             lens_flux[50, 50], 4.7310552067454452 * 0.05**2, decimal=4
         )
-
-    def test_image_linear_solve(self):
-        model, error_map, cov_param, param = self.imageModel.image_linear_solve(
-            self.kwargs_lens,
-            self.kwargs_source,
-            self.kwargs_lens_light,
-            self.kwargs_ps,
-            inv_bool=False,
-        )
-        chi2_reduced = self.imageModel.reduced_chi2(model, error_map)
-        npt.assert_almost_equal(chi2_reduced, 1, decimal=1)
-
-    def test_linear_response_matrix(self):
-        A = self.imageModel.linear_response_matrix(
-            self.kwargs_lens, self.kwargs_source, self.kwargs_lens_light, self.kwargs_ps
-        )
-        n, m = np.shape(A)
-        assert n == 3
-        assert m == 100 * 100
-
+        
     def test_image_with_params(self):
         model = self.imageModel.image(
             self.kwargs_lens,
@@ -208,7 +181,7 @@ class TestImageModel(object):
         npt.assert_almost_equal(chi2_reduced, 1, decimal=1)
 
     def test_likelihood_data_given_model(self):
-        logL, param = self.imageModel.likelihood_data_given_model(
+        logL = self.imageModel.likelihood_data_given_model(
             self.kwargs_lens,
             self.kwargs_source,
             self.kwargs_lens_light,
@@ -216,16 +189,6 @@ class TestImageModel(object):
             source_marg=False,
         )
         npt.assert_almost_equal(logL, -5000, decimal=-3)
-
-        logLmarg, _ = self.imageModel.likelihood_data_given_model(
-            self.kwargs_lens,
-            self.kwargs_source,
-            self.kwargs_lens_light,
-            self.kwargs_ps,
-            source_marg=True,
-        )
-        npt.assert_almost_equal(logL - logLmarg, 0, decimal=-3)
-        assert logLmarg < logL
 
     def test_reduced_residuals(self):
         model = sim_util.simulate_simple(
@@ -245,12 +208,6 @@ class TestImageModel(object):
     def test_numData_evaluate(self):
         numData = self.imageModel.num_data_evaluate
         assert numData == 10000
-
-    def test_num_param_linear(self):
-        num_param_linear = self.imageModel.num_param_linear(
-            self.kwargs_lens, self.kwargs_source, self.kwargs_lens_light, self.kwargs_ps
-        )
-        assert num_param_linear == 3
 
     def test_update_data(self):
         kwargs_data = sim_util.data_configure_simple(
@@ -434,27 +391,12 @@ class TestImageModel(object):
         npt.assert_almost_equal(extinction, np.exp(-1))
 
     def test_error_response(self):
-        C_D_response, model_error = self.imageModel._error_response(
+        C_D_response, model_error = self.imageModel.error_response(
             self.kwargs_lens, self.kwargs_ps, kwargs_special=None
         )
         assert len(model_error) == 100
         print(np.sum(model_error))
         npt.assert_almost_equal(np.sum(model_error), 0.0019271126921470687, decimal=3)
-
-    def test_point_source_linear_response_set(self):
-        kwargs_special = {"delta_x_image": [0.1, 0.1], "delta_y_image": [-0.1, -0.1]}
-        (
-            ra_pos,
-            dec_pos,
-            amp,
-            num_point,
-        ) = self.imageModel.point_source_linear_response_set(
-            self.kwargs_ps, self.kwargs_lens, kwargs_special, with_amp=True
-        )
-        ra, dec = self.imageModel.PointSource.image_position(
-            self.kwargs_ps, self.kwargs_lens
-        )
-        npt.assert_almost_equal(ra[0][0], ra_pos[0][0] - 0.1, decimal=5)
 
     def test_displace_astrometry(self):
         kwargs_special = {

--- a/test/test_ImSim/test_image_model_pixelbased.py
+++ b/test/test_ImSim/test_image_model_pixelbased.py
@@ -336,14 +336,14 @@ class TestImageModel(object):
         npt.assert_almost_equal(extinction, np.exp(-1))
 
     def test_error_response(self):
-        C_D_response, psf_model_error = self.imageModel._error_response(
+        C_D_response, psf_model_error = self.imageModel.error_response(
             self.kwargs_lens, self.kwargs_ps, kwargs_special=None
         )
         assert len(psf_model_error) == 100
         print(np.sum(psf_model_error))
         npt.assert_almost_equal(np.sum(psf_model_error), 0, decimal=3)
 
-        C_D_response, psf_model_error = self.imageModel_source._error_response(
+        C_D_response, psf_model_error = self.imageModel_source.error_response(
             self.kwargs_lens, self.kwargs_ps, kwargs_special=None
         )
         assert len(psf_model_error) == 100


### PR DESCRIPTION
1. ImageLinearFit only has functions related to linear solve
2. General features in ImageLinearFit have been moved to ImageModel
3. Made the code a bit cleaner, should no longer need to duplicate functions with underscore naming

Also worth noting that this PR slightly breaks backwards compatibility, since the linear_solver argument to ImageLinearFit.likelihood_data_given_model has been removed. The check for whether linear solver is activated or not is now done in SingleBandMultiModel.likelihood_data_given_model instead, and all functions inside of ImageLinearFit assume that linear solver is true.