### PR TITLE
Changed name: 'spherical' -> 'circular' multipoles

### DIFF
--- a/lenstronomy/LensModel/Profiles/epl_boxydisky.py
+++ b/lenstronomy/LensModel/Profiles/epl_boxydisky.py
@@ -12,10 +12,8 @@ __all__ = ["EPL_BOXYDISKY_ELL", "EPL_BOXYDISKY"]
 
 
 class EPL_BOXYDISKY_ELL(LensProfileBase):
-    """ " EPL (Elliptical Power Law) mass profile combined with Multipole with m=4, so
-    that it's either purely boxy or disky with EPL's axis and Multipole's axis aligned.
-
-    Reference to the implementation: https://ui.adsabs.harvard.edu/abs/2022A%26A...659A.127V/abstract
+    """ " EPL (Elliptical Power Law) mass profile combined with an elliptical multipole with m=4, so
+    that it's either purely boxy or disky with EPL's axis and multipole's axis aligned (exact for general axis ratio q).
 
     Read the documentation of lenstronomy.LensModel.Profiles.epl and lenstrnomy.LensModel.Profiles.multipole for details.
 
@@ -169,8 +167,8 @@ class EPL_BOXYDISKY_ELL(LensProfileBase):
 
 
 class EPL_BOXYDISKY(LensProfileBase):
-    """ " EPL (Elliptical Power Law) mass profile combined with Multipole with m=4, so
-    that it's either purely boxy or disky with EPL's axis and Multipole's axis aligned.
+    """ " EPL (Elliptical Power Law) mass profile combined with a circular multipole with m=4, so
+    that it's either purely boxy or disky with EPL's axis and multipole's axis aligned (exact for axis ratio q=1 only).
 
     Reference to the implementation: https://ui.adsabs.harvard.edu/abs/2022A%26A...659A.127V/abstract
 
@@ -207,7 +205,7 @@ class EPL_BOXYDISKY(LensProfileBase):
         "a4_a": +0.1,
     }
 
-    def __init__(self, use_elliptical_multipoles=True):
+    def __init__(self):
         self._epl = EPL()
         self._multipole = Multipole()
         self._m = int(4)

--- a/lenstronomy/LensModel/Profiles/epl_boxydisky.py
+++ b/lenstronomy/LensModel/Profiles/epl_boxydisky.py
@@ -12,20 +12,25 @@ __all__ = ["EPL_BOXYDISKY_ELL", "EPL_BOXYDISKY"]
 
 
 class EPL_BOXYDISKY_ELL(LensProfileBase):
-    """ " EPL (Elliptical Power Law) mass profile combined with an elliptical multipole with m=4, so
-    that it's either purely boxy or disky with EPL's axis and multipole's axis aligned (exact for general axis ratio q).
+    """ " EPL (Elliptical Power Law) mass profile combined with an elliptical multipole
+    with m=4, so that it's either purely boxy or disky with EPL's axis and multipole's
+    axis aligned (exact for general axis ratio q).
 
-    Read the documentation of lenstronomy.LensModel.Profiles.epl and lenstrnomy.LensModel.Profiles.multipole for details.
+    Read the documentation of lenstronomy.LensModel.Profiles.epl and
+    lenstrnomy.LensModel.Profiles.multipole for details.
 
     :param theta_E: Einstein radius
     :param gamma: negative power-law slope of the 3D mass distributions
-    :param e1: eccentricity. For details, read lenstronomy.Util.param_util.phi_q2_ellipticity document.
-    :param e2: eccentricity. For details, read lenstronomy.Util.param_util.phi_q2_ellipticity document.
+    :param e1: eccentricity. For details, read
+        lenstronomy.Util.param_util.phi_q2_ellipticity document.
+    :param e2: eccentricity. For details, read
+        lenstronomy.Util.param_util.phi_q2_ellipticity document.
     :param center_x: center of distortion
     :param center_y: center of distortion
-    :param a4_a: Strength of the deviation of multipole order 4 of the elliptical isodensity contours,
-     which is translated into the multipole strength from the MULTIPOLE class through a rescaling by theta_E / sqrt(q).
-     Profile is disky when a4_a>0 and boxy when a4_a<0.
+    :param a4_a: Strength of the deviation of multipole order 4 of the elliptical
+        isodensity contours, which is translated into the multipole strength from the
+        MULTIPOLE class through a rescaling by theta_E / sqrt(q). Profile is disky when
+        a4_a>0 and boxy when a4_a<0.
     """
 
     param_names = ["theta_E", "gamma", "e1", "e2", "center_x", "center_y", "a4_a"]
@@ -167,8 +172,9 @@ class EPL_BOXYDISKY_ELL(LensProfileBase):
 
 
 class EPL_BOXYDISKY(LensProfileBase):
-    """ " EPL (Elliptical Power Law) mass profile combined with a circular multipole with m=4, so
-    that it's either purely boxy or disky with EPL's axis and multipole's axis aligned (exact for axis ratio q=1 only).
+    """ " EPL (Elliptical Power Law) mass profile combined with a circular multipole with
+    m=4, so that it's either purely boxy or disky with EPL's axis and multipole's axis
+    aligned (exact for axis ratio q=1 only).
 
     Reference to the implementation: https://ui.adsabs.harvard.edu/abs/2022A%26A...659A.127V/abstract
 

--- a/lenstronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
+++ b/lenstronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
@@ -383,7 +383,7 @@ class EPL_MULTIPOLE_M1M3M4_ELL(LensProfileBase):
 
 
 class EPL_MULTIPOLE_M1M3M4(LensProfileBase):
-    """EPL (Elliptical Power Law) mass profile combined with three spherical multipole
+    """EPL (Elliptical Power Law) mass profile combined with three circular multipole
     terms of order m=1, m=3 and m=4 (exact for axis ratio =1).
 
     Reference to the implementation: https://ui.adsabs.harvard.edu/abs/2022A%26A...659A.127V/abstract

--- a/lenstronomy/LensModel/Profiles/epl_multipole_m3m4.py
+++ b/lenstronomy/LensModel/Profiles/epl_multipole_m3m4.py
@@ -310,7 +310,7 @@ class EPL_MULTIPOLE_M3M4_ELL(LensProfileBase):
 
 
 class EPL_MULTIPOLE_M3M4(LensProfileBase):
-    """EPL (Elliptical Power Law) mass profile combined with two spherical multipole
+    """EPL (Elliptical Power Law) mass profile combined with two circular multipole
     terms of order m=3 and m=4 (exact for axis ratio =1).
 
     Reference to the implementation: https://ui.adsabs.harvard.edu/abs/2022A%26A...659A.127V/abstract

--- a/lenstronomy/LensModel/Profiles/multipole.py
+++ b/lenstronomy/LensModel/Profiles/multipole.py
@@ -10,9 +10,9 @@ __all__ = ["Multipole", "EllipticalMultipole"]
 
 class Multipole(LensProfileBase):
     """
-    This class contains a SPHERICAL multipole contribution (for 1 component with m>=2)
+    This class contains a CIRCULAR multipole contribution (for 1 component with m>=2)
     This uses the same definitions as Xu et al.(2013) in Appendix B3 https://arxiv.org/pdf/1307.4220.pdf, Equation B12
-    Only the q=1 case (ie., spherical symmetry) makes this definition consistent with interpretation of multipoles as a deformation of the isophotes with an order m symmetry (eg., disky/boxy in the m=4 case).
+    Only the q=1 case (ie., circular symmetry) makes this definition consistent with interpretation of multipoles as a deformation of the isophotes with an order m symmetry (eg., disky/boxy in the m=4 case).
 
     m : int, multipole order, m>=1
     a_m : float, multipole strength
@@ -201,7 +201,7 @@ class EllipticalMultipole(LensProfileBase):
 
         if (
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
-        ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
+        ):  # avoid numerical instability when q is too close to 1 by taking circular multipole solution
             sph_multipole = Multipole()
             f_ = sph_multipole.function(
                 x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E
@@ -270,7 +270,7 @@ class EllipticalMultipole(LensProfileBase):
 
         if (
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
-        ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
+        ):  # avoid numerical instability when q is too close to 1 by taking circular multipole solution
             sph_multipole = Multipole()
             f_x, f_y = sph_multipole.derivatives(
                 x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E
@@ -353,7 +353,7 @@ class EllipticalMultipole(LensProfileBase):
 
         if (
             np.abs(1 - q**2) ** ((m + 1) / 2) < 1e-8
-        ):  # avoid numerical instability when q is too close to 1 by taking spherical multipole solution
+        ):  # avoid numerical instability when q is too close to 1 by taking circular multipole solution
             sph_multipole = Multipole()
             f_xx, f_xy, f_xy, f_yy = sph_multipole.hessian(
                 x, y, m, a_m, phi_m, center_x=center_x, center_y=center_y, r_E=r_E

--- a/test/test_LensModel/test_Profiles/test_epl_boxydisky.py
+++ b/test/test_LensModel/test_Profiles/test_epl_boxydisky.py
@@ -8,7 +8,7 @@ from lenstronomy.Util import util
 
 
 class TestEPL_BOXYDISKY(object):
-    """Test EPL_BOXYDISKY vs EPL + MULTIPOLE (Spherical) values."""
+    """Test EPL_BOXYDISKY vs EPL + MULTIPOLE (Circulqr) values."""
 
     def setup_method(self):
         from lenstronomy.LensModel.Profiles.epl import EPL

--- a/test/test_LensModel/test_Profiles/test_epl_boxydisky.py
+++ b/test/test_LensModel/test_Profiles/test_epl_boxydisky.py
@@ -8,7 +8,7 @@ from lenstronomy.Util import util
 
 
 class TestEPL_BOXYDISKY(object):
-    """Test EPL_BOXYDISKY vs EPL + MULTIPOLE (Circulqr) values."""
+    """Test EPL_BOXYDISKY vs EPL + MULTIPOLE (Circular) values."""
 
     def setup_method(self):
         from lenstronomy.LensModel.Profiles.epl import EPL

--- a/test/test_LensModel/test_Profiles/test_epl_multipole_m3m4.py
+++ b/test/test_LensModel/test_Profiles/test_epl_multipole_m3m4.py
@@ -15,7 +15,7 @@ from lenstronomy.LensModel.lens_model import LensModel
 
 
 class TestEPL_MULTIPOLE_M3M4(object):
-    """Test TestEPL_MULTIPOLE_M3M4 vs EPL + 2 MULTIPOLE (Spherical) values."""
+    """Test TestEPL_MULTIPOLE_M3M4 vs EPL + 2 MULTIPOLE (circular) values."""
 
     def setup_method(self):
         self.epl = EPL()

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -124,7 +124,7 @@ class TestEllipticalMultipole(object):
 
     def setup_method(self):
         self.Multipole = EllipticalMultipole()
-        self.SphericalMultipole = Multipole()
+        self.CircularMultipole = Multipole()
         self.x, self.y = util.make_grid(numPix=10, deltapix=0.2)
 
     def test_function(self):
@@ -148,30 +148,30 @@ class TestEllipticalMultipole(object):
         npt.assert_almost_equal(values[1], 0.000954611, decimal=6)
         npt.assert_almost_equal(values[2], -0.002321308, decimal=6)
 
-        # Test that the limit q-> 1 is consistent with the spherical multipoles
+        # Test that the limit q-> 1 is consistent with the circular multipoles
         function_ell_limit = self.Multipole.function(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
         )
-        function_sph = self.SphericalMultipole.function(
+        function_circ = self.CircularMultipole.function(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(function_ell_limit, function_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(function_ell_limit, function_circ, rtol=1e-4, atol=5e-5)
 
         function_ell_limit = self.Multipole.function(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
         )
-        function_sph = self.SphericalMultipole.function(
+        function_circ = self.CircularMultipole.function(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(function_ell_limit, function_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(function_ell_limit, function_circ, rtol=5e-5, atol=5e-5)
 
         function_ell_limit = self.Multipole.function(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
         )
-        function_sph = self.SphericalMultipole.function(
+        function_circ = self.CircularMultipole.function(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
         )
-        npt.assert_allclose(function_ell_limit, function_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(function_ell_limit, function_circ, rtol=1e-7, atol=1e-7)
 
     def test_derivatives(self):
         x = 1
@@ -194,33 +194,33 @@ class TestEllipticalMultipole(object):
         npt.assert_almost_equal(f_y[1], 0.012844618, decimal=6)
         npt.assert_almost_equal(f_y[2], 0.001639347, decimal=6)
 
-        # Test that the limit q-> 1 is consistent with the spherical multipoles
+        # Test that the limit q-> 1 is consistent with the circular multipoles
         alpha_x_ell_limit, alpha_y_ell_limit = self.Multipole.derivatives(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
         )
-        alpha_x_sph, alpha_y_sph = self.SphericalMultipole.derivatives(
+        alpha_x_circ, alpha_y_circ = self.CircularMultipole.derivatives(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
-        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=1e-4, atol=5e-5)
-        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(alpha_x_ell_limit, alpha_x_circ, rtol=1e-4, atol=5e-5)
+        npt.assert_allclose(alpha_y_ell_limit, alpha_y_circ, rtol=1e-4, atol=5e-5)
 
         alpha_x_ell_limit, alpha_y_ell_limit = self.Multipole.derivatives(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
         )
-        alpha_x_sph, alpha_y_sph = self.SphericalMultipole.derivatives(
+        alpha_x_circ, alpha_y_circ = self.CircularMultipole.derivatives(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
-        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(alpha_x_ell_limit, alpha_x_circ, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(alpha_y_ell_limit, alpha_y_circ, rtol=5e-5, atol=5e-5)
 
         alpha_x_ell_limit, alpha_y_ell_limit = self.Multipole.derivatives(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
         )
-        alpha_x_sph, alpha_y_sph = self.SphericalMultipole.derivatives(
+        alpha_x_circ, alpha_y_circ = self.CircularMultipole.derivatives(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
         )
-        npt.assert_allclose(alpha_x_ell_limit, alpha_x_sph, rtol=1e-7, atol=1e-7)
-        npt.assert_allclose(alpha_y_ell_limit, alpha_y_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(alpha_x_ell_limit, alpha_x_circ, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(alpha_y_ell_limit, alpha_y_circ, rtol=1e-7, atol=1e-7)
 
     def test_hessian(self):
         x = 1
@@ -268,8 +268,8 @@ class TestEllipticalMultipole(object):
             (values[0] + values[3]), a_m * np.cos(m * (phi_ell - phi_m)) / R, decimal=6
         )
 
-        # Test that the limit q-> 1 is consistent with the spherical multipoles and that q=1 gives exactly the spherical multipoles
-        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
+        # Test that the limit q-> 1 is consistent with the circular multipoles and that q=1 gives exactly the circular multipoles
+        f_xx_circ, f_xy_circ, f_yx_circ, f_yy_circ = self.CircularMultipole.hessian(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24
         )
         f_xx_ell_limit, f_xy_ell_limit, f_yx_ell_limit, f_yy_ell_limit = (
@@ -277,20 +277,20 @@ class TestEllipticalMultipole(object):
                 self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=0.9995
             )
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-4, atol=1e-4)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_circ, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_circ, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_circ, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_circ, rtol=1e-4, atol=1e-4)
 
         f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = self.Multipole.hessian(
             self.x, self.y, m=4, a_m=a_m, phi_m=np.pi / 24, q=1.0
         )
-        npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
-        npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
-        npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
-        npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
+        npt.assert_almost_equal(f_xx_ell_q1, f_xx_circ, decimal=8)
+        npt.assert_almost_equal(f_xy_ell_q1, f_xy_circ, decimal=8)
+        npt.assert_almost_equal(f_yx_ell_q1, f_yx_circ, decimal=8)
+        npt.assert_almost_equal(f_yy_ell_q1, f_yy_circ, decimal=8)
 
-        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
+        f_xx_circ, f_xy_circ, f_yx_circ, f_yy_circ = self.CircularMultipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18
         )
 
@@ -299,20 +299,20 @@ class TestEllipticalMultipole(object):
                 self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=0.9999
             )
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=5e-5, atol=5e-5)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_circ, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_circ, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_circ, rtol=5e-5, atol=5e-5)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_circ, rtol=5e-5, atol=5e-5)
 
         f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = self.Multipole.hessian(
             self.x, self.y, m=3, a_m=a_m, phi_m=np.pi / 18, q=1.0
         )
-        npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
-        npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
-        npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
-        npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
+        npt.assert_almost_equal(f_xx_ell_q1, f_xx_circ, decimal=8)
+        npt.assert_almost_equal(f_xy_ell_q1, f_xy_circ, decimal=8)
+        npt.assert_almost_equal(f_yx_ell_q1, f_yx_circ, decimal=8)
+        npt.assert_almost_equal(f_yy_ell_q1, f_yy_circ, decimal=8)
 
-        f_xx_sph, f_xy_sph, f_yx_sph, f_yy_sph = self.SphericalMultipole.hessian(
+        f_xx_circ, f_xy_circ, f_yx_circ, f_yy_circ = self.CircularMultipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6
         )
 
@@ -321,18 +321,18 @@ class TestEllipticalMultipole(object):
                 self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=0.9999999
             )
         )
-        npt.assert_allclose(f_xx_ell_limit, f_xx_sph, rtol=1e-7, atol=1e-7)
-        npt.assert_allclose(f_xy_ell_limit, f_xy_sph, rtol=1e-7, atol=1e-7)
-        npt.assert_allclose(f_yx_ell_limit, f_yx_sph, rtol=1e-7, atol=1e-7)
-        npt.assert_allclose(f_yy_ell_limit, f_yy_sph, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_xx_ell_limit, f_xx_circ, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_xy_ell_limit, f_xy_circ, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_yx_ell_limit, f_yx_circ, rtol=1e-7, atol=1e-7)
+        npt.assert_allclose(f_yy_ell_limit, f_yy_circ, rtol=1e-7, atol=1e-7)
 
         f_xx_ell_q1, f_xy_ell_q1, f_yx_ell_q1, f_yy_ell_q1 = self.Multipole.hessian(
             self.x, self.y, m=1, a_m=a_m, phi_m=np.pi / 6, q=1.0
         )
-        npt.assert_almost_equal(f_xx_ell_q1, f_xx_sph, decimal=8)
-        npt.assert_almost_equal(f_xy_ell_q1, f_xy_sph, decimal=8)
-        npt.assert_almost_equal(f_yx_ell_q1, f_yx_sph, decimal=8)
-        npt.assert_almost_equal(f_yy_ell_q1, f_yy_sph, decimal=8)
+        npt.assert_almost_equal(f_xx_ell_q1, f_xx_circ, decimal=8)
+        npt.assert_almost_equal(f_xy_ell_q1, f_xy_circ, decimal=8)
+        npt.assert_almost_equal(f_yx_ell_q1, f_yx_circ, decimal=8)
+        npt.assert_almost_equal(f_yy_ell_q1, f_yy_circ, decimal=8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed nomenclature to be consistent with paper on elliptical multipoles, makes more sense since multipoles are 2D perturbations (not 3D).