### PR TITLE
psf_error_map normalization

### DIFF
--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -23,7 +23,7 @@ class PSF(object):
         truncation=5,
         pixel_size=None,
         kernel_point_source=None,
-        psf_error_map=None,
+        psf_variance_map=None,
         point_source_supersampling_factor=1,
         kernel_point_source_init=None,
         kernel_point_source_normalisation=True,
@@ -37,10 +37,10 @@ class PSF(object):
          ImageModel modules)
         :param kernel_point_source: 2d numpy array, odd length, centered PSF of a point source
          (if not normalized, will be normalized)
-        :param psf_error_map: uncertainty in the PSF model per pixel (size of data, not super-sampled). 2d numpy array.
+        :param psf_variance_map: uncertainty in the PSF model per pixel (size of data, not super-sampled). 2d numpy array.
          Size can be larger or smaller than the pixel-sized PSF model and if so, will be matched.
          This error will be added to the pixel error around the position of point sources as follows:
-         sigma^2_i += 'psf_error_map'_j * <point source amplitude>**2
+         sigma^2_i += 'psf_variance_map'_j * <point source amplitude>**2
         :param point_source_supersampling_factor: int, supersampling factor of kernel_point_source.
          This is the input PSF to this class and does not need to be the choice in the modeling
          (thought preferred if modeling choses supersampling)
@@ -103,20 +103,20 @@ class PSF(object):
             self._kernel_point_source[1, 1] = 1
         else:
             raise ValueError("psf_type %s not supported!" % self.psf_type)
-        if psf_error_map is not None:
+        if psf_variance_map is not None:
             n_kernel = len(self.kernel_point_source)
-            self._psf_error_map = kernel_util.match_kernel_size(psf_error_map, n_kernel)
+            self._psf_variance_map = kernel_util.match_kernel_size(psf_variance_map, n_kernel)
             if self.psf_type == "PIXEL" and point_source_supersampling_factor > 1:
-                if len(psf_error_map) == len(self._kernel_point_source_supersampled):
+                if len(psf_variance_map) == len(self._kernel_point_source_supersampled):
                     Warning(
-                        "psf_error_map has the same size as the super-sampled kernel. Make sure the units in the"
-                        "psf_error_map are on the down-sampled pixel scale."
+                        "psf_variance_map has the same size as the super-sampled kernel. Make sure the units in the"
+                        "psf_variance_map are on the down-sampled pixel scale."
                     )
             if kernel_point_source_normalisation is True:
-                self._psf_error_map /= np.sum(kernel_point_source)**2
-            self.psf_error_map_bool = True
+                self._psf_variance_map /= np.sum(kernel_point_source) ** 2
+            self.psf_variance_map_bool = True
         else:
-            self.psf_error_map_bool = False
+            self.psf_variance_map_bool = False
 
         self._kernel_point_source_normalisation = kernel_point_source_normalisation
         if kernel_point_source_normalisation is False and psf_type == "PIXEL":
@@ -248,18 +248,18 @@ class PSF(object):
                 pass
 
     @property
-    def psf_error_map(self):
+    def psf_variance_map(self):
         """Error variance of the normalized PSF.
 
         This error will be added to the pixel error around the position of point sources as follows:
-        sigma^2_i += 'psf_error_map'_j * <point source amplitude>**2
+        sigma^2_i += 'psf_variance_map'_j * <point source amplitude>**2
 
         :return: error variance of the normalized PSF. Variance of
         :rtype: 2d numpy array of size of the PSF in pixel size (not supersampled)
         """
-        if not hasattr(self, "_psf_error_map"):
-            self._psf_error_map = np.zeros_like(self.kernel_point_source)
-        return self._psf_error_map
+        if not hasattr(self, "_psf_variance_map"):
+            self._psf_variance_map = np.zeros_like(self.kernel_point_source)
+        return self._psf_variance_map
 
     @property
     def fwhm(self):

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -105,7 +105,9 @@ class PSF(object):
             raise ValueError("psf_type %s not supported!" % self.psf_type)
         if psf_variance_map is not None:
             n_kernel = len(self.kernel_point_source)
-            self._psf_variance_map = kernel_util.match_kernel_size(psf_variance_map, n_kernel)
+            self._psf_variance_map = kernel_util.match_kernel_size(
+                psf_variance_map, n_kernel
+            )
             if self.psf_type == "PIXEL" and point_source_supersampling_factor > 1:
                 if len(psf_variance_map) == len(self._kernel_point_source_supersampled):
                     Warning(

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -112,6 +112,8 @@ class PSF(object):
                         "psf_error_map has the same size as the super-sampled kernel. Make sure the units in the"
                         "psf_error_map are on the down-sampled pixel scale."
                     )
+            if kernel_point_source_normalisation is True:
+                self._psf_error_map /= np.sum(kernel_point_source)**2
             self.psf_error_map_bool = True
         else:
             self.psf_error_map_bool = False

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -73,8 +73,8 @@ class PointSourceRendering(object):
         :param dec_pos: image positions of point sources
         :param amp: amplitude of modeled point sources
         :param data: 2d numpy array of the data
-        :param fix_psf_variance_map: bool, if True, estimates the error based on the input
-            (modeled) amplitude, else uses the data to do so.
+        :param fix_psf_variance_map: bool, if True, estimates the error based on the
+            input (modeled) amplitude, else uses the data to do so.
         :return: 2d array of size of the image with error terms (sigma**2) expected from
             inaccuracies in the PSF modeling
         """

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -66,7 +66,7 @@ class PointSourceRendering(object):
             )
         return self._kernel_supersampled_instance
 
-    def psf_variance_map(self, ra_pos, dec_pos, amp, data, fix_psf_error_map=False):
+    def psf_variance_map(self, ra_pos, dec_pos, amp, data, fix_psf_variance_map=False):
         """Variance of PSF error.
 
         :param ra_pos: image positions of point sources

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -83,7 +83,7 @@ class PointSourceRendering(object):
         psf_variance_map = self._psf.psf_variance_map
         variance_map = np.zeros_like(data)
         for i in range(len(x_pos)):
-            if fix_psf_error_map is True:
+            if fix_psf_variance_map is True:
                 amp_estimated = amp
             else:
                 amp_estimated = kernel_util.estimate_amp(

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -66,8 +66,9 @@ class PointSourceRendering(object):
             )
         return self._kernel_supersampled_instance
 
-    def psf_error_map(self, ra_pos, dec_pos, amp, data, fix_psf_error_map=False):
+    def psf_variance_map(self, ra_pos, dec_pos, amp, data, fix_psf_error_map=False):
         """
+        variance of PSF error
 
         :param ra_pos: image positions of point sources
         :param dec_pos: image positions of point sources
@@ -79,8 +80,8 @@ class PointSourceRendering(object):
         """
         x_pos, y_pos = self._pixel_grid.map_coord2pix(ra_pos, dec_pos)
         psf_kernel = self._psf.kernel_point_source
-        psf_error_map = self._psf.psf_error_map
-        error_map = np.zeros_like(data)
+        psf_variance_map = self._psf.psf_variance_map
+        variance_map = np.zeros_like(data)
         for i in range(len(x_pos)):
             if fix_psf_error_map is True:
                 amp_estimated = amp
@@ -88,7 +89,7 @@ class PointSourceRendering(object):
                 amp_estimated = kernel_util.estimate_amp(
                     data, x_pos[i], y_pos[i], psf_kernel
                 )
-            error_map = image_util.add_layer2image(
-                error_map, x_pos[i], y_pos[i], psf_error_map * amp_estimated**2
+            variance_map = image_util.add_layer2image(
+                variance_map, x_pos[i], y_pos[i], psf_variance_map * amp_estimated**2
             )
-        return error_map
+        return variance_map

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -73,7 +73,7 @@ class PointSourceRendering(object):
         :param dec_pos: image positions of point sources
         :param amp: amplitude of modeled point sources
         :param data: 2d numpy array of the data
-        :param fix_psf_error_map: bool, if True, estimates the error based on the input
+        :param fix_psf_variance_map: bool, if True, estimates the error based on the input
             (modeled) amplitude, else uses the data to do so.
         :return: 2d array of size of the image with error terms (sigma**2) expected from
             inaccuracies in the PSF modeling

--- a/lenstronomy/ImSim/Numerics/point_source_rendering.py
+++ b/lenstronomy/ImSim/Numerics/point_source_rendering.py
@@ -67,16 +67,16 @@ class PointSourceRendering(object):
         return self._kernel_supersampled_instance
 
     def psf_variance_map(self, ra_pos, dec_pos, amp, data, fix_psf_error_map=False):
-        """
-        variance of PSF error
+        """Variance of PSF error.
 
         :param ra_pos: image positions of point sources
         :param dec_pos: image positions of point sources
         :param amp: amplitude of modeled point sources
         :param data: 2d numpy array of the data
-        :param fix_psf_error_map: bool, if True, estimates the error based on the input (modeled) amplitude, else uses
-         the data to do so.
-        :return: 2d array of size of the image with error terms (sigma**2) expected from inaccuracies in the PSF modeling
+        :param fix_psf_error_map: bool, if True, estimates the error based on the input
+            (modeled) amplitude, else uses the data to do so.
+        :return: 2d array of size of the image with error terms (sigma**2) expected from
+            inaccuracies in the PSF modeling
         """
         x_pos, y_pos = self._pixel_grid.map_coord2pix(ra_pos, dec_pos)
         psf_kernel = self._psf.kernel_point_source

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -709,7 +709,7 @@ class ImageModel(object):
                             dec_pos,
                             None,
                             self.Data.data,
-                            fix_psf_error_map=False,
+                            fix_psf_variance_map=False,
                         )
         return error_map
 

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -81,7 +81,7 @@ class ImageModel(object):
             min_distance=min_distance,
             only_from_unspecified=True,
         )
-        self._psf_error_map = self.PSF.psf_error_map_bool
+        self._psf_error_map = self.PSF.psf_variance_map_bool
         if likelihood_mask is None:
             likelihood_mask = np.ones(data_class.num_pixel_axes)
         self.likelihood_mask = np.array(likelihood_mask, dtype=bool)
@@ -704,7 +704,7 @@ class ImageModel(object):
                         ra_pos, dec_pos = self._displace_astrometry(
                             ra_pos, dec_pos, kwargs_special=kwargs_special
                         )
-                        error_map += self.ImageNumerics.psf_error_map(
+                        error_map += self.ImageNumerics.psf_variance_map(
                             ra_pos,
                             dec_pos,
                             None,

--- a/lenstronomy/Plots/chain_plot.py
+++ b/lenstronomy/Plots/chain_plot.py
@@ -122,7 +122,7 @@ def psf_iteration_compare(kwargs_psf, **kwargs):
 
     psf = PSF(**kwargs_psf)
     # psf_out = psf.kernel_point_source
-    psf_error_map = psf.psf_error_map
+    psf_variance_map = psf.psf_variance_map
     n_kernel = len(psf_in)
     delta_x = n_kernel / 20.0
     delta_y = n_kernel / 10.0
@@ -131,7 +131,7 @@ def psf_iteration_compare(kwargs_psf, **kwargs):
         kwargs["cmap"] = "seismic"
 
     n = 3
-    if psf_error_map is not None:
+    if psf_variance_map is not None:
         n += 1
     f, axes = plt.subplots(1, n, figsize=(5 * n, 5))
     ax = axes[0]
@@ -194,14 +194,14 @@ def psf_iteration_compare(kwargs_psf, **kwargs):
         backgroundcolor="w",
     )
 
-    if psf_error_map is not None:
+    if psf_variance_map is not None:
         ax = axes[3]
         im = ax.matshow(
-            np.log10(psf_error_map * psf.kernel_point_source**2),
+            np.log10(psf_variance_map * psf.kernel_point_source**2),
             origin="lower",
             **kwargs
         )
-        n_kernel = len(psf_error_map)
+        n_kernel = len(psf_variance_map)
         delta_x = n_kernel / 20.0
         delta_y = n_kernel / 10.0
         divider = make_axes_locatable(ax)
@@ -212,7 +212,7 @@ def psf_iteration_compare(kwargs_psf, **kwargs):
         ax.text(
             delta_x,
             n_kernel - delta_y,
-            "psf error map",
+            "psf variance map",
             color="k",
             fontsize=20,
             backgroundcolor="w",

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -900,8 +900,8 @@ class PsfFitting(object):
         error_map_radius=None,
         block_center_neighbour=0,
     ):
-        """Provides a psf_variance_map based on the goodness of fit of the given PSF kernel
-        on the point source cutouts, their estimated amplitudes and positions.
+        """Provides a psf_variance_map based on the goodness of fit of the given PSF
+        kernel on the point source cutouts, their estimated amplitudes and positions.
 
         :param kernel: PSF kernel
         :param star_cutout_list: list of 2d arrays of cutouts of the point sources with

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -80,7 +80,7 @@ class PsfFitting(object):
         kwargs_psf,
         kwargs_params,
         num_iter=10,
-        keep_psf_error_map=True,
+        keep_psf_variance_map=True,
         no_break=True,
         verbose=True,
         **kwargs_psf_update
@@ -151,7 +151,7 @@ class PsfFitting(object):
                 "log likelihood before: %s and log likelihood after: %s"
                 % (logL_before, logL_best)
             )
-        if keep_psf_error_map is True:
+        if keep_psf_variance_map is True:
             kwargs_psf_final["psf_variance_map"] = error_map_init
         else:
             kwargs_psf_final["psf_variance_map"] = error_map_final

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -90,7 +90,7 @@ class PsfFitting(object):
         :param kwargs_psf: keyword arguments to construct the PSF() class
         :param kwargs_params: keyword arguments of the parameters of the model components (e.g. 'kwargs_lens' etc)
         :param num_iter: number of iterations in the PSF fitting and image fitting process
-        :param keep_psf_error_map: boolean, if True keeps previous psf_variance_map
+        :param keep_psf_variance_map: boolean, if True keeps previous psf_variance_map
         :param no_break: boolean, if True, runs until the end regardless of the next step getting worse, and then
          reads out the overall best fit
         :param verbose: print statements informing about progress of iterative procedure

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -40,7 +40,7 @@ class PsfFitting(object):
         the symmetry specified. These additional imposed symmetries can help stabelize the PSF estimate when there are
         limited constraints/number of point sources in the image.
 
-    The procedure only requires and changes the 'point_source_kernel' in the PSF() class and the 'psf_error_map'.
+    The procedure only requires and changes the 'point_source_kernel' in the PSF() class and the 'psf_variance_map'.
     Any previously set subgrid kernels or pixel_kernels are removed and constructed from the 'point_source_kernel'.
     """
 
@@ -90,7 +90,7 @@ class PsfFitting(object):
         :param kwargs_psf: keyword arguments to construct the PSF() class
         :param kwargs_params: keyword arguments of the parameters of the model components (e.g. 'kwargs_lens' etc)
         :param num_iter: number of iterations in the PSF fitting and image fitting process
-        :param keep_psf_error_map: boolean, if True keeps previous psf_error_map
+        :param keep_psf_error_map: boolean, if True keeps previous psf_variance_map
         :param no_break: boolean, if True, runs until the end regardless of the next step getting worse, and then
          reads out the overall best fit
         :param verbose: print statements informing about progress of iterative procedure
@@ -105,8 +105,8 @@ class PsfFitting(object):
             kernel_point_source_init = kwargs_psf["kernel_point_source_init"]
         kwargs_psf_new = copy.deepcopy(kwargs_psf)
         kwargs_psf_final = copy.deepcopy(kwargs_psf)
-        if "psf_error_map" in kwargs_psf:
-            error_map_final = kwargs_psf["psf_error_map"]
+        if "psf_variance_map" in kwargs_psf:
+            error_map_final = kwargs_psf["psf_variance_map"]
         else:
             error_map_final = np.zeros_like(kernel_point_source_init)
         error_map_init = copy.deepcopy(error_map_final)
@@ -152,9 +152,9 @@ class PsfFitting(object):
                 % (logL_before, logL_best)
             )
         if keep_psf_error_map is True:
-            kwargs_psf_final["psf_error_map"] = error_map_init
+            kwargs_psf_final["psf_variance_map"] = error_map_init
         else:
-            kwargs_psf_final["psf_error_map"] = error_map_final
+            kwargs_psf_final["psf_variance_map"] = error_map_final
         kwargs_psf_final["kernel_point_source_init"] = kernel_point_source_init
         return kwargs_psf_final
 
@@ -226,7 +226,7 @@ class PsfFitting(object):
             "psf_type": "PIXEL",
             "kernel_point_source": kwargs_psf_copy["kernel_point_source"],
             "point_source_supersampling_factor": point_source_supersampling_factor,
-            "psf_error_map": kwargs_psf_copy.get("psf_error_map", None),
+            "psf_variance_map": kwargs_psf_copy.get("psf_variance_map", None),
         }
         # if 'psf_error_map' in kwargs_psf_copy:
         #    kwargs_psf_new['psf_error_map'] = kwargs_psf_copy['psf_error_map'] / 10
@@ -900,7 +900,7 @@ class PsfFitting(object):
         error_map_radius=None,
         block_center_neighbour=0,
     ):
-        """Provides a psf_error_map based on the goodness of fit of the given PSF kernel
+        """Provides a psf_variance_map based on the goodness of fit of the given PSF kernel
         on the point source cutouts, their estimated amplitudes and positions.
 
         :param kernel: PSF kernel

--- a/test/test_Data/test_psf.py
+++ b/test/test_Data/test_psf.py
@@ -214,7 +214,7 @@ class TestData(object):
             "pixel_size": deltaPix,
         }
         psf_kernel = PSF(**kwargs)
-        error_map = psf_kernel.psf_error_map
+        error_map = psf_kernel.psf_variance_map
         assert error_map.all() == 0
 
     def test_warning(self):
@@ -234,11 +234,11 @@ class TestData(object):
             "psf_type": "PIXEL",
             "kernel_point_source": kernel_point_source_subsampled,
             "point_source_supersampling_factor": subsampling_res,
-            "psf_error_map": np.ones_like(kernel_point_source_subsampled),
+            "psf_variance_map": np.ones_like(kernel_point_source_subsampled),
         }
         psf_kernel = PSF(**kwargs_psf)
         n = len(psf_kernel.kernel_point_source)
-        error_map = psf_kernel.psf_error_map
+        error_map = psf_kernel.psf_variance_map
         assert len(error_map) == n
 
     def test_unnormalized(self):
@@ -317,7 +317,7 @@ class TestRaise(unittest.TestCase):
             PSF(
                 psf_type="PIXEL",
                 kernel_point_source=np.ones((3, 3)),
-                psf_error_map=np.ones((5, 5)),
+                psf_variance_map=np.ones((5, 5)),
             )
             psf.kernel_point_source_supersampled(supersampling_factor=3)
         with self.assertRaises(ValueError):

--- a/test/test_ImSim/test_Numerics/test_point_source_rendering.py
+++ b/test/test_ImSim/test_Numerics/test_point_source_rendering.py
@@ -24,7 +24,7 @@ class TestPointSourceRendering(object):
         kwargs_psf = {
             "kernel_point_source": kernel,
             "psf_type": "PIXEL",
-            "psf_error_map": np.ones_like(kernel) * kernel**2,
+            "psf_variance_map": np.ones_like(kernel) * kernel**2,
         }
         psf_class = PSF(**kwargs_psf)
 
@@ -32,22 +32,22 @@ class TestPointSourceRendering(object):
             pixel_grid, supersampling_factor=1, psf=psf_class
         )
 
-    def test_psf_error_map(self):
+    def test_psf_variance_map(self):
         ra_pos, dec_pos = [5], [5]
         data = np.zeros((10, 10))
-        image = self._ps_rendering.psf_error_map(
+        image = self._ps_rendering.psf_variance_map(
             ra_pos, dec_pos, amp=1, data=data, fix_psf_error_map=False
         )
         npt.assert_almost_equal(np.sum(image), 0, decimal=10)
 
-        image = self._ps_rendering.psf_error_map(
+        image = self._ps_rendering.psf_variance_map(
             ra_pos, dec_pos, amp=1, data=data, fix_psf_error_map=True
         )
         npt.assert_almost_equal(np.sum(image), 1, decimal=10)
 
         ra_pos, dec_pos = [50], [50]
         data = np.zeros((10, 10))
-        image = self._ps_rendering.psf_error_map(
+        image = self._ps_rendering.psf_variance_map(
             ra_pos, dec_pos, amp=1, data=data, fix_psf_error_map=False
         )
         npt.assert_almost_equal(np.sum(image), 0, decimal=10)
@@ -75,7 +75,7 @@ class TestRaise(unittest.TestCase):
         kwargs_psf = {
             "kernel_point_source": kernel,
             "psf_type": "PIXEL",
-            "psf_error_map": np.ones_like(kernel),
+            "psf_variance_map": np.ones_like(kernel),
         }
         psf_class = PSF(**kwargs_psf)
 

--- a/test/test_ImSim/test_Numerics/test_point_source_rendering.py
+++ b/test/test_ImSim/test_Numerics/test_point_source_rendering.py
@@ -36,19 +36,19 @@ class TestPointSourceRendering(object):
         ra_pos, dec_pos = [5], [5]
         data = np.zeros((10, 10))
         image = self._ps_rendering.psf_variance_map(
-            ra_pos, dec_pos, amp=1, data=data, fix_psf_error_map=False
+            ra_pos, dec_pos, amp=1, data=data, fix_psf_variance_map=False
         )
         npt.assert_almost_equal(np.sum(image), 0, decimal=10)
 
         image = self._ps_rendering.psf_variance_map(
-            ra_pos, dec_pos, amp=1, data=data, fix_psf_error_map=True
+            ra_pos, dec_pos, amp=1, data=data, fix_psf_variance_map=True
         )
         npt.assert_almost_equal(np.sum(image), 1, decimal=10)
 
         ra_pos, dec_pos = [50], [50]
         data = np.zeros((10, 10))
         image = self._ps_rendering.psf_variance_map(
-            ra_pos, dec_pos, amp=1, data=data, fix_psf_error_map=False
+            ra_pos, dec_pos, amp=1, data=data, fix_psf_variance_map=False
         )
         npt.assert_almost_equal(np.sum(image), 0, decimal=10)
 

--- a/test/test_ImSim/test_image_model.py
+++ b/test/test_ImSim/test_image_model.py
@@ -46,7 +46,7 @@ class TestImageModel(object):
         kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": kernel,
-            "psf_error_map": np.ones_like(kernel) * 0.001 * kernel**2,
+            "psf_variance_map": np.ones_like(kernel) * 0.001 * kernel**2,
         }
         psf_class = PSF(**kwargs_psf)
 
@@ -231,7 +231,7 @@ class TestImageModel(object):
         kwargs_psf = {
             "kernel_point_source": kernel,
             "psf_type": "PIXEL",
-            "psf_error_map": np.ones_like(kernel) * 0.001,
+            "psf_variance_map": np.ones_like(kernel) * 0.001,
         }
         psf_class = PSF(**kwargs_psf)
         lens_model_class = LensModel(["SPEP"])

--- a/test/test_ImSim/test_image_model_pixelbased.py
+++ b/test/test_ImSim/test_image_model_pixelbased.py
@@ -52,7 +52,7 @@ class TestImageModel(object):
         kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": kernel,
-            "psf_error_map": np.ones_like(kernel) * 0.001,
+            "psf_variance_map": np.ones_like(kernel) * 0.001,
         }
         psf_class = PSF(**kwargs_psf)
 
@@ -378,7 +378,7 @@ class TestRaise(unittest.TestCase):
         kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": kernel,
-            "psf_error_map": np.ones_like(kernel) * 0.001,
+            "psf_variance_map": np.ones_like(kernel) * 0.001,
         }
         self.psf_class = PSF(**kwargs_psf)
 

--- a/test/test_Plots/test_chain_plot.py
+++ b/test/test_Plots/test_chain_plot.py
@@ -44,7 +44,7 @@ class TestChainPlots(object):
     def test_psf_iteration_compare(self):
         kwargs_psf = self.kwargs_psf
         kwargs_psf["kernel_point_source_init"] = kwargs_psf["kernel_point_source"]
-        kwargs_psf["psf_error_map"] = np.ones_like(kwargs_psf["kernel_point_source"])
+        kwargs_psf["psf_variance_map"] = np.ones_like(kwargs_psf["kernel_point_source"])
         f, ax = chain_plot.psf_iteration_compare(kwargs_psf=kwargs_psf, vmin=-1, vmax=1)
         plt.close()
         f, ax = chain_plot.psf_iteration_compare(kwargs_psf=kwargs_psf)

--- a/test/test_Workflow/test_fitting_sequence.py
+++ b/test/test_Workflow/test_fitting_sequence.py
@@ -42,7 +42,7 @@ class TestFittingSequence(object):
         self.kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": psf_gaussian.kernel_point_source,
-            "psf_error_map": np.zeros_like(psf_gaussian.kernel_point_source),
+            "psf_variance_map": np.zeros_like(psf_gaussian.kernel_point_source),
         }
         psf_class = PSF(**self.kwargs_psf)
         # 'EXTERNAL_SHEAR': external shear

--- a/test/test_Workflow/test_psf_fitting.py
+++ b/test/test_Workflow/test_psf_fitting.py
@@ -47,7 +47,7 @@ class TestPSFIteration(object):
         self.kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": kernel_point_source,
-            "psf_error_map": psf_error_map,
+            "psf_variance_map": psf_error_map,
         }
 
         psf_class = PSF(**self.kwargs_psf)
@@ -298,7 +298,7 @@ class TestPSFIteration(object):
         diff_new = np.sum((kernel_new - kernel_true) ** 2)
         assert diff_old > diff_new
         assert diff_new < 0.01
-        assert "psf_error_map" in kwargs_psf_new
+        assert "psf_variance_map" in kwargs_psf_new
 
         kwargs_psf_new = self.psf_fitting.update_iterative(
             kwargs_psf,
@@ -361,7 +361,7 @@ class TestPSFIterationOld(object):
         self.kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": kernel_point_source,
-            "psf_error_map": psf_error_map,
+            "psf_variance_map": psf_error_map,
         }
 
         psf_class = PSF(**self.kwargs_psf)
@@ -535,7 +535,7 @@ class TestPSFIterationOld(object):
         diff_new = np.sum((kernel_new - kernel_true) ** 2)
         assert diff_old > diff_new
         assert diff_new < 0.01
-        assert "psf_error_map" in kwargs_psf_new
+        assert "psf_variance_map" in kwargs_psf_new
 
         kwargs_psf_new = self.psf_fitting.update_iterative(
             kwargs_psf,

--- a/test/test_Workflow/test_psf_fitting.py
+++ b/test/test_Workflow/test_psf_fitting.py
@@ -305,7 +305,7 @@ class TestPSFIteration(object):
             kwargs_params,
             num_iter=3,
             no_break=True,
-            keep_psf_error_map=True,
+            keep_psf_variance_map=True,
         )
         kernel_new = kwargs_psf_new["kernel_point_source"]
         kernel_true = self.kwargs_psf["kernel_point_source"]
@@ -518,7 +518,7 @@ class TestPSFIterationOld(object):
             "new_procedure": False,
             "no_break": False,
             "verbose": True,
-            "keep_psf_error_map": False,
+            "keep_psf_variance_map": False,
         }
 
         kwargs_params = copy.deepcopy(self.kwargs_params)
@@ -542,7 +542,7 @@ class TestPSFIterationOld(object):
             kwargs_params,
             num_iter=3,
             no_break=True,
-            keep_psf_error_map=True,
+            keep_psf_variance_map=True,
         )
         kernel_new = kwargs_psf_new["kernel_point_source"]
         kernel_true = self.kwargs_psf["kernel_point_source"]


### PR DESCRIPTION
normalizes the psf_error_map (currently defined as the variance at each pixel for the input PSF). Applies if the PSF input is not normalized