### PR TITLE
Bug fix in MultiPatchReconstruction.image_joint()

### DIFF
--- a/lenstronomy/Analysis/multi_patch_reconstruction.py
+++ b/lenstronomy/Analysis/multi_patch_reconstruction.py
@@ -127,9 +127,7 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
         for model_band in self.model_band_list:
             if model_band is not None:
                 image_model = model_band.image_model_class
-                model = image_model.image(
-                    **self._kwargs_params_no_tracersource
-                ) 
+                model = image_model.image(**self._kwargs_params_no_tracersource)
                 data_class_i = image_model.Data
                 # evaluate pixel of zero point with the base coordinate system
                 ra0, dec0 = data_class_i.radec_at_xy_0

--- a/lenstronomy/Analysis/multi_patch_reconstruction.py
+++ b/lenstronomy/Analysis/multi_patch_reconstruction.py
@@ -1,6 +1,7 @@
 from lenstronomy.Analysis.image_reconstruction import MultiBandImageReconstruction
 from lenstronomy.Data.pixel_grid import PixelGrid
 from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.ImSim.image_model import ImageModel
 from lenstronomy.Util import util
 import numpy as np
 import numpy.testing as npt
@@ -56,8 +57,6 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
             self._pixel_grid_joint = PixelGrid(**kwargs_pixel_grid)
         else:
             self._pixel_grid_joint = self._joint_pixel_grid(multi_band_list)
-        self._kwargs_params_no_tracersource = kwargs_params
-        self._kwargs_params_no_tracersource.pop("kwargs_tracer_source", None)
 
     @property
     def pixel_grid_joint(self):
@@ -127,7 +126,8 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
         for model_band in self.model_band_list:
             if model_band is not None:
                 image_model = model_band.image_model_class
-                model = image_model.image(**self._kwargs_params_no_tracersource)
+                kwargs_params = model_band.kwargs_model
+                model = ImageModel.image(image_model, **kwargs_params)
                 data_class_i = image_model.Data
                 # evaluate pixel of zero point with the base coordinate system
                 ra0, dec0 = data_class_i.radec_at_xy_0

--- a/lenstronomy/Analysis/multi_patch_reconstruction.py
+++ b/lenstronomy/Analysis/multi_patch_reconstruction.py
@@ -56,7 +56,8 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
             self._pixel_grid_joint = PixelGrid(**kwargs_pixel_grid)
         else:
             self._pixel_grid_joint = self._joint_pixel_grid(multi_band_list)
-        # self._kwargs_params = kwargs_params  # TODO: this is a but since linear parameters won't be updated
+        self._kwargs_params_no_tracersource = kwargs_params
+        self._kwargs_params_no_tracersource.pop("kwargs_tracer_source", None)
 
     @property
     def pixel_grid_joint(self):
@@ -126,10 +127,9 @@ class MultiPatchReconstruction(MultiBandImageReconstruction):
         for model_band in self.model_band_list:
             if model_band is not None:
                 image_model = model_band.image_model_class
-                kwargs_params = model_band.kwargs_model
                 model = image_model.image(
-                    **kwargs_params
-                )  # TODO: avoid using private definitions uses sub-set of the model parameters
+                    **self._kwargs_params_no_tracersource
+                ) 
                 data_class_i = image_model.Data
                 # evaluate pixel of zero point with the base coordinate system
                 ra0, dec0 = data_class_i.radec_at_xy_0

--- a/test/test_Analysis/test_multi_patch_reconstruction.py
+++ b/test/test_Analysis/test_multi_patch_reconstruction.py
@@ -116,7 +116,7 @@ class TestMultiPatchReconstruction(object):
         kwargs_data["image_data"] = image_sim
 
         kwargs_model = {
-            "lens_model_list": lens_model_list,
+            "lens_model_list": ["EPL"] + lens_model_list,
             "source_light_model_list": source_model_list,
         }
 
@@ -145,8 +145,9 @@ class TestMultiPatchReconstruction(object):
             }
             multi_band_list.append([kwargs_data_i, kwargs_psf, kwargs_numerics])
 
+        kwargs_model["index_lens_model_list"] = [[1, 2]] * len(x_pos)
         kwargs_params = {
-            "kwargs_lens": kwargs_lens_true,
+            "kwargs_lens": [kwargs_spemd] + kwargs_lens_true,
             "kwargs_source": kwargs_source_true,
         }
         self.multiPatch = MultiPatchReconstruction(


### PR DESCRIPTION
This fixes a bug that I introduced in PR #702 where select_kwargs() is executed twice, once in `model_band.kwargs_model` and once in `SingleBandMultiModel.image()` resulting in a list index error.
I've also made the test function more robust to be able to catch this sort of error in the future.