### PR TITLE
fix bug in TNFWC lens profile class

### DIFF
--- a/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
+++ b/lenstronomy/LensModel/Profiles/nfw_core_truncated.py
@@ -259,7 +259,7 @@ class TNFWC(LensProfileBase):
         """
         if b == t:
             t += 1e-3
-        prefactor = abs(t**2 / (t**2 - 1))
+        prefactor = t**2 / (t**2 - 1)
         return prefactor * (
             -self._u2(x, b, t)
             + self._u2(0.0, b, t)

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -779,6 +779,10 @@ class TestNumericsProfile(object):
         lens_model = ["TNFWC"]
         self.assert_differentials(lens_model, kwargs, potential=False)
 
+        kwargs = {"alpha_Rs": 4.0, "Rs": 2.0, "r_core": 12.1, "r_trunc": 0.5}
+        lens_model = ["TNFWC"]
+        self.assert_differentials(lens_model, kwargs, potential=False)
+
     def test_epl_m3m4(self):
 
         kwargs = {


### PR DESCRIPTION
I fix a bug in the TNFWC profile class when the parameter r_trunc is greater than Rs. A misplaced abs() operator would make the profile have negative convergence. This is now fixed, and a test covering the case r_trunc < Rs was added 