### PR TITLE
change LightModel initialization

### DIFF
--- a/lenstronomy/Analysis/light2mass.py
+++ b/lenstronomy/Analysis/light2mass.py
@@ -19,11 +19,13 @@ def light2mass_interpol(
     lensmodel quantities computed on a grid). Then provides an interpolated grid for the
     quantities.
 
-    :param lens_light_model_list: list of strings indicating the type of lens light models
+    :param lens_light_model_list: list of strings indicating the type of lens light
+        models
     :param kwargs_lens_light: lens light keyword argument list
-    :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize lens light
-        profile classes in the same order of the lens_light_model_list. If any of the profile_kwargs are None,
-        then that profile will be initialized using default settings.
+    :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to
+        initialize lens light profile classes in the same order of the
+        lens_light_model_list. If any of the profile_kwargs are None, then that profile
+        will be initialized using default settings.
     :param numPix: number of pixels per axis for the return interpolation
     :param deltaPix: interpolation/pixel size
     :param center_x: center of the grid
@@ -40,7 +42,10 @@ def light2mass_interpol(
     mask = mask_util.mask_azimuthal(x_grid_sub, y_grid_sub, center_x, center_y, r=1)
     x_grid, y_grid = util.make_grid(numPix=numPix, deltapix=deltaPix)
     # compute light on the subgrid
-    lightModel = LightModel(light_model_list=lens_light_model_list, profile_kwargs_list=lens_light_profile_kwargs_list)
+    lightModel = LightModel(
+        light_model_list=lens_light_model_list,
+        profile_kwargs_list=lens_light_profile_kwargs_list,
+    )
     flux = lightModel.surface_brightness(x_grid_sub, y_grid_sub, kwargs_lens_light)
     flux_norm = np.sum(flux[mask == 1]) / np.sum(mask)
     flux /= flux_norm

--- a/lenstronomy/Analysis/light2mass.py
+++ b/lenstronomy/Analysis/light2mass.py
@@ -8,6 +8,7 @@ __all__ = ["light2mass_interpol"]
 def light2mass_interpol(
     lens_light_model_list,
     kwargs_lens_light,
+    lens_light_profile_kwargs_list=None,
     numPix=100,
     deltaPix=0.05,
     subgrid_res=5,
@@ -18,7 +19,11 @@ def light2mass_interpol(
     lensmodel quantities computed on a grid). Then provides an interpolated grid for the
     quantities.
 
+    :param lens_light_model_list: list of strings indicating the type of lens light models
     :param kwargs_lens_light: lens light keyword argument list
+    :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize lens light
+        profile classes in the same order of the lens_light_model_list. If any of the profile_kwargs are None,
+        then that profile will be initialized using default settings.
     :param numPix: number of pixels per axis for the return interpolation
     :param deltaPix: interpolation/pixel size
     :param center_x: center of the grid
@@ -35,7 +40,7 @@ def light2mass_interpol(
     mask = mask_util.mask_azimuthal(x_grid_sub, y_grid_sub, center_x, center_y, r=1)
     x_grid, y_grid = util.make_grid(numPix=numPix, deltapix=deltaPix)
     # compute light on the subgrid
-    lightModel = LightModel(light_model_list=lens_light_model_list)
+    lightModel = LightModel(light_model_list=lens_light_model_list, profile_kwargs_list=lens_light_profile_kwargs_list)
     flux = lightModel.surface_brightness(x_grid_sub, y_grid_sub, kwargs_lens_light)
     flux_norm = np.sum(flux[mask == 1]) / np.sum(mask)
     flux /= flux_norm

--- a/lenstronomy/GalKin/light_profile.py
+++ b/lenstronomy/GalKin/light_profile.py
@@ -19,6 +19,7 @@ class LightProfile(object):
     def __init__(
         self,
         profile_list,
+        profile_kwargs_list=None,
         interpol_grid_num=2000,
         max_interpolate=1000,
         min_interpolate=0.001,
@@ -27,13 +28,16 @@ class LightProfile(object):
         """
 
         :param profile_list: list of light profiles for LightModel module (must support light_3d() functionalities)
+        :param profile_kwargs_list: list of dicts, keyword arguments used to initialize light profile
+            classes in the same order of the profile_list. If any of the profile_kwargs are None,
+            then that profile will be initialized using default settings.
         :param interpol_grid_num: int; number of interpolation steps (logarithmically between min and max value)
         :param max_interpolate: float; maximum interpolation of 3d light profile
         :param min_interpolate: float; minimum interpolate (and also drawing of light profile)
         :param max_draw: float; (optional) if set, draws up to this radius, else uses max_interpolate value
         """
 
-        self.light_model = LightModel(light_model_list=profile_list)
+        self.light_model = LightModel(light_model_list=profile_list, profile_kwargs_list=profile_kwargs_list)
         self._interp_grid_num = interpol_grid_num
         self._max_interpolate = max_interpolate
         self._min_interpolate = min_interpolate

--- a/lenstronomy/GalKin/light_profile.py
+++ b/lenstronomy/GalKin/light_profile.py
@@ -37,7 +37,9 @@ class LightProfile(object):
         :param max_draw: float; (optional) if set, draws up to this radius, else uses max_interpolate value
         """
 
-        self.light_model = LightModel(light_model_list=profile_list, profile_kwargs_list=profile_kwargs_list)
+        self.light_model = LightModel(
+            light_model_list=profile_list, profile_kwargs_list=profile_kwargs_list
+        )
         self._interp_grid_num = interpol_grid_num
         self._max_interpolate = max_interpolate
         self._min_interpolate = min_interpolate

--- a/lenstronomy/ImSim/differential_extinction.py
+++ b/lenstronomy/ImSim/differential_extinction.py
@@ -11,15 +11,18 @@ class DifferentialExtinction(object):
     optical depth tau_ext to compute the extinction on the sky/image.
     """
 
-    def __init__(self, optical_depth_model=None, tau0_index=0):
+    def __init__(self, optical_depth_model=None, profile_kwargs_list=None, tau0_index=0):
         """
 
         :param optical_depth_model: list of strings naming the profiles (same convention as LightModel module)
-         describing the optical depth of the extinction
+            describing the optical depth of the extinction
+        :param profile_kwargs_list: list of dicts, keyword arguments used to initialize light model
+            profile classes in the same order of the optical_depth_model list. If any of the profile_kwargs,
+            are None, then that profile will be initialized using default settings.
         """
         if optical_depth_model is None:
             optical_depth_model = []
-        self._profile = LightModel(light_model_list=optical_depth_model)
+        self._profile = LightModel(light_model_list=optical_depth_model, profile_kwargs_list=profile_kwargs_list)
         if len(optical_depth_model) == 0:
             self._compute_bool = False
         else:

--- a/lenstronomy/ImSim/differential_extinction.py
+++ b/lenstronomy/ImSim/differential_extinction.py
@@ -11,7 +11,9 @@ class DifferentialExtinction(object):
     optical depth tau_ext to compute the extinction on the sky/image.
     """
 
-    def __init__(self, optical_depth_model=None, profile_kwargs_list=None, tau0_index=0):
+    def __init__(
+        self, optical_depth_model=None, profile_kwargs_list=None, tau0_index=0
+    ):
         """
 
         :param optical_depth_model: list of strings naming the profiles (same convention as LightModel module)
@@ -22,7 +24,10 @@ class DifferentialExtinction(object):
         """
         if optical_depth_model is None:
             optical_depth_model = []
-        self._profile = LightModel(light_model_list=optical_depth_model, profile_kwargs_list=profile_kwargs_list)
+        self._profile = LightModel(
+            light_model_list=optical_depth_model,
+            profile_kwargs_list=profile_kwargs_list,
+        )
         if len(optical_depth_model) == 0:
             self._compute_bool = False
         else:

--- a/lenstronomy/LensModel/Profiles/sersic.py
+++ b/lenstronomy/LensModel/Profiles/sersic.py
@@ -96,9 +96,9 @@ class Sersic(SersicUtil, LensProfileBase):
         y_ = y - center_y
         r = np.sqrt(x_**2 + y_**2)
         if isinstance(r, int) or isinstance(r, float):
-            r = max(self._s, r)
+            r = max(self._smoothing, r)
         else:
-            r[r < self._s] = self._s
+            r[r < self._smoothing] = self._smoothing
         alpha = -self.alpha_abs(x, y, n_sersic, R_sersic, k_eff, center_x, center_y)
         f_x = alpha * x_ / r
         f_y = alpha * y_ / r
@@ -111,9 +111,9 @@ class Sersic(SersicUtil, LensProfileBase):
         y_ = y - center_y
         r = np.sqrt(x_**2 + y_**2)
         if isinstance(r, int) or isinstance(r, float):
-            r = max(self._s, r)
+            r = max(self._smoothing, r)
         else:
-            r[r < self._s] = self._s
+            r[r < self._smoothing] = self._smoothing
         d_alpha_dr = self.d_alpha_dr(
             x, y, n_sersic, R_sersic, k_eff, center_x, center_y
         )

--- a/lenstronomy/LensModel/Profiles/sersic_utils.py
+++ b/lenstronomy/LensModel/Profiles/sersic_utils.py
@@ -7,9 +7,8 @@ __all__ = ["SersicUtil"]
 
 
 class SersicUtil(object):
-    _s = 0.00001
 
-    def __init__(self, smoothing=_s, sersic_major_axis=False):
+    def __init__(self, smoothing=0.0001, sersic_major_axis=False):
         """
 
         :param smoothing: smoothing scale of the innermost part of the profile (for numerical reasons)
@@ -88,9 +87,9 @@ class SersicUtil(object):
         y_ = y - center_y
         r = np.sqrt(x_**2 + y_**2)
         if isinstance(r, int) or isinstance(r, float):
-            r = max(self._s, r)
+            r = max(self._smoothing, r)
         else:
-            r[r < self._s] = self._s
+            r[r < self._smoothing] = self._smoothing
         x_reduced = (r / r_eff) ** (1.0 / n_sersic)
         return x_reduced
 

--- a/lenstronomy/LensModel/Profiles/sersic_utils.py
+++ b/lenstronomy/LensModel/Profiles/sersic_utils.py
@@ -7,7 +7,7 @@ __all__ = ["SersicUtil"]
 
 
 class SersicUtil(object):
-    _s = 0.00001
+    _s = 0.001
 
     def __init__(self, smoothing=_s, sersic_major_axis=False):
         """

--- a/lenstronomy/LensModel/Profiles/sersic_utils.py
+++ b/lenstronomy/LensModel/Profiles/sersic_utils.py
@@ -7,7 +7,7 @@ __all__ = ["SersicUtil"]
 
 
 class SersicUtil(object):
-    _s = 0.001
+    _s = 0.00001
 
     def __init__(self, smoothing=_s, sersic_major_axis=False):
         """

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -546,10 +546,6 @@ def lens_class(
         )
 
         return NFWMCEllipsePotential(**profile_kwargs)
-    elif lens_type == "NFW_VIR_TRUNC":
-        from lenstronomy.LensModel.Profiles.nfw_vir_trunc import NFWVirTrunc
-
-        return NFWVirTrunc(**profile_kwargs)
     elif lens_type == "NIE":
         from lenstronomy.LensModel.Profiles.nie import NIE
 

--- a/lenstronomy/LightModel/light_model.py
+++ b/lenstronomy/LightModel/light_model.py
@@ -26,26 +26,23 @@ class LightModel(LinearBasis):
         light_model_list,
         deflection_scaling_list=None,
         source_redshift_list=None,
-        smoothing=0.001,
-        sersic_major_axis=None,
+        profile_kwargs_list=None,
     ):
         """
 
         :param light_model_list: list of light models
         :param deflection_scaling_list: list of floats indicating a relative scaling of the deflection angle from the
-         reduced angles in the lens model definition (optional, only possible in single lens plane with multiple source
-         planes)
+            reduced angles in the lens model definition (optional, only possible in single lens plane with multiple source
+            planes)
         :param source_redshift_list: list of redshifts for the different light models
-         (optional and only used in multi-plane lensing in conjunction with a cosmology model)
-        :param smoothing: smoothing factor for certain models (deprecated)
-        :param sersic_major_axis: boolean or None, if True, uses the semi-major axis as the definition of the Sersic
-         half-light radius, if False, uses the product average of semi-major and semi-minor axis. If None, uses the
-         convention in the lenstronomy yaml setting (which by default is =False)
+            (optional and only used in multi-plane lensing in conjunction with a cosmology model)
+        :param profile_kwargs_list: list of dicts, keyword arguments used to initialize light model
+            profile classes in the same order of the light_model_list. If any of the profile_kwargs
+            are None, then that profile will be initialized using default settings.
         """
         super(LightModel, self).__init__(
             light_model_list=light_model_list,
-            smoothing=smoothing,
-            sersic_major_axis=sersic_major_axis,
+            profile_kwargs_list=profile_kwargs_list
         )
         self.deflection_scaling_list = deflection_scaling_list
         self.redshift_list = source_redshift_list

--- a/lenstronomy/LightModel/light_model.py
+++ b/lenstronomy/LightModel/light_model.py
@@ -41,8 +41,7 @@ class LightModel(LinearBasis):
             are None, then that profile will be initialized using default settings.
         """
         super(LightModel, self).__init__(
-            light_model_list=light_model_list,
-            profile_kwargs_list=profile_kwargs_list
+            light_model_list=light_model_list, profile_kwargs_list=profile_kwargs_list
         )
         self.deflection_scaling_list = deflection_scaling_list
         self.redshift_list = source_redshift_list

--- a/lenstronomy/LightModel/light_model_base.py
+++ b/lenstronomy/LightModel/light_model_base.py
@@ -59,6 +59,8 @@ class LightModelBase(object):
             profile_kwargs_list = [{} for _ in range(len(light_model_list))]
 
         for profile_type, profile_kwargs in zip(light_model_list, profile_kwargs_list):
+            if profile_kwargs is None:
+                profile_kwargs = {}
             if profile_type == "GAUSSIAN":
                 from lenstronomy.LightModel.Profiles.gaussian import Gaussian
 

--- a/lenstronomy/LightModel/light_model_base.py
+++ b/lenstronomy/LightModel/light_model_base.py
@@ -4,10 +4,7 @@ __author__ = "sibirrer"
 
 import numpy as np
 from lenstronomy.Util.util import convert_bool_list
-from lenstronomy.Conf import config_loader
 
-convention_conf = config_loader.conventions_conf()
-sersic_major_axis_conf = convention_conf.get("sersic_major_axis", False)
 
 __all__ = ["LightModelBase"]
 
@@ -48,158 +45,157 @@ _MODELS_SUPPORTED = [
 class LightModelBase(object):
     """Class to handle source and lens light models."""
 
-    def __init__(self, light_model_list, smoothing=0.001, sersic_major_axis=None):
+    def __init__(self, light_model_list, profile_kwargs_list=None):
         """
 
         :param light_model_list: list of light models
-        :param smoothing: smoothing factor for certain models (deprecated)
-        :param sersic_major_axis: boolean or None, if True, uses the semi-major axis as the definition of the Sersic
-         half-light radius, if False, uses the product average of semi-major and semi-minor axis. If None, uses the
-         convention in the lenstronomy yaml setting (which by default is =False)
+        :param profile_kwargs_list: list of dicts, keyword arguments used to initialize light model
+            profile classes in the same order of the light_model_list. If any of the profile_kwargs
+            are None, then that profile will be initialized using default settings.
         """
         self.profile_type_list = light_model_list
         self.func_list = []
-        if sersic_major_axis is None:
-            sersic_major_axis = sersic_major_axis_conf
-        for profile_type in light_model_list:
+        if profile_kwargs_list is None:
+            profile_kwargs_list = [{} for _ in range(len(light_model_list))]
+
+        for profile_type, profile_kwargs in (light_model_list, profile_kwargs_list):
             if profile_type == "GAUSSIAN":
                 from lenstronomy.LightModel.Profiles.gaussian import Gaussian
 
-                self.func_list.append(Gaussian())
+                self.func_list.append(Gaussian(**profile_kwargs))
             elif profile_type == "GAUSSIAN_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.gaussian import GaussianEllipse
 
-                self.func_list.append(GaussianEllipse())
+                self.func_list.append(GaussianEllipse(**profile_kwargs))
             elif profile_type == "ELLIPSOID":
                 from lenstronomy.LightModel.Profiles.ellipsoid import Ellipsoid
 
-                self.func_list.append(Ellipsoid())
+                self.func_list.append(Ellipsoid(**profile_kwargs))
             elif profile_type == "MULTI_GAUSSIAN":
                 from lenstronomy.LightModel.Profiles.gaussian import MultiGaussian
 
-                self.func_list.append(MultiGaussian())
+                self.func_list.append(MultiGaussian(**profile_kwargs))
             elif profile_type == "MULTI_GAUSSIAN_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.gaussian import (
                     MultiGaussianEllipse,
                 )
 
-                self.func_list.append(MultiGaussianEllipse())
+                self.func_list.append(MultiGaussianEllipse(**profile_kwargs))
             elif profile_type == "SERSIC":
                 from lenstronomy.LightModel.Profiles.sersic import Sersic
 
-                self.func_list.append(Sersic(smoothing=smoothing))
+                self.func_list.append(Sersic(**profile_kwargs))
             elif profile_type == "SERSIC_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.sersic import SersicElliptic
 
                 self.func_list.append(
-                    SersicElliptic(
-                        smoothing=smoothing, sersic_major_axis=sersic_major_axis
-                    )
+                    SersicElliptic(**profile_kwargs)
                 )
             elif profile_type == "SERSIC_ELLIPSE_Q_PHI":
                 from lenstronomy.LightModel.Profiles.sersic import SersicElliptic_qPhi
 
                 self.func_list.append(
-                    SersicElliptic_qPhi(
-                        smoothing=smoothing, sersic_major_axis=sersic_major_axis
-                    )
+                    SersicElliptic_qPhi(**profile_kwargs)
                 )
             elif profile_type == "CORE_SERSIC":
                 from lenstronomy.LightModel.Profiles.sersic import CoreSersic
 
                 self.func_list.append(
-                    CoreSersic(smoothing=smoothing, sersic_major_axis=sersic_major_axis)
+                    CoreSersic(**profile_kwargs)
                 )
             elif profile_type == "SHAPELETS":
                 from lenstronomy.LightModel.Profiles.shapelets import ShapeletSet
 
-                self.func_list.append(ShapeletSet())
+                self.func_list.append(ShapeletSet(**profile_kwargs))
             elif profile_type == "SHAPELETS_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.shapelets_ellipse import (
                     ShapeletSetEllipse,
                 )
 
-                self.func_list.append(ShapeletSetEllipse())
+                self.func_list.append(ShapeletSetEllipse(**profile_kwargs))
             elif profile_type == "SHAPELETS_POLAR":
                 from lenstronomy.LightModel.Profiles.shapelets_polar import (
                     ShapeletSetPolar,
                 )
-
-                self.func_list.append(ShapeletSetPolar(exponential=False))
+                profile_kwargs["exponential"] = False
+                self.func_list.append(ShapeletSetPolar(**profile_kwargs))
             elif profile_type == "SHAPELETS_POLAR_EXP":
                 from lenstronomy.LightModel.Profiles.shapelets_polar import (
                     ShapeletSetPolar,
                 )
-
-                self.func_list.append(ShapeletSetPolar(exponential=True))
+                profile_kwargs["exponential"] = True
+                self.func_list.append(ShapeletSetPolar(**profile_kwargs))
             elif profile_type == "HERNQUIST":
                 from lenstronomy.LightModel.Profiles.hernquist import Hernquist
 
-                self.func_list.append(Hernquist())
+                self.func_list.append(Hernquist(**profile_kwargs))
             elif profile_type == "HERNQUIST_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.hernquist import HernquistEllipse
 
-                self.func_list.append(HernquistEllipse())
+                self.func_list.append(HernquistEllipse(**profile_kwargs))
             elif profile_type == "PJAFFE":
                 from lenstronomy.LightModel.Profiles.pseudo_jaffe import PseudoJaffe
 
-                self.func_list.append(PseudoJaffe())
+                self.func_list.append(PseudoJaffe(**profile_kwargs))
             elif profile_type == "PJAFFE_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.pseudo_jaffe import (
                     PseudoJaffeEllipse,
                 )
 
-                self.func_list.append(PseudoJaffeEllipse())
+                self.func_list.append(PseudoJaffeEllipse(**profile_kwargs))
             elif profile_type == "UNIFORM":
                 from lenstronomy.LightModel.Profiles.uniform import Uniform
 
-                self.func_list.append(Uniform())
+                self.func_list.append(Uniform(**profile_kwargs))
             elif profile_type == "POWER_LAW":
                 from lenstronomy.LightModel.Profiles.power_law import PowerLaw
 
-                self.func_list.append(PowerLaw())
+                self.func_list.append(PowerLaw(**profile_kwargs))
             elif profile_type == "NIE":
                 from lenstronomy.LightModel.Profiles.nie import NIE
 
-                self.func_list.append(NIE())
+                self.func_list.append(NIE(**profile_kwargs))
             elif profile_type == "CHAMELEON":
                 from lenstronomy.LightModel.Profiles.chameleon import Chameleon
 
-                self.func_list.append(Chameleon())
+                self.func_list.append(Chameleon(**profile_kwargs))
             elif profile_type == "DOUBLE_CHAMELEON":
                 from lenstronomy.LightModel.Profiles.chameleon import DoubleChameleon
 
-                self.func_list.append(DoubleChameleon())
+                self.func_list.append(DoubleChameleon(**profile_kwargs))
             elif profile_type == "TRIPLE_CHAMELEON":
                 from lenstronomy.LightModel.Profiles.chameleon import TripleChameleon
 
-                self.func_list.append(TripleChameleon())
+                self.func_list.append(TripleChameleon(**profile_kwargs))
             elif profile_type == "INTERPOL":
                 from lenstronomy.LightModel.Profiles.interpolation import Interpol
 
-                self.func_list.append(Interpol())
+                self.func_list.append(Interpol(**profile_kwargs))
             elif profile_type == "SLIT_STARLETS":
                 from lenstronomy.LightModel.Profiles.starlets import SLIT_Starlets
 
+                profile_kwargs["fast_inverse"] = True
+                profile_kwargs["second_gen"] = False
                 self.func_list.append(
-                    SLIT_Starlets(fast_inverse=True, second_gen=False)
+                    SLIT_Starlets(**profile_kwargs)
                 )
             elif profile_type == "SLIT_STARLETS_GEN2":
                 from lenstronomy.LightModel.Profiles.starlets import SLIT_Starlets
 
-                self.func_list.append(SLIT_Starlets(second_gen=True))
+                profile_kwargs["second_gen"] = True
+                self.func_list.append(SLIT_Starlets(**profile_kwargs))
             elif profile_type == "LINEAR":
                 from lenstronomy.LightModel.Profiles.linear import Linear
 
-                self.func_list.append(Linear())
+                self.func_list.append(Linear(**profile_kwargs))
             elif profile_type == "LINEAR_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.linear import LinearEllipse
 
-                self.func_list.append(LinearEllipse())
+                self.func_list.append(LinearEllipse(**profile_kwargs))
             elif profile_type == "LINE_PROFILE":
                 from lenstronomy.LightModel.Profiles.lineprofile import LineProfile
 
-                self.func_list.append(LineProfile())
+                self.func_list.append(LineProfile(**profile_kwargs))
             else:
                 raise ValueError(
                     "No light model of type %s found! Supported are the following models: %s"

--- a/lenstronomy/LightModel/light_model_base.py
+++ b/lenstronomy/LightModel/light_model_base.py
@@ -88,21 +88,15 @@ class LightModelBase(object):
             elif profile_type == "SERSIC_ELLIPSE":
                 from lenstronomy.LightModel.Profiles.sersic import SersicElliptic
 
-                self.func_list.append(
-                    SersicElliptic(**profile_kwargs)
-                )
+                self.func_list.append(SersicElliptic(**profile_kwargs))
             elif profile_type == "SERSIC_ELLIPSE_Q_PHI":
                 from lenstronomy.LightModel.Profiles.sersic import SersicElliptic_qPhi
 
-                self.func_list.append(
-                    SersicElliptic_qPhi(**profile_kwargs)
-                )
+                self.func_list.append(SersicElliptic_qPhi(**profile_kwargs))
             elif profile_type == "CORE_SERSIC":
                 from lenstronomy.LightModel.Profiles.sersic import CoreSersic
 
-                self.func_list.append(
-                    CoreSersic(**profile_kwargs)
-                )
+                self.func_list.append(CoreSersic(**profile_kwargs))
             elif profile_type == "SHAPELETS":
                 from lenstronomy.LightModel.Profiles.shapelets import ShapeletSet
 
@@ -117,12 +111,14 @@ class LightModelBase(object):
                 from lenstronomy.LightModel.Profiles.shapelets_polar import (
                     ShapeletSetPolar,
                 )
+
                 profile_kwargs["exponential"] = False
                 self.func_list.append(ShapeletSetPolar(**profile_kwargs))
             elif profile_type == "SHAPELETS_POLAR_EXP":
                 from lenstronomy.LightModel.Profiles.shapelets_polar import (
                     ShapeletSetPolar,
                 )
+
                 profile_kwargs["exponential"] = True
                 self.func_list.append(ShapeletSetPolar(**profile_kwargs))
             elif profile_type == "HERNQUIST":
@@ -176,9 +172,7 @@ class LightModelBase(object):
 
                 profile_kwargs["fast_inverse"] = True
                 profile_kwargs["second_gen"] = False
-                self.func_list.append(
-                    SLIT_Starlets(**profile_kwargs)
-                )
+                self.func_list.append(SLIT_Starlets(**profile_kwargs))
             elif profile_type == "SLIT_STARLETS_GEN2":
                 from lenstronomy.LightModel.Profiles.starlets import SLIT_Starlets
 

--- a/lenstronomy/LightModel/light_model_base.py
+++ b/lenstronomy/LightModel/light_model_base.py
@@ -58,7 +58,7 @@ class LightModelBase(object):
         if profile_kwargs_list is None:
             profile_kwargs_list = [{} for _ in range(len(light_model_list))]
 
-        for profile_type, profile_kwargs in (light_model_list, profile_kwargs_list):
+        for profile_type, profile_kwargs in zip(light_model_list, profile_kwargs_list):
             if profile_type == "GAUSSIAN":
                 from lenstronomy.LightModel.Profiles.gaussian import Gaussian
 

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -401,7 +401,7 @@ class ModelBandPlot(ModelBand):
             lens_redshift_list=lens_redshift_list_macro,
             z_source=z_source,
             cosmo=cosmo,
-            profile_kwargs_list=profile_kwargs_list_macro
+            profile_kwargs_list=profile_kwargs_list_macro,
         )
 
         if super_sample_factor is None:

--- a/lenstronomy/Plots/model_band_plot.py
+++ b/lenstronomy/Plots/model_band_plot.py
@@ -376,6 +376,7 @@ class ModelBandPlot(ModelBand):
 
         kwargs_lens_macro = []
         lens_model_list_macro = []
+        profile_kwargs_list_macro = []
         multi_plane = self._lensModel.multi_plane
         if multi_plane:
             lens_redshift_list = self._lensModel.redshift_list
@@ -392,6 +393,7 @@ class ModelBandPlot(ModelBand):
             kwargs_lens_macro.append(self._kwargs_lens_partial[idx])
             if multi_plane:
                 lens_redshift_list_macro.append(lens_redshift_list[idx])
+            profile_kwargs_list_macro.append(self._lensModel.profile_kwargs_list[idx])
 
         lens_model_macro = LensModel(
             lens_model_list_macro,
@@ -399,6 +401,7 @@ class ModelBandPlot(ModelBand):
             lens_redshift_list=lens_redshift_list_macro,
             z_source=z_source,
             cosmo=cosmo,
+            profile_kwargs_list=profile_kwargs_list_macro
         )
 
         if super_sample_factor is None:

--- a/lenstronomy/SimulationAPI/model_api.py
+++ b/lenstronomy/SimulationAPI/model_api.py
@@ -56,14 +56,16 @@ class ModelAPI(object):
             model list), only applicable in multi_plane mode.
         :param source_light_model_list: list of strings with source light model names
             (lensed light profiles)
-        :param source_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize source light
-            profile classes in the same order of the source_light_model_list. If any of the profile_kwargs are None,
-            then that profile will be initialized using default settings.
+        :param source_light_profile_kwargs_list: list of dicts, keyword arguments used
+            to initialize source light profile classes in the same order of the
+            source_light_model_list. If any of the profile_kwargs are None, then that
+            profile will be initialized using default settings.
         :param lens_light_model_list: list of strings with lens light model names (not
             lensed light profiles)
-        :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize lens light
-            profile classes in the same order of the lens_light_model_list. If any of the profile_kwargs are None,
-            then that profile will be initialized using default settings.
+        :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to
+            initialize lens light profile classes in the same order of the
+            lens_light_model_list. If any of the profile_kwargs are None, then that
+            profile will be initialized using default settings.
         :param point_source_model_list: list of strings with point source model names
         :param source_redshift_list: list of redshifts of the source profiles (optional)
         :param cosmo: instance of the astropy cosmology class. If not specified, uses

--- a/lenstronomy/SimulationAPI/model_api.py
+++ b/lenstronomy/SimulationAPI/model_api.py
@@ -27,7 +27,9 @@ class ModelAPI(object):
         z_source=None,
         lens_redshift_list=None,
         source_light_model_list=None,
+        source_light_profile_kwargs_list=None,
         lens_light_model_list=None,
+        lens_light_profile_kwargs_list=None,
         point_source_model_list=None,
         source_redshift_list=None,
         cosmo=None,
@@ -54,8 +56,14 @@ class ModelAPI(object):
             model list), only applicable in multi_plane mode.
         :param source_light_model_list: list of strings with source light model names
             (lensed light profiles)
+        :param source_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize source light
+            profile classes in the same order of the source_light_model_list. If any of the profile_kwargs are None,
+            then that profile will be initialized using default settings.
         :param lens_light_model_list: list of strings with lens light model names (not
             lensed light profiles)
+        :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize lens light
+            profile classes in the same order of the lens_light_model_list. If any of the profile_kwargs are None,
+            then that profile will be initialized using default settings.
         :param point_source_model_list: list of strings with point source model names
         :param source_redshift_list: list of redshifts of the source profiles (optional)
         :param cosmo: instance of the astropy cosmology class. If not specified, uses
@@ -100,9 +108,11 @@ class ModelAPI(object):
         self._source_model_class = LightModel(
             light_model_list=source_light_model_list,
             source_redshift_list=source_redshift_list,
+            profile_kwargs_list=source_light_profile_kwargs_list,
         )
         self._lens_light_model_class = LightModel(
-            light_model_list=lens_light_model_list
+            light_model_list=lens_light_model_list,
+            profile_kwargs_list=lens_light_profile_kwargs_list,
         )
         fixed_magnification = [False] * len(point_source_model_list)
         for i, ps_type in enumerate(point_source_model_list):

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -26,7 +26,9 @@ def create_class_instances(
     cosmology_model="FlatLambdaCDM",
     observed_convention_index=None,
     source_light_model_list=None,
+    source_light_profile_kwargs_list=None,
     lens_light_model_list=None,
+    lens_light_profile_kwargs_list=None,
     point_source_model_list=None,
     point_source_redshift_list=None,
     fixed_magnification_list=None,
@@ -42,6 +44,7 @@ def create_class_instances(
     index_lens_light_model_list=None,
     index_point_source_model_list=None,
     optical_depth_model_list=None,
+    optical_depth_profile_kwargs_list=None,
     index_optical_depth_model_list=None,
     band_index=0,
     tau0_index_list=None,
@@ -64,18 +67,24 @@ def create_class_instances(
     :param z_source: redshift of source (for single source plane mode, or for multiple source planes the redshift of the point source). In regard to this redshift the reduced deflection angles are defined in the lens model.
     :param z_source_convention: float, redshift of a source to define the reduced deflection angles of the lens models.
         If None, 'z_source' is used.
-    :param lens_redshift_list:
+    :param lens_redshift_list: None or list of floats in the same order of the lens_model_list
+    :param lens_profile_kwargs_list: list of dicts, keyword arguments used to initialize deflector profile
+        classes in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
+        profile will be initialized using default settings.
     :param multi_plane: bool, if True, computes the lensing quantities in multi-plane mode
     :param distance_ratio_sampling: bool, if True, samples the distance ratios in multi-lens-plane
     :param cosmology_sampling: bool, if True, samples the cosmology in multi-lens-plane
     :param cosmology_model: string, name of the cosmology model to be used in the multi-lens-plane mode
-    :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
-        in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
-        profile will be initialized using default settings.
     :param observed_convention_index:
-    :param source_light_model_list:
-    :param lens_light_model_list:
-    :param point_source_model_list:
+    :param source_light_model_list: list of strings indicating the type of source light models
+    :param source_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize source light
+        profile classes in the same order of the source_light_model_list. If any of the profile_kwargs are None,
+        then that profile will be initialized using default settings.
+    :param lens_light_model_list: list of strings indicating the type of lens light models
+    :param lens_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize lens light
+        profile classes in the same order of the lens_light_model_list. If any of the profile_kwargs are None,
+        then that profile will be initialized using default settings.
+    :param point_source_model_list: list of strings indicating the type of point source models
     :param fixed_magnification_list:
     :param flux_from_point_source_list: list of bools (optional), if set, will only return image positions
          (for imaging modeling) for the subset of the point source lists that =True. This option enables to model
@@ -96,6 +105,9 @@ def create_class_instances(
     :param index_lens_light_model_list: optional, list of list of all model indexes for each modeled band
     :param index_point_source_model_list: optional, list of list of all model indexes for each modeled band
     :param optical_depth_model_list: list of strings indicating the optical depth model to compute (differential) extinctions from the source
+    :param optical_depth_profile_kwargs_list: list of dicts, keyword arguments used to initialize light model
+        profile classes in the same order of the optical_depth_model_list. If any of the profile_kwargs are None,
+        then that profile will be initialized using default settings.
     :param index_optical_depth_model_list:
     :param band_index: int, index of band to consider. Has an effect if only partial models are considered for a specific band
     :param tau0_index_list: list of integers of the specific extinction scaling parameter tau0 for each band
@@ -214,8 +226,7 @@ def create_class_instances(
         light_model_list=source_light_model_list_i,
         deflection_scaling_list=source_deflection_scaling_list_i,
         source_redshift_list=source_redshift_list_i,
-        smoothing=surface_brightness_smoothing,
-        sersic_major_axis=sersic_major_axis,
+        profile_kwargs_list=source_light_profile_kwargs_list
     )
 
     if index_lens_light_model_list is None or all_models is True:
@@ -226,8 +237,7 @@ def create_class_instances(
         ]
     lens_light_model_class = LightModel(
         light_model_list=lens_light_model_list_i,
-        smoothing=surface_brightness_smoothing,
-        sersic_major_axis=sersic_major_axis,
+        profile_kwargs_list=lens_light_profile_kwargs_list
     )
 
     point_source_model_list_i = point_source_model_list
@@ -279,7 +289,9 @@ def create_class_instances(
     else:
         optical_depth_model_list_i = optical_depth_model_list
     extinction_class = DifferentialExtinction(
-        optical_depth_model=optical_depth_model_list_i, tau0_index=tau0_index
+        optical_depth_model=optical_depth_model_list_i,
+        profile_kwargs_list=optical_depth_profile_kwargs_list,
+        tau0_index=tau0_index
     )
     return (
         lens_model_class,

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -50,8 +50,6 @@ def create_class_instances(
     tau0_index_list=None,
     all_models=False,
     point_source_magnification_limit=None,
-    surface_brightness_smoothing=0.001,
-    sersic_major_axis=None,
     decouple_multi_plane=False,
     kwargs_multiplane_model=None,
     kwargs_multiplane_model_point_source=None,
@@ -113,11 +111,6 @@ def create_class_instances(
     :param tau0_index_list: list of integers of the specific extinction scaling parameter tau0 for each band
     :param all_models: bool, if True, will make class instances of all models ignoring potential keywords that are excluding specific models as indicated.
     :param point_source_magnification_limit: float >0 or None, if set and additional images are computed, then it will cut the point sources computed to the limiting (absolute) magnification
-    :param surface_brightness_smoothing: float, smoothing scale of light profile (minimal distance to the center of a profile)
-        this can help to avoid inaccuracies in the very center of a cuspy light profile
-    :param sersic_major_axis: boolean or None, if True, uses the semi-major axis as the definition of the Sersic
-        half-light radius, if False, uses the product average of semi-major and semi-minor axis. If None, uses the
-        convention in the lenstronomy yaml setting (which by default is =False)
     :param decouple_multi_plane: bool; if True, creates an instance of MultiPlaneDecoupled
     :param kwargs_multiplane_model: keyword arguments used to create an instance of MultiPlaneDecoupled if decouple_multi_plane is True
     :param kwargs_multiplane_model_point_source: keyword arguments used to create an option MultiPlaneDecoupled class for the lensed point source to be treated separately from the rest of the imaging data

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -226,7 +226,7 @@ def create_class_instances(
         light_model_list=source_light_model_list_i,
         deflection_scaling_list=source_deflection_scaling_list_i,
         source_redshift_list=source_redshift_list_i,
-        profile_kwargs_list=source_light_profile_kwargs_list
+        profile_kwargs_list=source_light_profile_kwargs_list,
     )
 
     if index_lens_light_model_list is None or all_models is True:
@@ -237,7 +237,7 @@ def create_class_instances(
         ]
     lens_light_model_class = LightModel(
         light_model_list=lens_light_model_list_i,
-        profile_kwargs_list=lens_light_profile_kwargs_list
+        profile_kwargs_list=lens_light_profile_kwargs_list,
     )
 
     point_source_model_list_i = point_source_model_list
@@ -291,7 +291,7 @@ def create_class_instances(
     extinction_class = DifferentialExtinction(
         optical_depth_model=optical_depth_model_list_i,
         profile_kwargs_list=optical_depth_profile_kwargs_list,
-        tau0_index=tau0_index
+        tau0_index=tau0_index,
     )
     return (
         lens_model_class,

--- a/test/test_LensModel/test_Profiles/test_sersic_lens.py
+++ b/test/test_LensModel/test_Profiles/test_sersic_lens.py
@@ -28,6 +28,7 @@ class TestSersic(object):
         values = self.sersic.function(x, y, n_sersic, R_sersic, k_eff)
         npt.assert_almost_equal(values, 1.0272982586319199, decimal=10)
 
+        # Tests the smoothing of the sersic profile at r=0
         x = np.array([0])
         y = np.array([0])
         values = self.sersic.function(x, y, n_sersic, R_sersic, k_eff)

--- a/test/test_LensModel/test_Profiles/test_sersic_lens.py
+++ b/test/test_LensModel/test_Profiles/test_sersic_lens.py
@@ -31,7 +31,7 @@ class TestSersic(object):
         x = np.array([0])
         y = np.array([0])
         values = self.sersic.function(x, y, n_sersic, R_sersic, k_eff)
-        npt.assert_almost_equal(values[0], 0.0, decimal=9)
+        npt.assert_almost_equal(values[0], 3.8391158402117444e-08, decimal=9)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -145,10 +145,10 @@ class TestLightModel(object):
     def test_init(self):
         model_list = [
             "CORE_SERSIC",
-            "LINEAR_ELLIPSE",
             "SERSIC",
             "SERSIC",
             "SHAPELETS",
+            "LINEAR_ELLIPSE",
             "SHAPELETS_ELLIPSE",
             "SHAPELETS_POLAR",
             "SHAPELETS_POLAR_EXP",
@@ -161,7 +161,7 @@ class TestLightModel(object):
             None,
             {"sersic_major_axis": False},
             {"sersic_major_axis": True},
-        ] + [None] * 8
+        ] + [None] * 9
         lightModel = LightModel(
             light_model_list=model_list, profile_kwargs_list=profile_kwargs_list
         )

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -141,12 +141,14 @@ class TestLightModel(object):
         ]
 
         self.LightModel = LightModel(
-            light_model_list=self.light_model_list, sersic_major_axis=False
+            light_model_list=self.light_model_list
         )
 
     def test_init(self):
         model_list = [
             "CORE_SERSIC",
+            "SERSIC",
+            "SERSIC",
             "SHAPELETS",
             "SHAPELETS_ELLIPSE",
             "SHAPELETS_POLAR",
@@ -156,8 +158,11 @@ class TestLightModel(object):
             "DOUBLE_CHAMELEON",
             "TRIPLE_CHAMELEON",
         ]
-        lightModel = LightModel(light_model_list=model_list)
+        profile_kwargs_list = [None, {"sersic_major_axis": False}, {"sersic_major_axis": True}] + [None] * 8
+        lightModel = LightModel(light_model_list=model_list, profile_kwargs_list=profile_kwargs_list)
         assert len(lightModel.profile_type_list) == len(model_list)
+        assert lightModel.func_list[1]._sersic_major_axis == False
+        assert lightModel.func_list[2]._sersic_major_axis == True
 
     def test_surface_brightness(self):
         output = self.LightModel.surface_brightness(

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -145,6 +145,7 @@ class TestLightModel(object):
     def test_init(self):
         model_list = [
             "CORE_SERSIC",
+            "LINEAR_ELLIPSE",
             "SERSIC",
             "SERSIC",
             "SHAPELETS",

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -19,16 +19,18 @@ class TestClassCreator(object):
                 {"interpol": True},
                 None,
             ],
-            "source_light_model_list": ["SERSIC"],
-            "lens_light_model_list": ["SERSIC"],
+            "source_light_model_list": ["SERSIC", "SERSIC"],
+            "source_light_profile_kwargs_list": [{"sersic_major_axis": False}, {"sersic_major_axis": True}],
+            "lens_light_model_list": ["SERSIC", "SERSIC"],
+            "lens_light_profile_kwargs_list": [{"sersic_major_axis": True}, None],
             "point_source_model_list": ["LENSED_POSITION"],
             "index_lens_model_list": [[0, 1, 2, 3, 4, 5]],
-            "index_source_light_model_list": [[0]],
-            "index_lens_light_model_list": [[0]],
+            "index_source_light_model_list": [[0, 1]],
+            "index_lens_light_model_list": [[0, 1]],
             "index_point_source_model_list": [[0]],
             "band_index": 0,
-            "source_deflection_scaling_list": [1],
-            "source_redshift_list": [1],
+            "source_deflection_scaling_list": [1, 1],
+            "source_redshift_list": [1, 1],
             "fixed_magnification_list": [True],
             "additional_images_list": [False],
             "lens_redshift_list": [0.5] * 6,
@@ -117,6 +119,12 @@ class TestClassCreator(object):
             lens_model_class.lens_model.func_list[1]
             != lens_model_class.lens_model.func_list[5]
         )
+
+        assert source_model_class.func_list[0]._sersic_major_axis == False
+        assert source_model_class.func_list[1]._sersic_major_axis == True
+
+        assert lens_light_model_class.func_list[0]._sersic_major_axis == True
+        assert lens_light_model_class.func_list[1]._sersic_major_axis == False
 
         (
             lens_model_class,

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -20,7 +20,10 @@ class TestClassCreator(object):
                 None,
             ],
             "source_light_model_list": ["SERSIC", "SERSIC"],
-            "source_light_profile_kwargs_list": [{"sersic_major_axis": False}, {"sersic_major_axis": True}],
+            "source_light_profile_kwargs_list": [
+                {"sersic_major_axis": False},
+                {"sersic_major_axis": True},
+            ],
             "lens_light_model_list": ["SERSIC", "SERSIC"],
             "lens_light_profile_kwargs_list": [{"sersic_major_axis": True}, None],
             "point_source_model_list": ["LENSED_POSITION"],


### PR DESCRIPTION
This is a continuation of PR #717 but for LightModel where the user is now able to specify initialization settings for light model profiles. This means that in the future, we no longer need to separate profiles based on their init (e.g. we don't need both SHAPELETS_POLAR and SHAPELETS_POLAR_EXP, but I kept them in anyways to maintain backwards compatibility for now. Maybe in a future lenstronomy 2.0 update, SHAPELETS_POLAR_EXP can be removed).