### PR TITLE
improved several docstrings and fixed some bugs/improved some features

### DIFF
--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -57,7 +57,7 @@ class PSF(object):
                 raise ValueError("fwhm must be set for GAUSSIAN psf type!")
             self._fwhm = fwhm
             self._sigma_gaussian = util.fwhm2sigma(self._fwhm)
-            self._truncation = truncation
+            self.truncation = truncation
             self._point_source_supersampling_factor = 0
         elif self.psf_type == "PIXEL":
             if kernel_point_source is None:
@@ -135,7 +135,7 @@ class PSF(object):
                 # num_pix = 2r + 1 where r = round(truncation * sigma) is the radius of the gaussian kernel
                 # kernel_num_pix is always an odd integer between 3 and 221
                 kernel_radius = max(
-                    round(self._truncation * sigma / self._pixel_size), 1
+                    round(self.truncation * sigma / self._pixel_size), 1
                 )
                 kernel_num_pix = min(2 * kernel_radius + 1, 221)
                 self._kernel_point_source = kernel_util.kernel_gaussian(
@@ -189,7 +189,7 @@ class PSF(object):
             # num_pix = 2r + 1 where r = round(truncation * sigma) is the radius of the gaussian kernel
             kernel_radius = max(
                 round(
-                    self._truncation * sigma / self._pixel_size * supersampling_factor
+                    self.truncation * sigma / self._pixel_size * supersampling_factor
                 ),
                 1,
             )
@@ -198,7 +198,7 @@ class PSF(object):
                 raise ValueError(
                     "The pixelized Gaussian kernel has a grid of %s pixels with a truncation at "
                     "%s times the sigma of the Gaussian, exceeding the limit allowed."
-                    % (kernel_num_pix, self._truncation)
+                    % (kernel_num_pix, self.truncation)
                 )
             kernel_point_source_supersampled = kernel_util.kernel_gaussian(
                 kernel_num_pix, self._pixel_size / supersampling_factor, self._fwhm

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -54,7 +54,9 @@ class PSF(object):
 
         if self.psf_type == "GAUSSIAN":
             if fwhm is None or pixel_size is None:
-                raise ValueError("fwhm and pixel_size must be set for GAUSSIAN psf type!")
+                raise ValueError(
+                    "fwhm and pixel_size must be set for GAUSSIAN psf type!"
+                )
             self._fwhm = fwhm
             self._sigma_gaussian = util.fwhm2sigma(self._fwhm)
             self._truncation = truncation

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -54,9 +54,7 @@ class PSF(object):
 
         if self.psf_type == "GAUSSIAN":
             if fwhm is None:
-                raise ValueError(
-                    "fwhm must be set for GAUSSIAN psf type!"
-                )
+                raise ValueError("fwhm must be set for GAUSSIAN psf type!")
             self._fwhm = fwhm
             self._sigma_gaussian = util.fwhm2sigma(self._fwhm)
             self._truncation = truncation

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -53,9 +53,9 @@ class PSF(object):
         self.kernel_point_source_init = kernel_point_source_init
 
         if self.psf_type == "GAUSSIAN":
-            if fwhm is None or pixel_size is None:
+            if fwhm is None:
                 raise ValueError(
-                    "fwhm and pixel_size must be set for GAUSSIAN psf type!"
+                    "fwhm must be set for GAUSSIAN psf type!"
                 )
             self._fwhm = fwhm
             self._sigma_gaussian = util.fwhm2sigma(self._fwhm)

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -53,8 +53,8 @@ class PSF(object):
         self.kernel_point_source_init = kernel_point_source_init
 
         if self.psf_type == "GAUSSIAN":
-            if fwhm is None:
-                raise ValueError("fwhm must be set for GAUSSIAN psf type!")
+            if fwhm is None or pixel_size is None:
+                raise ValueError("fwhm and pixel_size must be set for GAUSSIAN psf type!")
             self._fwhm = fwhm
             self._sigma_gaussian = util.fwhm2sigma(self._fwhm)
             self._truncation = truncation

--- a/lenstronomy/ImSim/Numerics/numerics.py
+++ b/lenstronomy/ImSim/Numerics/numerics.py
@@ -160,7 +160,7 @@ class Numerics(PointSourceRendering):
             sigma_list = [sigma]
             fraction_list = [1]
             if truncation_conv is None:
-                truncation_conv = psf._truncation
+                truncation_conv = psf.truncation
             self._conv = MultiGaussianConvolution(
                 sigma_list,
                 fraction_list,

--- a/lenstronomy/ImSim/Numerics/numerics.py
+++ b/lenstronomy/ImSim/Numerics/numerics.py
@@ -32,7 +32,7 @@ class Numerics(PointSourceRendering):
         point_source_supersampling_factor=None,
         convolution_kernel_size=None,
         convolution_type="fft_static",
-        truncation=4,
+        truncation_conv=None,
     ):
         """
 
@@ -41,23 +41,26 @@ class Numerics(PointSourceRendering):
         :param compute_mode: options are: 'regular', 'adaptive'
         :param supersampling_factor: int, factor of higher resolution sub-pixel sampling of surface brightness
         :param supersampling_convolution: bool, if True, performs (part of) the convolution on the super-sampled
-         grid/pixels
+            grid/pixels
         :param supersampling_kernel_size: int (odd number), size (in regular pixel units) of the super-sampled
-         convolution
+            convolution
         :param flux_evaluate_indexes: boolean 2d array of size of image (or None, then initiated as gird of True's).
-         Pixels indicated with True will be used to perform the surface brightness computation (and possible lensing
-         ray-shooting). Pixels marked as False will be assigned a flux value of zero (or ignored in the adaptive
-         convolution)
+            Pixels indicated with True will be used to perform the surface brightness computation (and possible lensing
+            ray-shooting). Pixels marked as False will be assigned a flux value of zero (or ignored in the adaptive
+            convolution)
         :param supersampled_indexes: 2d boolean array (only used in mode='adaptive') of pixels to be supersampled (in
-         surface brightness and if supersampling_convolution=True also in convolution). All other pixels not set to =True
-         will not be super-sampled.
+            surface brightness and if supersampling_convolution=True also in convolution). All other pixels not set to =True
+            will not be super-sampled.
         :param compute_indexes: 2d boolean array (only used in compute_mode='adaptive'), marks pixel that the response after
-         convolution is computed (all others =0). This can be set to likelihood_mask in the Likelihood module for
-         consistency.
+            convolution is computed (all others =0). This can be set to likelihood_mask in the Likelihood module for
+            consistency.
         :param point_source_supersampling_factor: super-sampling resolution of the point source placing
-         if None, then uses the supersampling factor of the original PSF
+            if None, then uses the supersampling factor of the original PSF
         :param convolution_kernel_size: int, odd number, size of convolution kernel. If None, takes size of point_source_kernel
         :param convolution_type: string, 'fft', 'grid', 'fft_static' mode of 2d convolution
+        :param truncation_conv: Truncation used for the construction of the convolution kernels (only relevant for Gaussian convolution). By default,
+            the truncation from the psf class will be used. Can be overwritten so that different PSFs are used for
+            convolution and point source rendering.
         """
         if compute_mode not in ["regular", "adaptive"]:
             raise ValueError(
@@ -156,13 +159,15 @@ class Numerics(PointSourceRendering):
             sigma = util.fwhm2sigma(fwhm)
             sigma_list = [sigma]
             fraction_list = [1]
+            if truncation_conv is None:
+                truncation_conv = psf._truncation
             self._conv = MultiGaussianConvolution(
                 sigma_list,
                 fraction_list,
                 pixel_scale,
                 supersampling_factor,
                 supersampling_convolution,
-                truncation=truncation,
+                truncation=truncation_conv,
             )
         elif self._psf_type == "NONE":
             self._conv = None

--- a/lenstronomy/ImSim/Numerics/numerics_subframe.py
+++ b/lenstronomy/ImSim/Numerics/numerics_subframe.py
@@ -25,7 +25,7 @@ class NumericsSubFrame(PointSourceRendering):
         point_source_supersampling_factor=None,
         convolution_kernel_size=None,
         convolution_type="fft_static",
-        truncation=4,
+        truncation_conv=None,
     ):
         """
 
@@ -34,22 +34,26 @@ class NumericsSubFrame(PointSourceRendering):
         :param compute_mode: options are: 'regular', 'adaptive'
         :param supersampling_factor: int, factor of higher resolution sub-pixel sampling of surface brightness
         :param supersampling_convolution: bool, if True, performs (part of) the convolution on the super-sampled
-        grid/pixels
+            grid/pixels
         :param supersampling_kernel_size: int (odd number), size (in regular pixel units) of the super-sampled
-        convolution
+            convolution
         :param flux_evaluate_indexes: boolean 2d array of size of image (or None, then initiated as gird of True's).
-        Pixels indicated with True will be used to perform the surface brightness computation (and possible lensing
-        ray-shooting). Pixels marked as False will be assigned a flux value of zero (or ignored in the adaptive
-        convolution)
+            Pixels indicated with True will be used to perform the surface brightness computation (and possible lensing
+            ray-shooting). Pixels marked as False will be assigned a flux value of zero (or ignored in the adaptive
+            convolution)
         :param supersampled_indexes: 2d boolean array (only used in mode='adaptive') of pixels to be supersampled (in
-        surface brightness and if supersampling_convolution=True also in convolution)
+            surface brightness and if supersampling_convolution=True also in convolution)
         :param compute_indexes: 2d boolean array (only used in mode='adaptive'), marks pixel that the resonse after
-        convolution is computed (all others =0). This can be set to likelihood_mask in the Likelihood module for
-        consistency.
+            convolution is computed (all others =0). This can be set to likelihood_mask in the Likelihood module for
+            consistency.
         :param point_source_supersampling_factor: super-sampling resolution of the point source placing
-         if None, then uses the supersampling factor of the original PSF
+            if None, then uses the supersampling factor of the original PSF
         :param convolution_kernel_size: int, odd number, size of convolution kernel. If None, takes size of
-        point_source_kernel
+            point_source_kernel
+        :param convolution_type: string, 'fft', 'grid', 'fft_static' mode of 2d convolution
+        :param truncation_conv: Truncation used for the construction of the convolution kernels (only relevant for Gaussian convolution). By default,
+            the truncation from the psf class will be used. Can be overwritten so that different PSFs are used for
+            convolution and point source rendering.
 
         """
         # if no super sampling, turn the supersampling convolution off
@@ -70,7 +74,7 @@ class NumericsSubFrame(PointSourceRendering):
             point_source_supersampling_factor=point_source_supersampling_factor,
             convolution_kernel_size=convolution_kernel_size,
             convolution_type=convolution_type,
-            truncation=truncation,
+            truncation_conv=truncation_conv,
         )
         super(NumericsSubFrame, self).__init__(
             pixel_grid=pixel_grid,

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -41,11 +41,11 @@ class ImageModel(object):
         :param extinction_class: instance of DifferentialExtinction() class
         :param kwargs_numerics: keyword arguments with various numeric description (see ImageNumerics class for options)
         :param likelihood_mask: 2d boolean array of pixels to be counted in the likelihood calculation/linear
-         optimization
+            optimization
         :param psf_error_map_bool_list: list of boolean of length of point source models.
-         Indicates whether PSF error map is used for the point source model stated as the index.
+            Indicates whether PSF error map is used for the point source model stated as the index.
         :param kwargs_pixelbased: keyword arguments with various settings related to the pixel-based solver
-         (see SLITronomy documentation)
+            (see SLITronomy documentation)
         """
 
         self.type = "single-band"

--- a/lenstronomy/PointSource/Types/source_position.py
+++ b/lenstronomy/PointSource/Types/source_position.py
@@ -31,8 +31,9 @@ class SourcePositions(PSBase):
         :param kwargs_ps: keyword arguments of the point source model
         :param kwargs_lens: keyword argument list of the lens model(s), only used when
             requiring the lens equation solver
-        :param magnification_limit: float >0 or None, if float is set, only those images will be computed that exceed the
-            lensing magnification (absolute value) limit
+        :param magnification_limit: float >0 or None, if float is set, only those images
+            will be computed that exceed the lensing magnification (absolute value)
+            limit
         :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical
             settings for the lens equation solver see LensEquationSolver() class for
             details
@@ -77,8 +78,9 @@ class SourcePositions(PSBase):
             when providing image positions directly
         :param x_pos: pre-computed image position (no lens equation solver applied)
         :param y_pos: pre-computed image position (no lens equation solver applied)
-        :param magnification_limit: float >0 or None, if float is set, only those images will be computed that exceed the
-            lensing magnification (absolute value) limit
+        :param magnification_limit: float >0 or None, if float is set, only those images
+            will be computed that exceed the lensing magnification (absolute value)
+            limit
         :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical
             settings for the lens equation solver see LensEquationSolver() class for
             details

--- a/lenstronomy/PointSource/Types/source_position.py
+++ b/lenstronomy/PointSource/Types/source_position.py
@@ -15,7 +15,6 @@ class SourcePositions(PSBase):
 
     Name within the PointSource module: 'SOURCE_POSITION'
     parameters: ra_source, dec_source, source_amp, mag_pert (optional)
-    If fixed_magnification=True, than 'source_amp' is a parameter instead of 'point_amp'
     mag_pert is a list of fractional magnification pertubations applied to point source images
     """
 
@@ -32,8 +31,7 @@ class SourcePositions(PSBase):
         :param kwargs_ps: keyword arguments of the point source model
         :param kwargs_lens: keyword argument list of the lens model(s), only used when
             requiring the lens equation solver
-        :param magnification_limit: float >0 or None, if float is set and additional
-            images are computed, only those images will be computed that exceed the
+        :param magnification_limit: float >0 or None, if float is set, only those images will be computed that exceed the
             lensing magnification (absolute value) limit
         :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical
             settings for the lens equation solver see LensEquationSolver() class for
@@ -79,8 +77,7 @@ class SourcePositions(PSBase):
             when providing image positions directly
         :param x_pos: pre-computed image position (no lens equation solver applied)
         :param y_pos: pre-computed image position (no lens equation solver applied)
-        :param magnification_limit: float >0 or None, if float is set and additional
-            images are computed, only those images will be computed that exceed the
+        :param magnification_limit: float >0 or None, if float is set, only those images will be computed that exceed the
             lensing magnification (absolute value) limit
         :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical
             settings for the lens equation solver see LensEquationSolver() class for

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -367,7 +367,7 @@ class PointSource(object):
                     amp_list.append(image_amp)
                 else:
                     amp_list.append(np.zeros_like(image_amp))
-                
+
         return amp_list
 
     def source_amplitude(self, kwargs_ps, kwargs_lens):
@@ -503,9 +503,10 @@ class PointSource(object):
         argument list currently only used in SimAPI to transform magnitudes to
         amplitudes in the lenstronomy conventions.
 
-        :param amp_list: list of model amplitudes for each point source model. This list should
-            include all of the point source models even if flux_from_point_source is False for any of them.
-            In that case, the amplitudes will not be changed for those models.
+        :param amp_list: list of model amplitudes for each point source model. This list
+            should include all of the point source models even if flux_from_point_source
+            is False for any of them. In that case, the amplitudes will not be changed
+            for those models.
         :param kwargs_ps: list of point source keywords
         :return: overwrites kwargs_ps with new amplitudes
         """

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -56,11 +56,11 @@ class PointSource(object):
         :param redshift_list: list of redshifts (only required for multiple source redshifts)
         :type redshift_list: None or list
         """
-        if len(point_source_type_list) > 0:
+        if "LENSED_POSITION" in point_source_type_list:
             if index_lens_model_list is not None and point_source_frame_list is None:
                 raise ValueError(
-                    "with specified index_lens_model_list a specified point_source_frame_list argument is "
-                    "required"
+                    "with specified index_lens_model_list, a specified point_source_frame_list argument is "
+                    "required for LENSED_POSITION"
                 )
             if index_lens_model_list is None:
                 point_source_frame_list = [None] * len(point_source_type_list)

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -317,6 +317,10 @@ class PointSource(object):
         ra_array, dec_array, amp_array = [], [], []
         for i, ra in enumerate(ra_list):
             for j in range(len(ra)):
+                # Remove images with zero amplitude so that they do not have to be rendered.
+                if with_amp is True and amp_list[i][j] == 0:
+                    continue
+
                 ra_array.append(ra_list[i][j])
                 dec_array.append(dec_list[i][j])
                 if with_amp:
@@ -360,9 +364,9 @@ class PointSource(object):
                     kwargs_lens_eqn_solver=self._kwargs_lens_eqn_solver,
                 )
                 if self._flux_from_point_source_list[i]:
-                    amp_list.append(np.zeros_like(image_amp))
-                else:
                     amp_list.append(image_amp)
+                else:
+                    amp_list.append(np.zeros_like(image_amp))
                 
         return amp_list
 

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -87,8 +87,11 @@ def create_class_instances(
         point_source_model_list should have fixed magnification. Only relevant for the LENSED_POSITION point
         source type. If set to True, then "source_amp" is a parameter instead of "point_amp", and the magnification
         is calculated from the lens models.
-    :param point_source_frame_list: Unused, as this was not working correctly previously.
-        # TODO: In addition to separating point source models into bands, also allow separation of images within a certain model into frames
+    :param point_source_frame_list: list of list of ints, assigns each model in point_source_type_list a frame list.
+        Only relevent for LENSED_POSITION. e.g. if point_source_type_list = ["UNLENSED", "LENSED_POSITION", "LENSED_POSITION"]
+        with point_source_frame_list = [None, [0, 1, 2], [1, 2, 0, 1]], then the first LENSED_POSITION will have a frame list of
+        [0, 1, 2] and the second LENSED_POSITION will have a frame list of [1, 2, 0, 1]. See docstring of point_source_frame_list
+        in PSBase for further details.
     :param additional_images_list: list of bool. Indicates which point source classes in the same order of the
         point_source_model_list should use the lens equation solver to solve for additional images. Only relevant
         for the LENSED_POSITION point source type.
@@ -180,22 +183,21 @@ def create_class_instances(
         kwargs_multiplane_model=kwargs_multiplane_model,
     )
 
-    if kwargs_multiplane_model_point_source is not None:
-        lens_model_class_point_source = LensModel(
-            lens_model_list=lens_model_list,
-            z_lens=z_lens,
-            z_source=z_source,
-            z_source_convention=z_source_convention,
-            lens_redshift_list=lens_redshift_list,
-            multi_plane=multi_plane,
-            cosmo=cosmo,
-            observed_convention_index=observed_convention_index,
-            profile_kwargs_list=lens_profile_kwargs_list,
-            decouple_multi_plane=decouple_multi_plane,
-            kwargs_multiplane_model=kwargs_multiplane_model_point_source,
-        )
-    else:
-        lens_model_class_point_source = lens_model_class
+    if kwargs_multiplane_model_point_source is None:
+        kwargs_multiplane_model_point_source = kwargs_multiplane_model
+    lens_model_class_point_source = LensModel(
+        lens_model_list=lens_model_list,
+        z_lens=z_lens,
+        z_source=z_source,
+        z_source_convention=z_source_convention,
+        lens_redshift_list=lens_redshift_list,
+        multi_plane=multi_plane,
+        cosmo=cosmo,
+        observed_convention_index=observed_convention_index,
+        profile_kwargs_list=lens_profile_kwargs_list,
+        decouple_multi_plane=decouple_multi_plane,
+        kwargs_multiplane_model=kwargs_multiplane_model_point_source,
+    )
 
     if index_source_light_model_list is None or all_models is True:
         source_light_model_list_i = source_light_model_list
@@ -276,8 +278,8 @@ def create_class_instances(
         additional_images_list=additional_images_list_i,
         magnification_limit=point_source_magnification_limit,
         kwargs_lens_eqn_solver=kwargs_lens_eqn_solver,
-        point_source_frame_list=None,
-        index_lens_model_list=None,
+        point_source_frame_list=point_source_frame_list_i,
+        index_lens_model_list=index_lens_model_list,
         redshift_list=point_source_redshift_list_i,
     )
     if tau0_index_list is None:

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -185,7 +185,10 @@ def create_class_instances(
 
     # Only create a second LensModel class if the user wants a separate class
     # or if index_lens_model_list is specified, since we need a class with all lens models
-    if kwargs_multiplane_model_point_source is not None or index_lens_model_list is not None:
+    if (
+        kwargs_multiplane_model_point_source is not None
+        or index_lens_model_list is not None
+    ):
         if kwargs_multiplane_model_point_source is None:
             kwargs_multiplane_model_point_source = kwargs_multiplane_model
         lens_model_class_point_source = LensModel(

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -87,7 +87,6 @@ def create_class_instances(
         and the magnification is calculated from the lens models.
     :param point_source_frame_list: Unused, as this was not working correctly previously.
         # TODO: In addition to separating point source models into bands, also allow separation of images within a certain model into frames
-    
     :param additional_images_list: list of bool. Indicates which point source classes in the same order of point_source_model_list should use the lens equation
         solver to solve for additional images. Only relevant for the LENSED_POSITION point source type.
     :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical settings for the lens equation solver

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -183,21 +183,26 @@ def create_class_instances(
         kwargs_multiplane_model=kwargs_multiplane_model,
     )
 
-    if kwargs_multiplane_model_point_source is None:
-        kwargs_multiplane_model_point_source = kwargs_multiplane_model
-    lens_model_class_point_source = LensModel(
-        lens_model_list=lens_model_list,
-        z_lens=z_lens,
-        z_source=z_source,
-        z_source_convention=z_source_convention,
-        lens_redshift_list=lens_redshift_list,
-        multi_plane=multi_plane,
-        cosmo=cosmo,
-        observed_convention_index=observed_convention_index,
-        profile_kwargs_list=lens_profile_kwargs_list,
-        decouple_multi_plane=decouple_multi_plane,
-        kwargs_multiplane_model=kwargs_multiplane_model_point_source,
-    )
+    # Only create a second LensModel class if the user wants a separate class
+    # or if index_lens_model_list is specified, since we need a class with all lens models
+    if kwargs_multiplane_model_point_source is not None or index_lens_model_list is not None:
+        if kwargs_multiplane_model_point_source is None:
+            kwargs_multiplane_model_point_source = kwargs_multiplane_model
+        lens_model_class_point_source = LensModel(
+            lens_model_list=lens_model_list,
+            z_lens=z_lens,
+            z_source=z_source,
+            z_source_convention=z_source_convention,
+            lens_redshift_list=lens_redshift_list,
+            multi_plane=multi_plane,
+            cosmo=cosmo,
+            observed_convention_index=observed_convention_index,
+            profile_kwargs_list=lens_profile_kwargs_list,
+            decouple_multi_plane=decouple_multi_plane,
+            kwargs_multiplane_model=kwargs_multiplane_model_point_source,
+        )
+    else:
+        lens_model_class_point_source = lens_model_class
 
     if index_source_light_model_list is None or all_models is True:
         source_light_model_list_i = source_light_model_list

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -61,7 +61,8 @@ def create_class_instances(
 
     :param lens_model_list: list of strings indicating the type of lens models
     :param z_lens: redshift of the deflector (for single lens plane mode, but only relevant when computing physical quantities)
-    :param z_source: redshift of source (for single source plane mode, or for multiple source planes the redshift of the point source). In regard to this redshift the reduced deflection angles are defined in the lens model.
+    :param z_source: redshift of source (for single source plane mode, or for multiple source planes the redshift of the point source).
+        In regard to this redshift the reduced deflection angles are defined in the lens model.
     :param z_source_convention: float, redshift of a source to define the reduced deflection angles of the lens models.
         If None, 'z_source' is used.
     :param lens_redshift_list: None or list of floats in the same order of the lens_model_list
@@ -82,13 +83,15 @@ def create_class_instances(
         profile classes in the same order of the lens_light_model_list. If any of the profile_kwargs are None,
         then that profile will be initialized using default settings.
     :param point_source_model_list: list of strings indicating the type of point source models
-    :param fixed_magnification_list: list of bool. Indicates which point source classes in the same order of point_source_model_list should have fixed magnification.
-        Only relevant for the LENSED_POSITION point source type. If set to True, then "source_amp" is a parameter instead of "point_amp",
-        and the magnification is calculated from the lens models.
+    :param fixed_magnification_list: list of bool. Indicates which point source classes in the same order of
+        point_source_model_list should have fixed magnification. Only relevant for the LENSED_POSITION point
+        source type. If set to True, then "source_amp" is a parameter instead of "point_amp", and the magnification
+        is calculated from the lens models.
     :param point_source_frame_list: Unused, as this was not working correctly previously.
         # TODO: In addition to separating point source models into bands, also allow separation of images within a certain model into frames
-    :param additional_images_list: list of bool. Indicates which point source classes in the same order of point_source_model_list should use the lens equation
-        solver to solve for additional images. Only relevant for the LENSED_POSITION point source type.
+    :param additional_images_list: list of bool. Indicates which point source classes in the same order of the
+        point_source_model_list should use the lens equation solver to solve for additional images. Only relevant
+        for the LENSED_POSITION point source type.
     :param kwargs_lens_eqn_solver: keyword arguments specifying the numerical settings for the lens equation solver
          see LensEquationSolver() class for details
     :param source_deflection_scaling_list: List of floats for each source ligth model (optional, and only applicable
@@ -109,11 +112,14 @@ def create_class_instances(
     :param index_optical_depth_model_list: list of list of ints, indicates which optical depth models are in each band.
     :param band_index: int, index of band to consider. Has an effect if only partial models are considered for a specific band
     :param tau0_index_list: list of integers of the specific extinction scaling parameter tau0 for each band
-    :param all_models: bool, if True, will make class instances of all models ignoring potential keywords that are excluding specific models as indicated.
-    :param point_source_magnification_limit: float >0 or None, if set and additional images are computed, then it will cut the point sources computed to the limiting (absolute) magnification
+    :param all_models: bool, if True, will make class instances of all models ignoring potential keywords that are excluding
+        specific models as indicated.
+    :param point_source_magnification_limit: float >0 or None, if set and additional images are computed, then it will cut
+        the point sources computed to the limiting (absolute) magnification
     :param decouple_multi_plane: bool; if True, creates an instance of MultiPlaneDecoupled
     :param kwargs_multiplane_model: keyword arguments used to create an instance of MultiPlaneDecoupled if decouple_multi_plane is True
-    :param kwargs_multiplane_model_point_source: keyword arguments used to create an option MultiPlaneDecoupled class for the lensed point source to be treated separately from the rest of the imaging data
+    :param kwargs_multiplane_model_point_source: keyword arguments used to create an option MultiPlaneDecoupled class for the lensed
+        point source to be treated separately from the rest of the imaging data
     :param tracer_source_model_list: list of tracer source models (not used in this function)
     :param tracer_source_band: integer, list index of source surface brightness band to apply tracer model to
     :param tracer_partition: in case of tracer models for specific sub-parts of the surface brightness model

--- a/lenstronomy/Util/class_creator.py
+++ b/lenstronomy/Util/class_creator.py
@@ -261,7 +261,9 @@ def create_class_instances(
                 for k in index_point_source_model_list[band_index]
             ]
         if point_source_frame_list is not None:
-            warnings.warn("point_source_frame_list is unused in class_creator.create_class_instances()")
+            warnings.warn(
+                "point_source_frame_list is unused in class_creator.create_class_instances()"
+            )
             point_source_frame_list_i = [
                 point_source_frame_list[k]
                 for k in index_point_source_model_list[band_index]

--- a/lenstronomy/Util/kernel_util.py
+++ b/lenstronomy/Util/kernel_util.py
@@ -553,7 +553,7 @@ def estimate_amp(data, x_pos, y_pos, psf_kernel):
     numPix_x, numPix_y = np.shape(data)
     x_int = int(round(x_pos - 0.49999))
     y_int = int(round(y_pos - 0.49999))
-    # TODO: make amplitude estimate not sucebtible to rounding effects on which pixels to chose to estimate the amplitude
+    # TODO: make amplitude estimate not susceptible to rounding effects on which pixels to chose to estimate the amplitude
     if x_int > 2 and x_int < numPix_x - 2 and y_int > 2 and y_int < numPix_y - 2:
         mean_image = max(np.sum(data[y_int - 2 : y_int + 3, x_int - 2 : x_int + 3]), 0)
         num = len(psf_kernel)

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -35,7 +35,7 @@ class TestPointSource(object):
             lens_model=lensModel,
             fixed_magnification_list=[False] * 3,
             additional_images_list=[False] * 4,
-            flux_from_point_source_list=[True, True, True],
+            flux_from_point_source_list=[True, False, True],
             index_lens_model_list=[[0]],
             point_source_frame_list=[[0] * len(self.x_pos), [0], [0]],
         )
@@ -82,7 +82,7 @@ class TestPointSource(object):
 
     def test_num_basis(self):
         num_basis = self.PointSource.num_basis(self.kwargs_ps, self.kwargs_lens)
-        assert num_basis == 9
+        assert num_basis == 8
 
     def test_linear_response_set(self):
         ra_pos, dec_pos, amp, n = self.PointSource.linear_response_set(
@@ -145,8 +145,10 @@ class TestPointSource(object):
         amp_list = [np.ones_like(self.x_pos) * 20, [100], np.ones_like(self.x_pos) * 10]
         kwargs_out = self.PointSource.set_amplitudes(amp_list, self.kwargs_ps)
         assert kwargs_out[0]["point_amp"][0] == 10 * self.kwargs_ps[0]["point_amp"][0]
-        assert kwargs_out[1]["point_amp"][0] == 10 * self.kwargs_ps[1]["point_amp"][0]
         assert kwargs_out[2]["point_amp"][3] == 10 * self.kwargs_ps[2]["point_amp"][3]
+        
+        # Since flux_from_point_source = False for this model, its amplitudes aren't updated
+        assert kwargs_out[1]["point_amp"][0] == self.kwargs_ps[1]["point_amp"][0]
 
     def test_update_search_window(self):
         search_window = 5

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -111,7 +111,7 @@ class TestPointSource(object):
             self.kwargs_ps, self.kwargs_lens
         )
         assert ra_list[0] == self.x_pos[0]
-        assert len(ra_list) == 9
+        assert len(ra_list) == 8
 
         ra_list, dec_list, amp_list = self.PointSource.point_source_list(
             self.kwargs_ps, self.kwargs_lens, k=0
@@ -146,7 +146,7 @@ class TestPointSource(object):
         kwargs_out = self.PointSource.set_amplitudes(amp_list, self.kwargs_ps)
         assert kwargs_out[0]["point_amp"][0] == 10 * self.kwargs_ps[0]["point_amp"][0]
         assert kwargs_out[2]["point_amp"][3] == 10 * self.kwargs_ps[2]["point_amp"][3]
-        
+
         # Since flux_from_point_source = False for this model, its amplitudes aren't updated
         assert kwargs_out[1]["point_amp"][0] == self.kwargs_ps[1]["point_amp"][0]
 

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -45,16 +45,27 @@ class TestClassCreator(object):
             "lens_light_model_list": ["SERSIC"],
             "point_source_model_list": ["LENSED_POSITION"],
         }
+
+        # Band 0: SIS + SHEAR, SERSIC, SERSIC, LENSED_POSITION 1 + UNLENSED
+        # Band 1: EPL + SHEAR, SERSIC, SERSIC, UNLENSED + LENSED_POSITION 2
+        # LENSED_POSITION 1 will have a point_source_frame_list of [0, 1], indicating that
+        # it has two images, where the first image comes from being lensed by the lens models in band 0
+        # and the second image comes from being lensed by the lens models in band 1
+        # LENSED_POSITION 2 will have a point_source_frame_list of [1, 0, 1], indicating that it has
+        # three images, where the first and third images come from being lensed by the lens models in
+        # band 1 and the second image comes from being lensed by the lens models in band 0
         self.kwargs_model_3 = {
-            "lens_model_list": ["SIS"],
+            "lens_model_list": ["SIS", "EPL", "SHEAR"],
             "source_light_model_list": ["SERSIC"],
             "lens_light_model_list": ["SERSIC"],
-            "point_source_model_list": ["LENSED_POSITION"],
-            "index_lens_model_list": [[0]],
-            "index_source_light_model_list": [[0]],
-            "index_lens_light_model_list": [[0]],
-            "index_point_source_model_list": [[0]],
-            "point_source_frame_list": [[0]],
+            "point_source_model_list": ["LENSED_POSITION", "UNLENSED", "LENSED_POSITION"],
+            "index_lens_model_list": [[0, 2], [1, 2]],
+            "index_source_light_model_list": [[0], [0]],
+            "index_lens_light_model_list": [[0], [0]],
+            "index_point_source_model_list": [[0, 1], [1, 2]],
+            "point_source_frame_list": [[0, 1], None, [1, 0, 1]],
+            "point_source_redshift_list": [0.5, 1, 1.5],
+            "band_index": 1
         }
         self.kwargs_model_4 = {
             "lens_model_list": ["SIS", "SIS"],
@@ -145,7 +156,22 @@ class TestClassCreator(object):
             point_source_class,
             extinction_class,
         ) = class_creator.create_class_instances(**self.kwargs_model_3)
-        assert lens_model_class.lens_model_list[0] == "SIS"
+
+        # Since band index = 1, we should only have the EPL and SHEAR lens models
+        assert lens_model_class.lens_model_list[0] == "EPL"
+        assert lens_model_class.lens_model_list[1] == "SHEAR"
+
+        # The point source class should have access to the full lens model list
+        assert point_source_class._lens_model.lens_model_list == ["SIS", "EPL", "SHEAR"]
+
+        # Since band index = 1, we should only have the UNLENSED and second LENSED_POSITION lens models
+        assert point_source_class.point_source_type_list[0] == "UNLENSED"
+        assert point_source_class.point_source_type_list[1] == "LENSED_POSITION"
+        assert point_source_class._redshift_list == [1, 1.5]
+
+        # Since we assigned LENSED_POSITION 2 with a point_source_frame_list of [1, 0, 1]
+        # the three images should correspond to lens models [[1, 2], [0, 2], [1, 2]]
+        assert point_source_class._point_source_list[1]._model.k_list == [[1, 2], [0, 2], [1, 2]]
 
         (
             lens_model_class,

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -58,14 +58,18 @@ class TestClassCreator(object):
             "lens_model_list": ["SIS", "EPL", "SHEAR"],
             "source_light_model_list": ["SERSIC"],
             "lens_light_model_list": ["SERSIC"],
-            "point_source_model_list": ["LENSED_POSITION", "UNLENSED", "LENSED_POSITION"],
+            "point_source_model_list": [
+                "LENSED_POSITION",
+                "UNLENSED",
+                "LENSED_POSITION",
+            ],
             "index_lens_model_list": [[0, 2], [1, 2]],
             "index_source_light_model_list": [[0], [0]],
             "index_lens_light_model_list": [[0], [0]],
             "index_point_source_model_list": [[0, 1], [1, 2]],
             "point_source_frame_list": [[0, 1], None, [1, 0, 1]],
             "point_source_redshift_list": [0.5, 1, 1.5],
-            "band_index": 1
+            "band_index": 1,
         }
         self.kwargs_model_4 = {
             "lens_model_list": ["SIS", "SIS"],
@@ -171,7 +175,11 @@ class TestClassCreator(object):
 
         # Since we assigned LENSED_POSITION 2 with a point_source_frame_list of [1, 0, 1]
         # the three images should correspond to lens models [[1, 2], [0, 2], [1, 2]]
-        assert point_source_class._point_source_list[1]._model.k_list == [[1, 2], [0, 2], [1, 2]]
+        assert point_source_class._point_source_list[1]._model.k_list == [
+            [1, 2],
+            [0, 2],
+            [1, 2],
+        ]
 
         (
             lens_model_class,

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -280,7 +280,7 @@ class TestRaise(unittest.TestCase):
                 point_source_model_list=["UNLENSED", "LENSED_POSITION"],
                 index_point_source_model_list=[[0], [1]],
                 point_source_frame_list=[None, [1, 0]],
-                band_index=1
+                band_index=1,
             )
 
 

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -168,7 +168,7 @@ class TestClassCreator(object):
         # The point source class should have access to the full lens model list
         assert point_source_class._lens_model.lens_model_list == ["SIS", "EPL", "SHEAR"]
 
-        # Since band index = 1, we should only have the UNLENSED and second LENSED_POSITION lens models
+        # Since band index = 1, we should only have the UNLENSED and second LENSED_POSITION point source models
         assert point_source_class.point_source_type_list[0] == "UNLENSED"
         assert point_source_class.point_source_type_list[1] == "LENSED_POSITION"
         assert point_source_class._redshift_list == [1, 1.5]


### PR DESCRIPTION
1. Fixed a bug in the PointSource class where a shape/size mismatch can occur in the point_source_list() function in situations where flux_from_point_source is False. This occurs because the image_position() and image_amplitude() will return different size lists, since the check for flux_from_point_source occurs in image_amplitude() but not image_position(). This has been changed so that image_amplitude() will also return the amplitudes of point sources when flux_from_point_source is False, but their values are set to 0.
2. Removed point_source_frame_list functionality from create_class_instances() since it was not working properly before
3. Fixed a bug in create_class_instances() where point_source_redshift_list was not being downselected by the band index before being passed into PointSource.
4. Got rid of flux_from_point_source_list argument in create_class_instances() since you can already downselect point source models by including or excluding them in the bands
5. Changed truncation to truncation_conv in the Numerics class and updated its docstring to better indicate its intended usage.