### PR TITLE
Adds the NIRCam bands of COSMOS-Web

### DIFF
--- a/lenstronomy/SimulationAPI/ObservationConfig/JWST.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/JWST.py
@@ -8,6 +8,13 @@ import lenstronomy.Util.util as util
 
 __all__ = ["JWST"]
 
+# - keyword exposure_time: exposure time per image (in seconds)
+# - keyword sky_brightness: sky brightness (in magnitude per square arcseconds in units of electrons)
+# - keyword magnitude_zero_point: magnitude in which 1 count (e-) per second per arcsecond square is registered
+# - keyword num_exposures: number of exposures that are combined (depends on coadd_years)
+# - keyword seeing: Full-Width-at-Half-Maximum (FWHM) of PSF
+# - keyword psf_type: string, type of PSF ('GAUSSIAN' and 'PIXEL' supported)
+
 
 NIRCAM_F200W_band_obs = {
     "exposure_time": 3600.0,
@@ -19,7 +26,6 @@ NIRCAM_F200W_band_obs = {
     "psf_type": "PIXEL",
 }
 
-
 NIRCAM_F356W_band_obs = {
     "exposure_time": 3600.0,
     "sky_brightness": 28.39,  # this is derived using the ETC
@@ -30,12 +36,42 @@ NIRCAM_F356W_band_obs = {
     "psf_type": "PIXEL",  # note kernel_point_source (the PSF map) must be provided separately
 }
 
-# - keyword exposure_time: exposure time per image (in seconds)
-# - keyword sky_brightness: sky brightness (in magnitude per square arcseconds in units of electrons)
-# - keyword magnitude_zero_point: magnitude in which 1 count (e-) per second per arcsecond square is registered
-# - keyword num_exposures: number of exposures that are combined (depends on coadd_years)
-# - keyword seeing: Full-Width-at-Half-Maximum (FWHM) of PSF
-# - keyword psf_type: string, type of PSF ('GAUSSIAN' and 'PIXEL' supported)
+# for COSMOS-Web observations
+NIRCAM_F115W_band_obs = {
+    "exposure_time": 257,
+    "sky_brightness": 30.96,  
+    "magnitude_zero_point": 28.02,
+    "num_exposures": 8,
+    "seeing": 0.04, # PSF FWHM
+    "psf_type": "PIXEL",
+}
+
+NIRCAM_F150W_band_obs = {
+    "exposure_time": 257,
+    "sky_brightness": 29.96, 
+    "magnitude_zero_point": 28.02,
+    "num_exposures": 8,
+    "seeing": 0.05,
+    "psf_type": "PIXEL",
+}
+
+NIRCAM_F277W_band_obs = {
+    "exposure_time": 257,
+    "sky_brightness": 28.96,  
+    "magnitude_zero_point": 26.49,
+    "num_exposures": 8,
+    "seeing": 0.092,
+    "psf_type": "PIXEL",
+}
+
+NIRCAM_F444W_band_obs = {
+    "exposure_time": 257,
+    "sky_brightness": 28.15, 
+    "magnitude_zero_point": 26.49,
+    "num_exposures": 8,
+    "seeing": 0.145,
+    "psf_type": "PIXEL",
+}
 
 
 class JWST(object):
@@ -44,7 +80,7 @@ class JWST(object):
     def __init__(self, band="F200W", psf_type="PIXEL", coadd_years=None):
         """
 
-        :param band: string, 'F200W' or 'F356W' supported. Determines obs dictionary.
+        :param band: string, 'F115W', 'F150W', 'F200W', 'F277W', 'F356W' or 'F444W' supported. Determines obs dictionary.
         :param psf_type: string, type of PSF ('GAUSSIAN', 'PIXEL' supported).
         :param coadd_years: int, number of years corresponding to num_exposures in obs dict. Currently supported: None.
         """
@@ -55,7 +91,18 @@ class JWST(object):
         elif band == "F356W":
             self.obs = NIRCAM_F356W_band_obs
             self.arm = "long"
-
+        elif band=="F115W":
+            self.obs = NIRCAM_F115W_band_obs
+            self.arm = "short"
+        elif band=="F150W":
+            self.obs = NIRCAM_F150W_band_obs
+            self.arm = "short"
+        elif band=="F277W":
+            self.obs = NIRCAM_F277W_band_obs
+            self.arm = "long"
+        elif band=="F444W":
+            self.obs = NIRCAM_F444W_band_obs
+            self.arm = "long"
         else:
             raise ValueError("band %s not supported!" % band)
 

--- a/lenstronomy/SimulationAPI/ObservationConfig/JWST.py
+++ b/lenstronomy/SimulationAPI/ObservationConfig/JWST.py
@@ -39,16 +39,16 @@ NIRCAM_F356W_band_obs = {
 # for COSMOS-Web observations
 NIRCAM_F115W_band_obs = {
     "exposure_time": 257,
-    "sky_brightness": 30.96,  
+    "sky_brightness": 30.96,
     "magnitude_zero_point": 28.02,
     "num_exposures": 8,
-    "seeing": 0.04, # PSF FWHM
+    "seeing": 0.04,  # PSF FWHM
     "psf_type": "PIXEL",
 }
 
 NIRCAM_F150W_band_obs = {
     "exposure_time": 257,
-    "sky_brightness": 29.96, 
+    "sky_brightness": 29.96,
     "magnitude_zero_point": 28.02,
     "num_exposures": 8,
     "seeing": 0.05,
@@ -57,7 +57,7 @@ NIRCAM_F150W_band_obs = {
 
 NIRCAM_F277W_band_obs = {
     "exposure_time": 257,
-    "sky_brightness": 28.96,  
+    "sky_brightness": 28.96,
     "magnitude_zero_point": 26.49,
     "num_exposures": 8,
     "seeing": 0.092,
@@ -66,7 +66,7 @@ NIRCAM_F277W_band_obs = {
 
 NIRCAM_F444W_band_obs = {
     "exposure_time": 257,
-    "sky_brightness": 28.15, 
+    "sky_brightness": 28.15,
     "magnitude_zero_point": 26.49,
     "num_exposures": 8,
     "seeing": 0.145,
@@ -91,16 +91,16 @@ class JWST(object):
         elif band == "F356W":
             self.obs = NIRCAM_F356W_band_obs
             self.arm = "long"
-        elif band=="F115W":
+        elif band == "F115W":
             self.obs = NIRCAM_F115W_band_obs
             self.arm = "short"
-        elif band=="F150W":
+        elif band == "F150W":
             self.obs = NIRCAM_F150W_band_obs
             self.arm = "short"
-        elif band=="F277W":
+        elif band == "F277W":
             self.obs = NIRCAM_F277W_band_obs
             self.arm = "long"
-        elif band=="F444W":
+        elif band == "F444W":
             self.obs = NIRCAM_F444W_band_obs
             self.arm = "long"
         else:

--- a/test/test_SimulationAPI/test_ObservationConfig/test_JWST.py
+++ b/test/test_SimulationAPI/test_ObservationConfig/test_JWST.py
@@ -10,10 +10,10 @@ class TestJWST(unittest.TestCase):
         self.F356W = JWST(band="F356W")
         self.F356W2 = JWST(band="F356W", psf_type="GAUSSIAN")
 
-        self.F115W = JWST(band='F115W')
-        self.F150W = JWST(band='F150W')
-        self.F277W = JWST(band='F277W')
-        self.F444W = JWST(band='F444W')
+        self.F115W = JWST(band="F115W")
+        self.F150W = JWST(band="F150W")
+        self.F277W = JWST(band="F277W")
+        self.F444W = JWST(band="F444W")
 
         kwargs_F200W = self.F200W.kwargs_single_band()
         kwargs_F356W = self.F356W.kwargs_single_band()
@@ -24,7 +24,6 @@ class TestJWST(unittest.TestCase):
         kwargs_F277W = self.F277W.kwargs_single_band()
         kwargs_F444W = self.F444W.kwargs_single_band()
 
-
         self.F200W_band = SingleBand(**kwargs_F200W)
         self.F356W_band = SingleBand(**kwargs_F356W)
         self.F356W2_band = SingleBand(**kwargs_F356W2)
@@ -33,7 +32,6 @@ class TestJWST(unittest.TestCase):
         self.F150W_band = SingleBand(**kwargs_F150W)
         self.F277W_band = SingleBand(**kwargs_F277W)
         self.F444W_band = SingleBand(**kwargs_F444W)
-
 
         # dictionaries mapping JWST kwargs to SingleBand kwargs
         self.camera_settings = {

--- a/test/test_SimulationAPI/test_ObservationConfig/test_JWST.py
+++ b/test/test_SimulationAPI/test_ObservationConfig/test_JWST.py
@@ -10,13 +10,30 @@ class TestJWST(unittest.TestCase):
         self.F356W = JWST(band="F356W")
         self.F356W2 = JWST(band="F356W", psf_type="GAUSSIAN")
 
+        self.F115W = JWST(band='F115W')
+        self.F150W = JWST(band='F150W')
+        self.F277W = JWST(band='F277W')
+        self.F444W = JWST(band='F444W')
+
         kwargs_F200W = self.F200W.kwargs_single_band()
         kwargs_F356W = self.F356W.kwargs_single_band()
         kwargs_F356W2 = self.F356W2.kwargs_single_band()
 
+        kwargs_F115W = self.F115W.kwargs_single_band()
+        kwargs_F150W = self.F150W.kwargs_single_band()
+        kwargs_F277W = self.F277W.kwargs_single_band()
+        kwargs_F444W = self.F444W.kwargs_single_band()
+
+
         self.F200W_band = SingleBand(**kwargs_F200W)
         self.F356W_band = SingleBand(**kwargs_F356W)
         self.F356W2_band = SingleBand(**kwargs_F356W2)
+
+        self.F115W_band = SingleBand(**kwargs_F115W)
+        self.F150W_band = SingleBand(**kwargs_F150W)
+        self.F277W_band = SingleBand(**kwargs_F277W)
+        self.F444W_band = SingleBand(**kwargs_F444W)
+
 
         # dictionaries mapping JWST kwargs to SingleBand kwargs
         self.camera_settings = {
@@ -75,6 +92,26 @@ class TestJWST(unittest.TestCase):
             self.assertEqual(
                 self.F356W2.obs[config],
                 getattr(self.F356W2_band, setting),
+                msg=f"{config} did not match",
+            )
+            self.assertEqual(
+                self.F115W.obs[config],
+                getattr(self.F115W_band, setting),
+                msg=f"{config} did not match",
+            )
+            self.assertEqual(
+                self.F150W.obs[config],
+                getattr(self.F150W_band, setting),
+                msg=f"{config} did not match",
+            )
+            self.assertEqual(
+                self.F277W.obs[config],
+                getattr(self.F277W_band, setting),
+                msg=f"{config} did not match",
+            )
+            self.assertEqual(
+                self.F444W.obs[config],
+                getattr(self.F444W_band, setting),
                 msg=f"{config} did not match",
             )
 


### PR DESCRIPTION
This PR adds the NIRCam bands used in COSMOS-Web for the COSMOS-Web Lens Survey ([COWLS I](https://arxiv.org/abs/2503.08777), [COWLS II](https://arxiv.org/abs/2503.08782), [COWLS III](https://arxiv.org/abs/2503.08785)).