### PR TITLE
Implement ability to use jaxtronomy profiles in lenstronomy

### DIFF
--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -35,6 +35,7 @@ class MultiPlane(object):
         distance_ratio_sampling=False,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
+        use_jax=False,
     ):
         """
 
@@ -63,6 +64,7 @@ class MultiPlane(object):
             distance ratios to update T_ij value in multi-lens plane computation.
         :param cosmology_sampling: bool, if True, will use sampled cosmology
         :param cosmology_model: str, name of the cosmology model to use for
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
         """
         self.cosmology_sampling = cosmology_sampling
         self.cosmology_model = cosmology_model
@@ -137,6 +139,7 @@ class MultiPlane(object):
             z_interp_stop=z_interp_stop,
             num_z_interp=num_z_interp,
             profile_kwargs_list=profile_kwargs_list,
+            use_jax=use_jax,
         )
         self._z_source = z_source
         self._set_source_distances(z_source)

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -64,7 +64,8 @@ class MultiPlane(object):
             distance ratios to update T_ij value in multi-lens plane computation.
         :param cosmology_sampling: bool, if True, will use sampled cosmology
         :param cosmology_model: str, name of the cosmology model to use for
-        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
+            Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
         self.cosmology_sampling = cosmology_sampling
         self.cosmology_model = cosmology_model

--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -23,6 +23,7 @@ class MultiPlaneBase(ProfileListBase):
         z_interp_stop=None,
         num_z_interp=100,
         profile_kwargs_list=None,
+        use_jax=False,
     ):
         """
         A description of the recursive multi-plane formalism can be found e.g. here: https://arxiv.org/abs/1312.1536
@@ -35,6 +36,7 @@ class MultiPlaneBase(ProfileListBase):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
         """
         self._lens_model_list = lens_model_list
 
@@ -63,6 +65,7 @@ class MultiPlaneBase(ProfileListBase):
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
             profile_kwargs_list=profile_kwargs_list,
+            use_jax=use_jax,
         )
 
         if len(self._lens_model_list) < 1:

--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -36,7 +36,8 @@ class MultiPlaneBase(ProfileListBase):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
-        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
+            Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
         self._lens_model_list = lens_model_list
 

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -77,7 +77,8 @@ class LensModel(object):
             to update T_ij value in multi-lens plane computation.
         :param cosmology_model: str, name of the cosmology model to be used for
             cosmology sampling. Default is 'FlatLambdaCDM'.
-        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
+            Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
             Only supported for MultiPlane() and SinglePlane() at the moment
         """
         self.lens_model_list = lens_model_list

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -41,6 +41,7 @@ class LensModel(object):
         distance_ratio_sampling=False,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
+        use_jax=False,
     ):
         """
 
@@ -76,6 +77,8 @@ class LensModel(object):
             to update T_ij value in multi-lens plane computation.
         :param cosmology_model: str, name of the cosmology model to be used for
             cosmology sampling. Default is 'FlatLambdaCDM'.
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
+            Only supported for MultiPlane() and SinglePlane() at the moment
         """
         self.lens_model_list = lens_model_list
         self.z_lens = z_lens
@@ -197,6 +200,7 @@ class LensModel(object):
                     distance_ratio_sampling=distance_ratio_sampling,
                     cosmology_sampling=cosmology_sampling,
                     cosmology_model=cosmology_model,
+                    use_jax=use_jax,
                 )
                 self.type = "MultiPlane"
 
@@ -225,6 +229,7 @@ class LensModel(object):
                     lens_redshift_list=lens_redshift_list,
                     z_source_convention=z_source_convention,
                     profile_kwargs_list=profile_kwargs_list,
+                    use_jax=use_jax
                 )
                 self.type = "SinglePlane"
                 if z_source is not None and z_source_convention is not None:

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -230,7 +230,7 @@ class LensModel(object):
                     lens_redshift_list=lens_redshift_list,
                     z_source_convention=z_source_convention,
                     profile_kwargs_list=profile_kwargs_list,
-                    use_jax=use_jax
+                    use_jax=use_jax,
                 )
                 self.type = "SinglePlane"
                 if z_source is not None and z_source_convention is not None:

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -174,7 +174,7 @@ class ProfileListBase(object):
             lens_redshift_list = [None] * len(lens_model_list)
         if profile_kwargs_list is None:
             profile_kwargs_list = [{} for _ in range(len(lens_model_list))]
-        
+
         # use_jax can be either a bool or list of bools to select specific models to be imported from jaxtronomy
         # If it's a bool, convert to list of bools
         if isinstance(use_jax, bool):

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -170,6 +170,7 @@ class ProfileListBase(object):
         self._param_name_list = name_list
 
     def _load_model_instances(
+        self,
         lens_model_list,
         profile_kwargs_list=None,
         lens_redshift_list=None,

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -144,23 +144,16 @@ class ProfileListBase(object):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
-        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
+            Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
-        if use_jax:
-            from jaxtronomy.LensModel.profile_list_base import ProfileListBase as ProfileListBase_JAX
-            self.func_list = ProfileListBase_JAX._load_model_instances(
-                lens_model_list,
-                profile_kwargs_list=profile_kwargs_list,
-                lens_redshift_list=lens_redshift_list,
-                z_source_convention=z_source_convention,
-            )
-        else:
-            self.func_list = self._load_model_instances(
-                lens_model_list,
-                profile_kwargs_list=profile_kwargs_list,
-                lens_redshift_list=lens_redshift_list,
-                z_source_convention=z_source_convention,
-            )
+        self.func_list = self._load_model_instances(
+            lens_model_list,
+            profile_kwargs_list=profile_kwargs_list,
+            lens_redshift_list=lens_redshift_list,
+            z_source_convention=z_source_convention,
+            use_jax=use_jax,
+        )
         self._num_func = len(self.func_list)
         self._model_list = lens_model_list
 
@@ -175,11 +168,17 @@ class ProfileListBase(object):
         profile_kwargs_list=None,
         lens_redshift_list=None,
         z_source_convention=None,
+        use_jax=False,
     ):
         if lens_redshift_list is None:
             lens_redshift_list = [None] * len(lens_model_list)
         if profile_kwargs_list is None:
             profile_kwargs_list = [{} for _ in range(len(lens_model_list))]
+        if use_jax is True or use_jax is False:
+            use_jax = [use_jax] * len(lens_model_list)
+        if True in use_jax:
+            from jaxtronomy.LensModel.profile_list_base import lens_class as lens_class_jax
+
         func_list = []
         imported_classes = []
         imported_profile_kwargs = []
@@ -187,10 +186,14 @@ class ProfileListBase(object):
             if lens_type in ["NFW_MC", "NFW_MC_ELLIPSE_POTENTIAL"]:
                 profile_kwargs_list[i]["z_lens"] = lens_redshift_list[i]
                 profile_kwargs_list[i]["z_source"] = z_source_convention
+            if use_jax[i] is True:
+                init_lens_class = lens_class_jax
+            else:
+                init_lens_class = lens_class
 
             # Creates another instance for dynamic profiles
             if lens_type in DYNAMIC_PROFILES:
-                lensmodel_class = lens_class(
+                lensmodel_class = init_lens_class(
                     lens_type,
                     profile_kwargs=profile_kwargs_list[i],
                 )
@@ -198,7 +201,7 @@ class ProfileListBase(object):
             # already been created
             else:
                 if (lens_type, profile_kwargs_list[i]) not in imported_profile_kwargs:
-                    lensmodel_class = lens_class(
+                    lensmodel_class = init_lens_class(
                         lens_type,
                         profile_kwargs=profile_kwargs_list[i],
                     )

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -136,6 +136,7 @@ class ProfileListBase(object):
         profile_kwargs_list=None,
         lens_redshift_list=None,
         z_source_convention=None,
+        use_jax=False,
     ):
         """
 
@@ -143,18 +144,28 @@ class ProfileListBase(object):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
         """
-        self.func_list = self._load_model_instances(
-            lens_model_list,
-            profile_kwargs_list=profile_kwargs_list,
-            lens_redshift_list=lens_redshift_list,
-            z_source_convention=z_source_convention,
-        )
+        if use_jax:
+            from jaxtronomy.LensModel.profile_list_base import ProfileListBase as ProfileListBase_JAX
+            self.func_list = ProfileListBase_JAX._load_model_instances(
+                lens_model_list,
+                profile_kwargs_list=profile_kwargs_list,
+                lens_redshift_list=lens_redshift_list,
+                z_source_convention=z_source_convention,
+            )
+        else:
+            self.func_list = self._load_model_instances(
+                lens_model_list,
+                profile_kwargs_list=profile_kwargs_list,
+                lens_redshift_list=lens_redshift_list,
+                z_source_convention=z_source_convention,
+            )
         self._num_func = len(self.func_list)
         self._model_list = lens_model_list
 
+    @staticmethod
     def _load_model_instances(
-        self,
         lens_model_list,
         profile_kwargs_list=None,
         lens_redshift_list=None,

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -177,7 +177,9 @@ class ProfileListBase(object):
         if use_jax is True or use_jax is False:
             use_jax = [use_jax] * len(lens_model_list)
         if True in use_jax:
-            from jaxtronomy.LensModel.profile_list_base import lens_class as lens_class_jax
+            from jaxtronomy.LensModel.profile_list_base import (
+                lens_class as lens_class_jax,
+            )
 
         func_list = []
         imported_classes = []

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -174,7 +174,10 @@ class ProfileListBase(object):
             lens_redshift_list = [None] * len(lens_model_list)
         if profile_kwargs_list is None:
             profile_kwargs_list = [{} for _ in range(len(lens_model_list))]
-        if use_jax is True or use_jax is False:
+        
+        # use_jax can be either a bool or list of bools to select specific models to be imported from jaxtronomy
+        # If it's a bool, convert to list of bools
+        if isinstance(use_jax, bool):
             use_jax = [use_jax] * len(lens_model_list)
         if True in use_jax:
             from jaxtronomy.LensModel.profile_list_base import (

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -25,7 +25,8 @@ class SinglePlane(ProfileListBase):
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
         :param alpha_scaling: scaling factor of deflection angle relative to z_source_convention
-        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
+            Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
         self._alpha_scaling = alpha_scaling
         ProfileListBase.__init__(

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -16,6 +16,7 @@ class SinglePlane(ProfileListBase):
         lens_redshift_list=None,
         z_source_convention=None,
         alpha_scaling=1,
+        use_jax=False,
     ):
         """
 
@@ -24,6 +25,7 @@ class SinglePlane(ProfileListBase):
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
         :param alpha_scaling: scaling factor of deflection angle relative to z_source_convention
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy
         """
         self._alpha_scaling = alpha_scaling
         ProfileListBase.__init__(
@@ -32,6 +34,7 @@ class SinglePlane(ProfileListBase):
             profile_kwargs_list=profile_kwargs_list,
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
+            use_jax=use_jax,
         )
 
     def ray_shooting(self, x, y, kwargs, k=None):

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -6,7 +6,11 @@ import pytest
 from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.LensModel.MultiPlane.multi_plane import MultiPlane
 from lenstronomy.LensModel.Profiles.nfw import NFW
+from lenstronomy.LensModel.Profiles.tnfw import TNFW
 from lenstronomy.Util.util import make_grid
+
+from jaxtronomy.LensModel.Profiles.nfw import NFW as NFW_jax
+from jaxtronomy.LensModel.Profiles.tnfw import TNFW as TNFW_jax
 import unittest
 
 
@@ -67,6 +71,32 @@ class TestLensModel(object):
 
         lensModel = LensModel(lens_model_list, z_source_convention=5, z_lens=0.2)
         assert lensModel.z_source == 5
+
+    def test_use_jax(self):
+        lensModel = LensModel(["NFW", "TNFW"], use_jax=True)
+        assert isinstance(lensModel.lens_model.func_list[0], NFW_jax)
+        assert isinstance(lensModel.lens_model.func_list[1], TNFW_jax)
+
+        lensModel = LensModel(["NFW", "TNFW"], use_jax=[True, False])
+        assert isinstance(lensModel.lens_model.func_list[0], NFW_jax)
+        assert isinstance(lensModel.lens_model.func_list[1], TNFW)
+
+        lensModel = LensModel(["NFW", "TNFW"], use_jax=False)
+        assert isinstance(lensModel.lens_model.func_list[0], NFW)
+        assert isinstance(lensModel.lens_model.func_list[1], TNFW)
+
+        lensModel = LensModel(["NFW", "TNFW"], lens_redshift_list=[1, 1], z_source=1.3, multi_plane=True, use_jax=True)
+        assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW_jax)
+        assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW_jax)
+
+        lensModel = LensModel(["NFW", "TNFW"], lens_redshift_list=[1, 1], z_source=1.3, multi_plane=True, use_jax=[False, True])
+        assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW)
+        assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW_jax)
+
+        lensModel = LensModel(["NFW", "TNFW"], lens_redshift_list=[1, 1], z_source=1.3, multi_plane=True, use_jax=False)
+        assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW)
+        assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW)
+        
 
     def test_info(self):
         lens_model_list = [

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -85,18 +85,35 @@ class TestLensModel(object):
         assert isinstance(lensModel.lens_model.func_list[0], NFW)
         assert isinstance(lensModel.lens_model.func_list[1], TNFW)
 
-        lensModel = LensModel(["NFW", "TNFW"], lens_redshift_list=[1, 1], z_source=1.3, multi_plane=True, use_jax=True)
+        lensModel = LensModel(
+            ["NFW", "TNFW"],
+            lens_redshift_list=[1, 1],
+            z_source=1.3,
+            multi_plane=True,
+            use_jax=True,
+        )
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW_jax)
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW_jax)
 
-        lensModel = LensModel(["NFW", "TNFW"], lens_redshift_list=[1, 1], z_source=1.3, multi_plane=True, use_jax=[False, True])
+        lensModel = LensModel(
+            ["NFW", "TNFW"],
+            lens_redshift_list=[1, 1],
+            z_source=1.3,
+            multi_plane=True,
+            use_jax=[False, True],
+        )
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW)
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW_jax)
 
-        lensModel = LensModel(["NFW", "TNFW"], lens_redshift_list=[1, 1], z_source=1.3, multi_plane=True, use_jax=False)
+        lensModel = LensModel(
+            ["NFW", "TNFW"],
+            lens_redshift_list=[1, 1],
+            z_source=1.3,
+            multi_plane=True,
+            use_jax=False,
+        )
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW)
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW)
-        
 
     def test_info(self):
         lens_model_list = [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ colossus
 git+https://github.com/mattgomer/SKiNN@main#egg=SKiNN
 git+https://github.com/aymgal/coolest@main#egg=coolest
 git+https://gitlab.com/cosmograil/starred@main#egg=starred-astro
+git+https://github.com/lenstronomy/JAXtronomy


### PR DESCRIPTION
This PR allows the user to import deflector profiles from jaxtronomy instead of lenstronomy by setting the `use_jax` flag to `True` during the initialization of the `LensModel` class. This is useful in situations where it is not possible to use the full jaxtronomy `LensModel` class, for example when using PyHalo, the `LensModel` class will have tens of thousands of deflector profiles for dark matter substructure, leading to infinite compile time in jaxtronomy. This is due to how the JAX compiler handles `for` loops, leading to issues with the `for` loops in `SinglePlane` or `MultiPlaneBase` iterating through every profile.

This is hopefully a temporary solution until we figure out a clean way of doing it in jaxtronomy.