### PR TITLE
when use_jax flag is true, convert jax arrays back into np arrays

### DIFF
--- a/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -32,6 +32,7 @@ class MultiPlaneDecoupled(MultiPlane):
         alpha_x_interp_background=None,
         alpha_y_interp_background=None,
         z_split=None,
+        use_jax=False,
     ):
         """A class for multiplane lensing in which the deflection angles at certain
         coordinates are fixed through user-specified interpolation functions. These
@@ -62,6 +63,8 @@ class MultiPlaneDecoupled(MultiPlane):
             y-component of the deflection angle at (x,y)
         :param z_interp_list: a list of redshifts corresponding to the
             alpha_x_interp_list and alpha_y_interp_list entries
+        :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
+            Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
         self._alphax_interp_foreground = alpha_x_interp_foreground
         self._alphay_interp_foreground = alpha_y_interp_foreground
@@ -98,7 +101,7 @@ class MultiPlaneDecoupled(MultiPlane):
         self._Td = cosmo_bkg.T_xy(0, z_split)
         self._Tds = cosmo_bkg.T_xy(self._z_split, z_source)
         self._main_deflector = SinglePlane(
-            lens_model_list, profile_kwargs_list=profile_kwargs_list
+            lens_model_list, profile_kwargs_list=profile_kwargs_list, use_jax=use_jax
         )
         # useful to have these saved to access later outside the class
         self.kwargs_multiplane_model = {

--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -193,6 +193,8 @@ class MultiPlaneBase(ProfileListBase):
         alpha_x = np.array(alpha_x)
         alpha_y = np.array(alpha_y)
 
+        # NOTE: jax arrays are converted back into regular numpy arrays in cases where use_jax is True.
+
         z_lens_last = z_start
         first_deflector = True
         for i, idex in enumerate(self._sorted_redshift_index):
@@ -226,7 +228,7 @@ class MultiPlaneBase(ProfileListBase):
         else:
             delta_T = T_ij_end
         x, y = self._ray_step_add(x, y, alpha_x, alpha_y, delta_T)
-        return x, y, alpha_x, alpha_y
+        return x.__array__(), y.__array__(), alpha_x.__array__(), alpha_y.__array__()
 
     def ray_shooting_partial(
         self,
@@ -343,6 +345,9 @@ class MultiPlaneBase(ProfileListBase):
         y = np.zeros_like(theta_y, dtype=float)
         alpha_x = np.array(theta_x, dtype=float)
         alpha_y = np.array(theta_y, dtype=float)
+
+        # NOTE: jax arrays are converted back into regular numpy arrays in cases where use_jax is True.
+        
         i = 0
         z_lens_last = 0
         for i, index in enumerate(self._sorted_redshift_index):
@@ -383,7 +388,7 @@ class MultiPlaneBase(ProfileListBase):
             beta_i_x, beta_i_y, beta_j_x, beta_j_y, T_i, T_j, T_ij
         )
         dt_geo += dt_geo_new
-        return dt_geo, dt_grav
+        return dt_geo.__array__(), dt_grav.__array__()
 
     @staticmethod
     def _index_ordering(redshift_list):

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -79,7 +79,7 @@ class LensModel(object):
             cosmology sampling. Default is 'FlatLambdaCDM'.
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
-            Only supported for MultiPlane() and SinglePlane() at the moment
+            Only supported for MultiPlane(), MultiPlaneDecoupled(), and SinglePlane() at the moment
         """
         self.lens_model_list = lens_model_list
         self.z_lens = z_lens
@@ -182,6 +182,7 @@ class LensModel(object):
                     z_interp_stop=z_interp_stop,
                     num_z_interp=num_z_interp,
                     profile_kwargs_list=profile_kwargs_list,
+                    use_jax=use_jax,
                     **kwargs_multiplane_model
                 )
                 self.type = "MultiPlaneDecoupled"

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane_decoupled.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane_decoupled.py
@@ -378,6 +378,14 @@ class TestMultiPlaneDecoupled(object):
         npt.assert_allclose(beta_x_new, beta_x_true)
         npt.assert_allclose(beta_y_new, beta_y_true)
 
+        # Test use_jax
+        lens_model_decoupled = LensModel(use_jax=True, **self.kwargs_multiplane_model_point)
+        beta_x_new, beta_y_new = lens_model_decoupled.ray_shooting(
+            self.x_image[1], self.y_image[1], self.kwargs_lens_free
+        )
+        npt.assert_allclose(beta_x_new, beta_x_true)
+        npt.assert_allclose(beta_y_new, beta_y_true)
+
     def test_grid_deflection_model(self):
 
         # the true source coordinate

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -73,10 +73,29 @@ class TestLensModel(object):
         assert lensModel.z_source == 5
 
     def test_use_jax(self):
+        x = np.array([1.0, 2.0])
+        y = np.array([1.5, 2.5])
+        kwargs_lens = [{"Rs": 0.5, "alpha_Rs": 0.7}, {"Rs": 0.5, "alpha_Rs": 0.7, "r_trunc": 0.9}]
+
+        # Tests that the jaxtronomy profiles are being used
         lensModel = LensModel(["NFW", "TNFW"], use_jax=True)
         assert isinstance(lensModel.lens_model.func_list[0], NFW_jax)
         assert isinstance(lensModel.lens_model.func_list[1], TNFW_jax)
 
+        # Tests that the result is converted back from jax array to np array
+        result = lensModel.potential(x, y, kwargs_lens)
+        assert isinstance(result, np.ndarray)
+
+        resultx, resulty = lensModel.ray_shooting(x, y, kwargs_lens)
+        assert isinstance(resultx, np.ndarray) and isinstance(resulty, np.ndarray)
+
+        fxx, fxy, fyx, fyy = lensModel.hessian(x, y, kwargs_lens)
+        assert isinstance(fxx, np.ndarray)
+        assert isinstance(fxy, np.ndarray)
+        assert isinstance(fyx, np.ndarray)
+        assert isinstance(fyy, np.ndarray)
+
+        # Tests other options for use_jax
         lensModel = LensModel(["NFW", "TNFW"], use_jax=[True, False])
         assert isinstance(lensModel.lens_model.func_list[0], NFW_jax)
         assert isinstance(lensModel.lens_model.func_list[1], TNFW)
@@ -85,6 +104,7 @@ class TestLensModel(object):
         assert isinstance(lensModel.lens_model.func_list[0], NFW)
         assert isinstance(lensModel.lens_model.func_list[1], TNFW)
 
+        # Tests use_jax for multiplane
         lensModel = LensModel(
             ["NFW", "TNFW"],
             lens_redshift_list=[1, 1],
@@ -94,6 +114,19 @@ class TestLensModel(object):
         )
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[0], NFW_jax)
         assert isinstance(lensModel.lens_model.multi_plane_base.func_list[1], TNFW_jax)
+
+        # Tests that the result is converted back from jax array to np array
+        result = lensModel.arrival_time(x, y, kwargs_lens)
+        assert isinstance(result, np.ndarray)
+
+        resultx, resulty = lensModel.ray_shooting(x, y, kwargs_lens)
+        assert isinstance(resultx, np.ndarray) and isinstance(resulty, np.ndarray)
+
+        fxx, fxy, fyx, fyy = lensModel.hessian(x, y, kwargs_lens)
+        assert isinstance(fxx, np.ndarray)
+        assert isinstance(fxy, np.ndarray)
+        assert isinstance(fyx, np.ndarray)
+        assert isinstance(fyy, np.ndarray)
 
         lensModel = LensModel(
             ["NFW", "TNFW"],

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -88,11 +88,10 @@ class TestLensModel(object):
         # Tests that the result is converted back from jax array to np array
         result = lensModel.potential(x, y, kwargs_lens)
         assert isinstance(result, np.ndarray)
+        result = lensModel.potential(x, y, kwargs_lens, k=1)
+        assert isinstance(result, np.ndarray)
 
         resultx, resulty = lensModel.ray_shooting(x, y, kwargs_lens)
-        assert isinstance(resultx, np.ndarray) and isinstance(resulty, np.ndarray)
-
-        resultx, resulty = lensModel.ray_shooting(x, y, kwargs_lens, k=1)
         assert isinstance(resultx, np.ndarray) and isinstance(resulty, np.ndarray)
 
         fxx, fxy, fyx, fyy = lensModel.hessian(x, y, kwargs_lens)

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -89,6 +89,9 @@ class TestLensModel(object):
         resultx, resulty = lensModel.ray_shooting(x, y, kwargs_lens)
         assert isinstance(resultx, np.ndarray) and isinstance(resulty, np.ndarray)
 
+        resultx, resulty = lensModel.ray_shooting(x, y, kwargs_lens, k=1)
+        assert isinstance(resultx, np.ndarray) and isinstance(resulty, np.ndarray)
+
         fxx, fxy, fyx, fyy = lensModel.hessian(x, y, kwargs_lens)
         assert isinstance(fxx, np.ndarray)
         assert isinstance(fxy, np.ndarray)


### PR DESCRIPTION
This avoids errors in situations where specifically numpy arrays are needed. This does not have a noticeable impact on performance.

I also added the use_jax flag to the MultiPlaneDecoupled class.