### PR TITLE
add CUSTOM solver_type option for Solver4Point class

### DIFF
--- a/lenstronomy/LensModel/Solver/solver.py
+++ b/lenstronomy/LensModel/Solver/solver.py
@@ -9,18 +9,20 @@ class Solver(object):
     """Joint solve class to manage with type of solver to be executed and checks whether
     the requirements are fulfilled."""
 
-    def __init__(self, solver_type, lensModel, num_images):
+    def __init__(self, solver_type, lensModel, num_images, parameter_module=None):
         """
 
         :param solver_type: string, option for specific solver type
          see detailed instruction of the Solver4Point and Solver2Point classes
         :param lensModel: instance of a LensModel() class
         :param num_images: int, number of images to be solved for
+        :param parameter_module: a class to be used with solver_type that has routines to be used in the Solver4Point
+        module for parameter handling: extract_array, update_kwargs, and add_fixed_lens
         """
         self._num_images = num_images
         self._lensModel = lensModel
         if self._num_images == 4:
-            self._solver = Solver4Point(lensModel, solver_type=solver_type)
+            self._solver = Solver4Point(lensModel, solver_type=solver_type, parameter_module=parameter_module)
         elif self._num_images == 2:
             self._solver = Solver2Point(lensModel, solver_type=solver_type)
         else:

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -157,6 +157,7 @@ class Param(object):
         log_sampling_lens=[],
         distance_ratio_sampling=False,
         cosmology_sampling=False,
+        solver_param_module=None
     ):
         """
 
@@ -235,6 +236,8 @@ class Param(object):
          distance ratios to update T_ij value in multi-lens plane computation.
         :param cosmology_sampling: bool, if True, will use sampled cosmology
         :param cosmology_model: str, name of the cosmology model to use for
+        :param solver_param_module: a class that performs conversions update_kwargs, extract_array, and add_fixed_lens
+        for the Solver4Point class with the solver_type = 'CUSTOM' option
         """
 
         self._lens_model_list = kwargs_model.get("lens_model_list", [])
@@ -384,6 +387,7 @@ class Param(object):
                 solver_type=self._solver_type,
                 lensModel=self._lens_model_class,
                 num_images=self._num_images,
+                parameter_module=solver_param_module
             )
         source_model_list = self._source_light_model_list
         if len(source_model_list) != 1 or source_model_list[0] not in [


### PR DESCRIPTION
I add the possibility to specify solver_type = 'CUSTOM' with a user-specified class to handle parameters during the application of the solver in the Solver4Point class. The test function gives an example of how to use this methodology to enforce a fixed axis ratio q while still sampling in the e1/e2 basis with an elliptical power law profile.  