### PR TITLE
KinematicsAPI compatible with multiple IFU observations

### DIFF
--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -230,8 +230,8 @@ class KinematicsAPI(object):
                     kwargs_anisotropy,
                     supersampling_factor=supersampling_factor,
                     voronoi_bins=voronoi_bins,
-                    )
-                print(np.shape(sigma_v_map_), 'test sigma_v_map IFU_grid')
+                )
+                print(np.shape(sigma_v_map_), "test sigma_v_map IFU_grid")
             else:
                 sigma_v_map_ = galkin[i].dispersion_map(
                     kwargs_profile,

--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -56,7 +56,7 @@ class KinematicsAPI(object):
             default cosmology
         :param lens_model_kinematics_bool: bool list of length of the lens model. Only
             takes a subset of all the models as part of the kinematics computation (
-            can be used to ignore substructure, shear etc that do not describe the
+            can be used to ignore substructure, shear etc. that do not describe the
             main deflector potential
         :param light_model_kinematics_bool: bool list of length of the light model. Only
             takes a subset of all the models as part of the kinematics computation (can
@@ -231,7 +231,6 @@ class KinematicsAPI(object):
                     supersampling_factor=supersampling_factor,
                     voronoi_bins=voronoi_bins,
                 )
-                print(np.shape(sigma_v_map_), "test sigma_v_map IFU_grid")
             else:
                 sigma_v_map_ = galkin[i].dispersion_map(
                     kwargs_profile,

--- a/lenstronomy/Analysis/td_cosmography.py
+++ b/lenstronomy/Analysis/td_cosmography.py
@@ -183,7 +183,6 @@ class TDCosmography(KinematicsAPI):
         r_eff=None,
         theta_E=None,
         gamma=None,
-        direct_convolve=False,
         supersampling_factor=1,
         voronoi_bins=None,
     ):
@@ -200,7 +199,6 @@ class TDCosmography(KinematicsAPI):
         :param r_eff: projected half-light radius of the stellar light associated
             with the deflector galaxy, optional, if set to None will be computed in this
             function with default settings that may not be accurate.
-        :param direct_convolve: bool, if True, compute the 2D integral numerically
         :param supersampling_factor: supersampling factor for 2D integration grid
         :param voronoi_bins: mapping of the voronoi bins, -1 values for  pixels not
             binned
@@ -213,7 +211,6 @@ class TDCosmography(KinematicsAPI):
             r_eff=r_eff,
             theta_E=theta_E,
             gamma=gamma,
-            direct_convolve=direct_convolve,
             supersampling_factor=supersampling_factor,
             voronoi_bins=voronoi_bins,
         )

--- a/lenstronomy/ImSim/image_model.py
+++ b/lenstronomy/ImSim/image_model.py
@@ -674,7 +674,7 @@ class ImageModel(object):
 
     def _error_map_model(self, kwargs_lens, kwargs_ps, kwargs_special=None):
         """Noise estimate (variances as diagonal of the pixel covariance matrix)
-        resulted from inherent model uncertainties This term is currently the psf error
+        resulted from inherent model uncertainties. This term is currently the psf error
         map.
 
         :param kwargs_lens: lens model keyword arguments

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -163,7 +163,6 @@ class TestKinematicsAPI(object):
         vel_disp_temp = kinematicAPI.velocity_dispersion_analytical(
             theta_E, gamma, r_ani=r_ani, r_eff=r_eff
         )
-        print(v_sigma, vel_disp_temp)
         # assert 1 == 0
         npt.assert_almost_equal(v_sigma / vel_disp_temp, 1, decimal=1)
         npt.assert_almost_equal(v_sigma_mge_lens / v_sigma, 1, decimal=1)
@@ -613,7 +612,6 @@ class TestKinematicsAPI(object):
             supersampling_factor=5,
             voronoi_bins=None,
         )
-        print(np.shape(vel_dis), "test vel_disp")
 
         jampy_vel_dis = np.array(
             [
@@ -926,7 +924,6 @@ class TestKinematicsAPI(object):
             theta_E=theta_E,
             gamma=2,
         )
-        print(vel_disp_numerical, vel_disp_analytic)
         npt.assert_almost_equal(vel_disp_numerical, vel_disp_analytic, decimal=-1)
 
         z_lens = 0.5

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -610,10 +610,10 @@ class TestKinematicsAPI(object):
             theta_E=kwargs_lens[0]["theta_E"],
             gamma=kwargs_lens[0]["gamma"],
             kappa_ext=0,
-            direct_convolve=True,
             supersampling_factor=5,
             voronoi_bins=None,
         )
+        print(np.shape(vel_dis), 'test vel_disp')
 
         jampy_vel_dis = np.array(
             [
@@ -843,7 +843,8 @@ class TestKinematicsAPI(object):
                 ],
             ]
         )
-
+        n = int(np.sqrt(len(vel_dis)))
+        vel_dis = vel_dis.reshape(int(n), int(n))
         assert np.max(np.abs(jampy_vel_dis / vel_dis[14:28, 14:28] - 1)) < 0.009
 
     def test_velocity_dispersion_map(self):
@@ -954,14 +955,12 @@ class TestKinematicsAPI(object):
             [{"theta_E": 1, "center_x": 0, "center_y": 0}],
             [{"Rs": 1, "amp": 1, "center_x": 0, "center_y": 0}],
             {"r_ani": 1},
-            direct_convolve=False,
         )
 
         kin_api.velocity_dispersion_map(
             [{"theta_E": 1, "center_x": 0, "center_y": 0}],
             [{"Rs": 1, "amp": 1, "center_x": 0, "center_y": 0}],
             {"r_ani": 1},
-            direct_convolve=True,
         )
 
     def test_interpolated_sersic(self):
@@ -1109,34 +1108,6 @@ class TestKinematicsAPI(object):
 
 class TestRaise(unittest.TestCase):
     def test_raise(self):
-        with self.assertRaises(ValueError):
-            # self._kwargs_aperture_kin["aperture_type"] != "IFU_grid":
-            z_lens = 0.5
-            z_source = 1.5
-            kwargs_model = {
-                "lens_model_list": ["SIS"],
-                "lens_light_model_list": ["HERNQUIST"],
-            }
-
-            kwargs_aperture = {
-                "aperture_type": "slit",
-                "length": 1,
-                "width": 1,
-            }
-            kinematicAPI = KinematicsAPI(
-                z_lens,
-                z_source,
-                kwargs_model,
-                kwargs_seeing={"psf_type": "GAUSSIAN", "fwhm": 0.7},
-                kwargs_aperture=kwargs_aperture,
-                anisotropy_model="OM",
-            )
-            kinematicAPI.velocity_dispersion_map(
-                [{"theta_E": 1, "center_x": 0, "center_y": 0}],
-                [{"Rs": 1, "amp": 1, "center_x": 0, "center_y": 0}],
-                {"r_ani": 1},
-                direct_convolve=True,
-            )
 
         with self.assertRaises(ValueError):
             z_lens = 0.5
@@ -1360,7 +1331,6 @@ class TestRaise(unittest.TestCase):
                 theta_E=theta_e,
                 gamma=gamma,
                 kappa_ext=0,
-                direct_convolve=True,
                 supersampling_factor=5,
                 voronoi_bins=None,
             )

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -613,7 +613,7 @@ class TestKinematicsAPI(object):
             supersampling_factor=5,
             voronoi_bins=None,
         )
-        print(np.shape(vel_dis), 'test vel_disp')
+        print(np.shape(vel_dis), "test vel_disp")
 
         jampy_vel_dis = np.array(
             [


### PR DESCRIPTION
This PR is needed to allow for multiple IFU data sets (such as JWST and KCWI) to be processed at the same time. Simplified options for direct convolution when IFU data sets are provided to take away options from the users.