### PR TITLE
various small changes for convenience/consistency

### DIFF
--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -18,7 +18,7 @@ class ImageLinearFit(ImageModel):
     def __init__(
         self,
         data_class,
-        psf_class=None,
+        psf_class,
         lens_model_class=None,
         source_model_class=None,
         lens_light_model_class=None,

--- a/lenstronomy/ImSim/image_linear_solve.py
+++ b/lenstronomy/ImSim/image_linear_solve.py
@@ -507,7 +507,7 @@ class ImageLinearFit(ImageModel):
         return error_map
 
     def point_source_linear_response_set(
-        self, kwargs_ps, kwargs_lens, kwargs_special, with_amp=True
+        self, kwargs_ps, kwargs_lens, kwargs_special=None, with_amp=True
     ):
         """
 

--- a/lenstronomy/PointSource/Types/lensed_position.py
+++ b/lenstronomy/PointSource/Types/lensed_position.py
@@ -8,8 +8,12 @@ class LensedPositions(PSBase):
     """
     class of a lensed point source parameterized as the (multiple) observed image positions
     Name within the PointSource module: 'LENSED_POSITION'
-    parameters: ra_image, dec_image, point_amp
-    If fixed_magnification=True, than 'source_amp' is a parameter instead of 'point_amp'
+    parameters:
+        ra_image: list of floats
+        dec_image: list of floats
+        point_amp: list of floats
+    If fixed_magnification=True, then 'source_amp' is a parameter instead of 'point_amp'
+        source_amp: float
 
     """
 

--- a/lenstronomy/PointSource/Types/lensed_position.py
+++ b/lenstronomy/PointSource/Types/lensed_position.py
@@ -9,9 +9,9 @@ class LensedPositions(PSBase):
     class of a lensed point source parameterized as the (multiple) observed image positions
     Name within the PointSource module: 'LENSED_POSITION'
     parameters:
-        ra_image: list of floats
-        dec_image: list of floats
-        point_amp: list of floats
+        ra_image: list or array of floats
+        dec_image: list or array of floats
+        point_amp: list or array of floats
     If fixed_magnification=True, then 'source_amp' is a parameter instead of 'point_amp'
         source_amp: float
 

--- a/lenstronomy/PointSource/Types/source_position.py
+++ b/lenstronomy/PointSource/Types/source_position.py
@@ -14,8 +14,11 @@ class SourcePositions(PSBase):
     specified source position.
 
     Name within the PointSource module: 'SOURCE_POSITION'
-    parameters: ra_source, dec_source, source_amp, mag_pert (optional)
-    mag_pert is a list of fractional magnification pertubations applied to point source images
+    parameters:
+        ra_source: float
+        dec_source: float
+        source_amp: float
+        mag_pert: optional list of fractional magnification pertubations applied to point source images
     """
 
     def image_position(

--- a/lenstronomy/PointSource/Types/unlensed.py
+++ b/lenstronomy/PointSource/Types/unlensed.py
@@ -9,7 +9,10 @@ class Unlensed(PSBase):
     class of a single point source in the image plane, aka star
     Name within the PointSource module: 'UNLENSED'
     This model can deal with arrays of point sources.
-    parameters: ra_image, dec_image, point_amp
+    parameters:
+        ra_image: list of floats
+        dec_image: list of floats
+        point_amp: list of floats
 
     """
 

--- a/lenstronomy/PointSource/Types/unlensed.py
+++ b/lenstronomy/PointSource/Types/unlensed.py
@@ -10,9 +10,9 @@ class Unlensed(PSBase):
     Name within the PointSource module: 'UNLENSED'
     This model can deal with arrays of point sources.
     parameters:
-        ra_image: list of floats
-        dec_image: list of floats
-        point_amp: list of floats
+        ra_image: list or array of floats
+        dec_image: list or array of floats
+        point_amp: list or array of floats
 
     """
 

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -533,7 +533,7 @@ class PointSource(object):
         pos_bool = True
         for kwargs in kwargs_ps:
             if "point_amp" in kwargs:
-                point_amp = kwargs["point_amp"]
+                point_amp = np.asarray(kwargs["point_amp"])
                 if not np.all(point_amp >= 0):
                     pos_bool = False
                     break

--- a/lenstronomy/PointSource/point_source.py
+++ b/lenstronomy/PointSource/point_source.py
@@ -538,7 +538,7 @@ class PointSource(object):
                     pos_bool = False
                     break
             if "source_amp" in kwargs:
-                point_amp = kwargs["source_amp"]
+                point_amp = np.asarray(kwargs["source_amp"])
                 if not np.all(point_amp >= 0):
                     pos_bool = False
                     break


### PR DESCRIPTION
1. the psf_class argument is required in the initialization of the ImageModel class, so it should also be required in the initialization of the ImageLinearFit class
2. Since kwargs_special is optional in ImageLinearFit.point_source_linear_response_set(), I have added a default value of None to this argument
3. Improved some docstrings in point source classes
4. In PointSource.check_positive_flux(), convert kwargs['amp'] to an array if it is a list so that it does not crash when comparing to an int