### PR TITLE
bug fix in PixelGrid when nx!=ny

### DIFF
--- a/lenstronomy/Analysis/image_reconstruction.py
+++ b/lenstronomy/Analysis/image_reconstruction.py
@@ -86,7 +86,7 @@ class MultiBandImageReconstruction(object):
             n_data = self._imageModel.num_data_evaluate
             if n_data > 0:
                 print(
-                    logL * 2 / n_data,
+                    -logL * 2 / n_data,
                     "reduced X^2 of all evaluated imaging data combined.",
                 )
 

--- a/lenstronomy/Data/imaging_data.py
+++ b/lenstronomy/Data/imaging_data.py
@@ -90,7 +90,7 @@ class ImageData(PixelGrid, ImageNoise):
          when modeling multiple exposures that have different magnitude zero points (or flux normalizations) but demand
          the same model normalization
         """
-        nx, ny = np.shape(image_data)
+        ny, nx = np.shape(image_data)
         if transform_pix2angle is None:
             transform_pix2angle = np.array([[1, 0], [0, 1]])
         cos_phi, sin_phi = np.cos(phi_rot), np.sin(phi_rot)
@@ -134,7 +134,7 @@ class ImageData(PixelGrid, ImageNoise):
         :param image_data: 2d numpy array of same size as nx, ny
         :return: None
         """
-        nx, ny = np.shape(image_data)
+        ny, nx = np.shape(image_data)
         if not self._nx == nx and not self._ny == ny:
             raise ValueError(
                 "shape of new data %s %s must equal old data %s %s!"

--- a/lenstronomy/Data/pixel_grid.py
+++ b/lenstronomy/Data/pixel_grid.py
@@ -73,10 +73,14 @@ class PixelGrid(Coordinates, AngularSensitivity):
         return np.mean(self._x_grid), np.mean(self._y_grid)
 
     def shift_coordinate_system(self, x_shift, y_shift, pixel_unit=False):
-        """Shifts the coordinate system :param x_shift: shift in x (or RA) :param
-        y_shift: shift in y (or DEC) :param pixel_unit: bool, if True, units of pixels
-        in input, otherwise RA/DEC :return: updated data class with change in coordinate
-        system."""
+        """
+        Shifts the coordinate system
+
+        :param x_shift: shift in x (or RA)
+        :param y_shift: shift in y (or DEC)
+        :param pixel_unit: bool, if True, units of pixels in input, otherwise RA/DEC
+        :return: updated data class with change in coordinate system.
+        """
         self._shift_coordinates(x_shift, y_shift, pixel_unit=pixel_unit)
         self._x_grid, self._y_grid = self.coordinate_grid(self._nx, self._ny)
 

--- a/lenstronomy/Util/util.py
+++ b/lenstronomy/Util/util.py
@@ -131,7 +131,7 @@ def array2image(array, nx=0, ny=0):
                 % (len(array))
             )
         nx, ny = n, n
-    image = array.reshape(int(nx), int(ny))
+    image = array.reshape(int(ny), int(nx))
     return image
 
 

--- a/test/test_Data/test_pixel_grid.py
+++ b/test/test_Data/test_pixel_grid.py
@@ -1,0 +1,40 @@
+import numpy.testing as npt
+import numpy as np
+
+from lenstronomy.Data.pixel_grid import PixelGrid
+
+class TestPixelGrid(object):
+
+    def setup_method(self):
+        self.nx, self.ny = 30, 20
+        self.delta_pix = 0.1
+        transform_pix2angle = np.array([[1, 0], [0, 1]]) * self.delta_pix
+        ra_at_xy_0, dec_at_xy_0 = 0, 0
+        self.pixel_grid = PixelGrid(nx=self.nx,
+                                    ny=self.ny,
+                  transform_pix2angle=transform_pix2angle,
+                  ra_at_xy_0=ra_at_xy_0,
+                  dec_at_xy_0=dec_at_xy_0,
+                  antenna_primary_beam=None,)
+
+    def test_num_pix(self):
+        num_pix = self.pixel_grid.num_pixel
+        npt.assert_almost_equal(num_pix, self.nx * self.ny)
+
+    def test_num_pixel_axes(self):
+        nx, ny = self.pixel_grid.num_pixel_axes
+        assert nx == self.nx
+        assert ny == self.ny
+
+    def test_width(self):
+        dx, dy = self.pixel_grid.width
+        npt.assert_almost_equal(dx, self.nx * self.delta_pix)
+        npt.assert_almost_equal(dy, self.ny * self.delta_pix)
+
+    def test_pixel_coordinates(self):
+        x_grid, y_grid = self.pixel_grid.pixel_coordinates
+        print(np.shape(x_grid[0, :]))
+
+        npt.assert_almost_equal(x_grid[0, :], np.linspace(start=0, stop=(self.nx-1)*self.delta_pix, num=self.nx), decimal=4)
+        npt.assert_almost_equal(y_grid[:, 0], np.linspace(start=0, stop=(self.ny - 1) * self.delta_pix, num=self.ny),
+                                decimal=4)

--- a/test/test_LightModel/test_Profiles/test_interpolation.py
+++ b/test/test_LightModel/test_Profiles/test_interpolation.py
@@ -21,7 +21,7 @@ class TestInterpol(object):
             x, y = util.make_grid(numPix=(len_x, len_y), deltapix=1.0)
             gauss = Gaussian()
             flux = gauss.function(x, y, amp=1.0, center_x=0.0, center_y=0.0, sigma=1.0)
-            image = util.array2image(flux, nx=len_y, ny=len_x)
+            image = util.array2image(flux, nx=len_x, ny=len_y)
 
             interp = Interpol()
             kwargs_interp = {

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -317,7 +317,7 @@ def test_image2array():
 
 def test_image2array2image():
     image = np.zeros((20, 10))
-    nx, ny = np.shape(image)
+    ny, nx = np.shape(image)
     image[1, 2] = 1
     array = util.image2array(image)
     image_new = util.array2image(array, nx, ny)


### PR DESCRIPTION
This PR fixes a minor bug when the shape of the pixel grid is not rectangular (currently barely the case)