### PR TITLE
Enable point source simulation for interferometric images, update tes…

### DIFF
--- a/lenstronomy/Util/primary_beam_util.py
+++ b/lenstronomy/Util/primary_beam_util.py
@@ -1,0 +1,30 @@
+__author__ = "nan zhang"
+
+import numpy as np
+from scipy.ndimage import map_coordinates
+
+from lenstronomy.Util.package_util import exporter
+
+export, __all__ = exporter()
+
+@export
+def primary_beam_value_at_coords(x_pos, y_pos, primary_beam, order=3):
+    """Interpolate the primary beam values at specified pixel coordinates.
+    The coordinates falling outside the image are assigned to constant zero.
+
+    :param x_pos: array or scalar of x-pixel-coordinates.
+    :param y_pos: array or scalar of y-pixel-coordinates.
+    :param primary_beam: the primary_beam map
+    :param order: the order of the spline interpolation
+    :return: a numpy array of the interpolated primary beam values
+    """
+
+    primary_beam_interpolated_values = map_coordinates(
+        input=primary_beam,
+        coordinates=np.vstack([y_pos, x_pos]),
+        order=order,
+        mode='constant',
+        cval=0
+        )
+    
+    return primary_beam_interpolated_values

--- a/test/test_ImSim/test_image_model_with_interferometric_changes.py
+++ b/test/test_ImSim/test_image_model_with_interferometric_changes.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.PointSource.point_source import PointSource
 from lenstronomy.ImSim.image_model import ImageModel
 import lenstronomy.Util.simulation_util as sim_util
 from lenstronomy.Util import kernel_util
@@ -11,13 +12,11 @@ from lenstronomy.Data.psf import PSF
 import scipy.signal
 
 """
-test the antenna primary beam and interferometric PSF (containing negative pixels and do not want normalisation)
-The idea of this test is to define two sets of data class and psf class, one with the antenna primary beam and PSF, one without, 
-and compare the (image_with_pb_and_psf) with scipy.signal.fftconvolve(image_without_pb_psf * pb, PSF, mode='same').
+Test the implementation of interferometric PSF and primary beam in image simulation.
 """
 
 
-def test_ImageModel_with_primary_beam_and_interferometry_psf():
+def test_lens_light_and_source_light_simulation_with_interferometric_PSF_and_primary_beam():
     sigma_bkg = 0.05
     exp_time = np.inf
     numPix = 100
@@ -185,3 +184,125 @@ def test_ImageModel_with_primary_beam_and_interferometry_psf():
         apply_primary_beam=False,
     )
     npt.assert_almost_equal(image_without_pb_image1, image_without_pb_image2, decimal=8)
+
+    
+def test_point_source_simulation_with_interferometric_PSF_and_primary_beam():
+    sigma_bkg = 0.05
+    exp_time = np.inf
+    numPix = 100
+    deltaPix = 0.2
+
+    # simulate a primary beam (pb)
+    primary_beam = np.zeros((numPix, numPix))
+    for i in range(numPix):
+        for j in range(numPix):
+            primary_beam[i, j] = np.exp(-2e-4 * ((i - 78) ** 2 + (j - 56) ** 2))
+    primary_beam /= np.max(primary_beam)
+
+    # simulate a spherical sinc function as psf, which contains negative pixels
+    psf_test = np.zeros((221, 221))
+    for i in range(221):
+        for j in range(221):
+            if i > j:
+                psf_test[i, j] = psf_test[j, i]
+            r = np.sqrt((i - 110) ** 2 + (j - 110) ** 2)
+            if r == 0:
+                psf_test[i, j] = 1
+            else:
+                psf_test[i, j] = np.sin(r * 0.5) / (r * 0.5)
+
+    # Define data class with the primary beam
+    kwargs_data = sim_util.data_configure_simple(
+        numPix, deltaPix, exp_time, sigma_bkg
+    )
+    kwargs_data['ra_at_xy_0'] = -(50)*deltaPix
+    kwargs_data['dec_at_xy_0'] = -(50)*deltaPix
+    kwargs_data['antenna_primary_beam'] = primary_beam
+    data_class = ImageData(**kwargs_data)
+    
+    # Define two PSF classes
+    kwargs_psf_none = {'psf_type': 'NONE', 'pixel_size': deltaPix}
+    psf_class_none = PSF(**kwargs_psf_none)
+    
+    kernel_cut = kernel_util.cut_psf(psf_test, 201, normalisation=False)
+    kwargs_psf = {
+        "psf_type": "PIXEL",
+        "pixel_size": deltaPix,
+        "kernel_point_source": kernel_cut,
+        "kernel_point_source_normalisation": False,
+    }
+    psf_class = PSF(**kwargs_psf)
+    
+    # define lens model
+    kwargs_lens = [
+        {
+        'theta_E': 1.7, 
+        'gamma': 2.0, 
+        'e1': -0.02, 
+        'e2': -0.01, 
+        'center_x': -0.31, 
+        'center_y': -0.26
+        }
+    ]
+    lens_model_list = ['EPL']
+    lens_model_class = LensModel(lens_model_list=lens_model_list)
+    
+    # Define the Point Source class
+    point_source_model_list = ['UNLENSED', 'LENSED_POSITION', 'SOURCE_POSITION']
+    pointSource = PointSource(
+        point_source_type_list=point_source_model_list, 
+        lens_model=lens_model_class, 
+        fixed_magnification_list=[True, True, True]
+    )
+    kwargs_ps = [
+        {'ra_image': [-1.7, -0.4 , -1.57], 
+         'dec_image': [0.21, 0.99 , 2.21], 
+         'point_amp': [100, 100, 100]},
+        {'ra_image': [1.49, 3.85, 0.81], 
+         'dec_image': [2.51,  1.67, -3.78], 
+         'source_amp': [100, 100, 100]},
+        {'ra_source': 3.23, 
+         'dec_source': -0.40, 
+         'source_amp': 100}
+    ]
+    
+    # Define the image model class
+    imageModel_no_psf = ImageModel(
+        data_class, 
+        psf_class_none, 
+        lens_model_class = lens_model_class,
+        point_source_class = pointSource
+    )
+
+    imageModel_with_psf = ImageModel(
+        data_class,
+        psf_class, 
+        lens_model_class = lens_model_class,
+        point_source_class = pointSource
+    )
+    
+    # Generate images with different psf, pb conditions
+    image_uncon_no_pb = imageModel_no_psf.image(
+        kwargs_lens=kwargs_lens, 
+        kwargs_ps = kwargs_ps, 
+        apply_primary_beam = False
+    )
+    image_uncon = imageModel_no_psf.image(
+        kwargs_lens=kwargs_lens, 
+        kwargs_ps = kwargs_ps
+    )
+    image_no_pb = imageModel_with_psf.image(
+        kwargs_lens=kwargs_lens, 
+        kwargs_ps = kwargs_ps, 
+        apply_primary_beam = False
+    )
+    image = imageModel_with_psf.image(
+        kwargs_lens=kwargs_lens, 
+        kwargs_ps = kwargs_ps
+    )
+    
+    # test the values by testing the summations
+    npt.assert_almost_equal(np.sum(image_uncon_no_pb), 998.0643356369997, decimal=8)
+    npt.assert_almost_equal(np.sum(image_uncon), 834.2233081496132, decimal=8)
+    npt.assert_almost_equal(np.sum(image_no_pb), 25539.14307941169, decimal=8)
+    npt.assert_almost_equal(np.sum(image), 21228.25308383333, decimal=8)

--- a/test/test_Util/test_primary_beam_util.py
+++ b/test/test_Util/test_primary_beam_util.py
@@ -1,0 +1,36 @@
+__author__ = "nan zhang"
+
+import numpy.testing as npt
+import numpy as np
+
+from lenstronomy.Util import primary_beam_util
+
+def test_primary_beam_value_at_coords():
+    
+    numPix = 100
+    primary_beam = np.zeros((numPix, numPix))
+    for i in range(numPix):
+        for j in range(numPix):
+            primary_beam[i, j] = np.exp(-1e-4 * ((i - 78) ** 2 + (j - 56) ** 2))
+    primary_beam /= np.max(primary_beam)
+    
+    # Test scalar numbers as input
+    output1 = primary_beam_util.primary_beam_value_at_coords(0, 1.2, primary_beam)
+    npt.assert_almost_equal(output1, 0.405407, decimal=8)
+    
+    # Test points outside of the image sent to zero
+    output2_1 = primary_beam_util.primary_beam_value_at_coords(-0.001, 10, primary_beam)
+    output2_2 = primary_beam_util.primary_beam_value_at_coords(numPix-1+0.001, 10, primary_beam)
+    output2_3 = primary_beam_util.primary_beam_value_at_coords(50, -0.001, primary_beam)
+    output2_4 = primary_beam_util.primary_beam_value_at_coords(50, numPix-1+0.001, primary_beam)
+    assert output2_1 == .0
+    assert output2_2 == .0
+    assert output2_3 == .0
+    assert output2_4 == .0
+    
+    # Test array as input
+    x_pos = np.array([1.2,  89,  -2,    6,   43.7 ])
+    y_pos = np.array([5.73, 15.2, 10.6, 102, 43])
+    output3 = primary_beam_util.primary_beam_value_at_coords(x_pos, y_pos, primary_beam)
+    npt.assert_almost_equal(output3, np.array([0.4394668 , 0.60454208, 0., 0., 0.87142193]), decimal=8)
+    


### PR DESCRIPTION
…t files

This PR extends the image generation of the ImageModel to correctly simulate point sources when interferometric PSF and Primary Beam (PB) effects are applied.

To ensure the primary beam is applied before convolution, the PB values are interpolated at the exact coordinates of each point source. The point source amplitude is then scaled by this PB (if PB is applied) response before being rendered and convolved by the PSF.