### PR TITLE
Correction on GaKin IFU aperture with rotation anlge

### DIFF
--- a/lenstronomy/GalKin/aperture_types.py
+++ b/lenstronomy/GalKin/aperture_types.py
@@ -402,7 +402,8 @@ class IFUGrid(ApertureBase):
         :param angle: angle of the IFU grid in radians
         """
         x0, y0 = _rotate(x_grid[0, 0], y_grid[0, 0], -angle)
-        x1, y1 = _rotate(x_grid[0, 1], y_grid[1, 0], -angle)
+        x1 = _rotate(x_grid[0, 1], y_grid[0, 1], -angle)[0]
+        y1 = _rotate(x_grid[1, 0], y_grid[1, 0], -angle)[1]
         delta_x = x1 - x0
         delta_y = y1 - y0
         if not np.isclose(np.abs(delta_x), np.abs(delta_y), rtol=1e-3):
@@ -580,7 +581,8 @@ class IFUBinned(ApertureBase):
         :param angle: angle of the IFU grid in radians
         """
         x0, y0 = _rotate(x_grid[0, 0], y_grid[0, 0], -angle)
-        x1, y1 = _rotate(x_grid[0, 1], y_grid[1, 0], -angle)
+        x1 = _rotate(x_grid[0, 1], y_grid[0, 1], -angle)[0]
+        y1 = _rotate(x_grid[1, 0], y_grid[1, 0], -angle)[1]
         delta_x = x1 - x0
         delta_y = y1 - y0
         if not np.isclose(np.abs(delta_x), np.abs(delta_y), rtol=1e-3):

--- a/test/test_GalKin/test_aperture_types.py
+++ b/test/test_GalKin/test_aperture_types.py
@@ -295,6 +295,13 @@ class TestApertureTypesSample(object):
         hr_map = xg_sample_p**2 + yg_sample_p**2
         hr_map = aperture_types._unpad_map(hr_map, padding=ifu.padding_pix(1.0))
         assert hr_map.shape == (num_pix_y, num_pix_x)
+        # test with rotation angle
+        phi = 0.12
+        x = y = np.linspace(-0.5, 0.5)
+        xg, yg = np.meshgrid(x, y)
+        xg, yg = aperture_types._rotate(xg, yg, phi)
+        ifu = aperture_types.IFUGrid(xg, yg, angle=phi)
+        assert_allclose(ifu.delta_pix, x[1] - x[0], rtol=1e-3)
 
     def test_ifu_shells(self):
         r_bins = np.array([0.0, 0.5, 1.0, 1.5])


### PR DESCRIPTION
I've just noticed the way the pixel scale along each axis was computed wrong when the grid was rotated (raising a value error as delta_x != delta_y). Now I have corrected that issue and added a test.