### PR TITLE
Enable mask_starred in PSF iteration with JAX compatibility fixes

### DIFF
--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -119,7 +119,9 @@ class PSF(object):
             if kernel_point_source_normalisation is True:
                 # self._psf_variance_map /= np.sum(kernel_point_source) ** 2
                 # Handle the inconsistency between jax and numpy arrays for the psf variance map.
-                if isinstance(self._psf_variance_map, jax.Array) or isinstance(kernel_point_source, jax.Array):
+                if isinstance(self._psf_variance_map, jax.Array) or isinstance(
+                    kernel_point_source, jax.Array
+                ):
                     psf_var = np.asarray(self._psf_variance_map)
                     kernel = np.asarray(kernel_point_source)
                     psf_var /= np.sum(kernel) ** 2

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -1,5 +1,5 @@
 import copy
-
+import jax
 import numpy as np
 import lenstronomy.Util.kernel_util as kernel_util
 import lenstronomy.Util.util as util
@@ -117,7 +117,15 @@ class PSF(object):
                         "psf_variance_map are on the down-sampled pixel scale."
                     )
             if kernel_point_source_normalisation is True:
-                self._psf_variance_map /= np.sum(kernel_point_source) ** 2
+                # self._psf_variance_map /= np.sum(kernel_point_source) ** 2
+                # Handle the inconsistency between jax and numpy arrays for the psf variance map.
+                if isinstance(self._psf_variance_map, jax.Array) or isinstance(kernel_point_source, jax.Array):
+                    psf_var = np.asarray(self._psf_variance_map)
+                    kernel = np.asarray(kernel_point_source)
+                    psf_var /= np.sum(kernel) ** 2
+                    self._psf_variance_map = np.asarray(psf_var)
+                else:
+                    self._psf_variance_map /= np.sum(kernel_point_source) ** 2
             self.psf_variance_map_bool = True
         else:
             self.psf_variance_map_bool = False

--- a/lenstronomy/Data/psf.py
+++ b/lenstronomy/Data/psf.py
@@ -122,10 +122,10 @@ class PSF(object):
                 if isinstance(self._psf_variance_map, jax.Array) or isinstance(
                     kernel_point_source, jax.Array
                 ):
-                    psf_var = np.asarray(self._psf_variance_map)
-                    kernel = np.asarray(kernel_point_source)
+                    psf_var = np.array(self._psf_variance_map)
+                    kernel = np.array(kernel_point_source)
                     psf_var /= np.sum(kernel) ** 2
-                    self._psf_variance_map = np.asarray(psf_var)
+                    self._psf_variance_map = psf_var
                 else:
                     self._psf_variance_map /= np.sum(kernel_point_source) ** 2
             self.psf_variance_map_bool = True

--- a/lenstronomy/Sampling/Pool/multiprocessing.py
+++ b/lenstronomy/Sampling/Pool/multiprocessing.py
@@ -58,15 +58,16 @@ class MultiPool(Pool):
         :param kwargs: Extra arguments passed to the :class:`multiprocessing.pool.Pool` superclass.
         """
 
-        '''
+        """
         Since macOS uses fork as the default multiprocessing mode, and STARRED relies on JAX which conflicts with fork and can lead to deadlocks, I explicitly switched to spawn mode here.
         Initially, I planned to implement a conditional check—i.e., if use_starred=True in the update_psf function within psf_fitting.py, then automatically switch the multiprocessing mode to spawn.
         However, in practice this introduced additional conflicts, so I decided not to proceed with this approach.
-        '''
-         # ===== Force using spawn context =====
-        if 'context' not in kwargs:
+        """
+        # ===== Force using spawn context =====
+        if "context" not in kwargs:
             import multiprocess
-            kwargs['context'] = multiprocess.get_context('spawn')
+
+            kwargs["context"] = multiprocess.get_context("spawn")
         # ===== End =====
         new_initializer = functools.partial(_initializer_wrapper, initializer)
         super(MultiPool, self).__init__(processes, new_initializer, initargs, **kwargs)

--- a/lenstronomy/Sampling/Pool/multiprocessing.py
+++ b/lenstronomy/Sampling/Pool/multiprocessing.py
@@ -57,6 +57,17 @@ class MultiPool(Pool):
         :type initargs: iterable, optional
         :param kwargs: Extra arguments passed to the :class:`multiprocessing.pool.Pool` superclass.
         """
+
+        '''
+        Since macOS uses fork as the default multiprocessing mode, and STARRED relies on JAX which conflicts with fork and can lead to deadlocks, I explicitly switched to spawn mode here.
+        Initially, I planned to implement a conditional check—i.e., if use_starred=True in the update_psf function within psf_fitting.py, then automatically switch the multiprocessing mode to spawn.
+        However, in practice this introduced additional conflicts, so I decided not to proceed with this approach.
+        '''
+         # ===== Force using spawn context =====
+        if 'context' not in kwargs:
+            import multiprocess
+            kwargs['context'] = multiprocess.get_context('spawn')
+        # ===== End =====
         new_initializer = functools.partial(_initializer_wrapper, initializer)
         super(MultiPool, self).__init__(processes, new_initializer, initargs, **kwargs)
         self.size = self._processes

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -173,6 +173,7 @@ class PsfFitting(object):
         corner_symmetry=None,
         use_starred=False,
         kwargs_starred=None,
+        mask_starred=None,
     ):
         """
 
@@ -210,6 +211,12 @@ class PsfFitting(object):
         :param use_starred: boolean, if True, uses the STARRED method to estimate the PSF (https://ui.adsabs.harvard.edu/abs/2023JOSS....8.5340M/abstract)
         :param kwargs_starred: dictionary, keyword arguments for the starred.procedures.psf_routines.update_PSF() method.
          Example: kwargs_starred = {'lambda_scales':2., 'lambda_hf':2., 'lambda_positivity':0.}
+        :param mask_starred: array-like of shape (N, size, size), optional. 
+         Mask array used in the STARRED PSF iteration. Here, N corresponds to the number of PSF kernels 
+         (i.e., the number of point sources), and size is the pixel size of the input initial PSF. 
+         For supersampled PSFs, the original (pre-supersampling) size should be used. 
+         Each mask is applied to exclude contamination from other point sources when estimating the PSF, 
+         ensuring that each PSF kernel is reconstructed using only its corresponding source, respectively.
 
         :return: kwargs_psf_new, logL_after, error_map
         """
@@ -444,7 +451,7 @@ class PsfFitting(object):
                 model,
                 parameters,
                 sigma2_maps_list,
-                masks=None,
+                masks=mask_starred,
                 **kwargs_starred,
             )
 

--- a/lenstronomy/Workflow/psf_fitting.py
+++ b/lenstronomy/Workflow/psf_fitting.py
@@ -211,11 +211,11 @@ class PsfFitting(object):
         :param use_starred: boolean, if True, uses the STARRED method to estimate the PSF (https://ui.adsabs.harvard.edu/abs/2023JOSS....8.5340M/abstract)
         :param kwargs_starred: dictionary, keyword arguments for the starred.procedures.psf_routines.update_PSF() method.
          Example: kwargs_starred = {'lambda_scales':2., 'lambda_hf':2., 'lambda_positivity':0.}
-        :param mask_starred: array-like of shape (N, size, size), optional. 
-         Mask array used in the STARRED PSF iteration. Here, N corresponds to the number of PSF kernels 
-         (i.e., the number of point sources), and size is the pixel size of the input initial PSF. 
-         For supersampled PSFs, the original (pre-supersampling) size should be used. 
-         Each mask is applied to exclude contamination from other point sources when estimating the PSF, 
+        :param mask_starred: array-like of shape (N, size, size), optional.
+         Mask array used in the STARRED PSF iteration. Here, N corresponds to the number of PSF kernels
+         (i.e., the number of point sources), and size is the pixel size of the input initial PSF.
+         For supersampled PSFs, the original (pre-supersampling) size should be used.
+         Each mask is applied to exclude contamination from other point sources when estimating the PSF,
          ensuring that each PSF kernel is reconstructed using only its corresponding source, respectively.
 
         :return: kwargs_psf_new, logL_after, error_map

--- a/test/test_Data/test_psf.py
+++ b/test/test_Data/test_psf.py
@@ -252,6 +252,47 @@ class TestData(object):
         kernel_odd_new = kernel_util.kernel_make_odd(kernel_point_source)
         npt.assert_almost_equal(kernel_odd_new, kernel_odd, decimal=16)
 
+    def test_jax_array_psf_variance_map(self):
+        """Test that jax arrays in kernel_point_source or psf_variance_map are handled
+        correctly during normalisation (covers the jax.Array branch in psf.py)."""
+        jnp = pytest.importorskip("jax.numpy")
+
+        kernel_np = kernel_util.kernel_gaussian(
+            num_pix=17, delta_pix=self.deltaPix, fwhm=0.2
+        )
+        psf_variance_map = np.ones_like(kernel_np)
+
+        # Case 1: kernel_point_source is a jax array
+        kernel_jax = jnp.array(kernel_np)
+        kwargs_psf = {
+            "psf_type": "PIXEL",
+            "kernel_point_source": kernel_jax,
+            "psf_variance_map": psf_variance_map,
+            "kernel_point_source_normalisation": True,
+        }
+        psf = PSF(**kwargs_psf)
+        # After normalisation by sum(kernel)^2 ≈ 1, the total should remain close to original
+        npt.assert_almost_equal(
+            np.sum(psf.psf_variance_map),
+            np.sum(psf_variance_map) / np.sum(kernel_np) ** 2,
+            decimal=6,
+        )
+
+        # Case 2: psf_variance_map is a jax array
+        variance_jax = jnp.ones_like(kernel_np)
+        kwargs_psf2 = {
+            "psf_type": "PIXEL",
+            "kernel_point_source": kernel_np,
+            "psf_variance_map": variance_jax,
+            "kernel_point_source_normalisation": True,
+        }
+        psf2 = PSF(**kwargs_psf2)
+        npt.assert_almost_equal(
+            np.sum(psf2.psf_variance_map),
+            np.sum(np.asarray(variance_jax)) / np.sum(kernel_np) ** 2,
+            decimal=6,
+        )
+
     def test_unnormalized(self):
         psf_norm_factor = 0.1
         kernel_point_source = np.zeros((51, 51))


### PR DESCRIPTION
This PR fixes several issues encountered when using the `starred` method

Changes:
- `lenstronomy/Data/psf.py`: fix numpy and JAX array type conflict
- `lenstronomy/Workflow/psf_fitting.py`: add PSF iteration mask support for starred 
- `lenstronomy/Sampling/Pool/multiprocessing.py`: fix deadlock caused by JAX and fork mode in multiprocessing (just a simple and straightforward approach)