### PR TITLE
IFU_binned also is computed as a map (no MC sampling) in KinematcsAPI

### DIFF
--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -291,7 +291,10 @@ class KinematicsAPI(object):
             else:
                 kwargs_light_i = kwargs_light
             if self.kinematics_backend == "galkin":
-                if self._kwargs_aperture_kin[i]["aperture_type"] in ["IFU_grid", "IFU_binned"]:
+                if self._kwargs_aperture_kin[i]["aperture_type"] in [
+                    "IFU_grid",
+                    "IFU_binned",
+                ]:
                     sigma_v_map_ = jam_model[i].dispersion_map_grid_convolved(
                         kwargs_profile,
                         kwargs_light_i,

--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -291,7 +291,7 @@ class KinematicsAPI(object):
             else:
                 kwargs_light_i = kwargs_light
             if self.kinematics_backend == "galkin":
-                if self._kwargs_aperture_kin[i]["aperture_type"] == "IFU_grid":
+                if self._kwargs_aperture_kin[i]["aperture_type"] in ["IFU_grid", "IFU_binned"]:
                     sigma_v_map_ = jam_model[i].dispersion_map_grid_convolved(
                         kwargs_profile,
                         kwargs_light_i,

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -1052,6 +1052,45 @@ class TestKinematicsAPI(object):
             {"r_ani": 1},
         )
 
+    def test_velocity_dispersion_map_binned(self):
+        np.random.seed(42)
+        z_lens = 0.5
+        z_source = 1.5
+        kwargs_options = {
+            "lens_model_list": ["SIS"],
+            "lens_light_model_list": ["HERNQUIST"],
+        }
+        x = y = np.linspace(-1, 1, 10)
+        x, y = np.meshgrid(x, y)
+        bins = np.ones_like(x) * -1
+        bins[2:4, 2:4] = 0
+        bins[4:6, 4:6] = 1
+        aperture_type = "IFU_binned"
+        kwargs_aperture = {
+            "aperture_type": aperture_type,
+            "x_grid": x,
+            "y_grid": y,
+            "bins": bins,
+        }
+        psf_fwhm = 0.7
+        kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": psf_fwhm}
+        anisotropy_model = "OM"
+        kin_api = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_options,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            anisotropy_model=anisotropy_model,
+            kinematics_backend="galkin",
+        )
+        vel_map_bins = kin_api.velocity_dispersion_map(
+            [{"theta_E": 1, "center_x": 0, "center_y": 0}],
+            [{"Rs": 1, "amp": 1, "center_x": 0, "center_y": 0}],
+            {"r_ani": 1},
+        )
+        npt.assert_allclose(vel_map_bins, [259.646809, 273.450448], rtol=1e-3)
+
     def test_multi_obs_dispersion(self):
         anisotropy_model = "const"
         kwargs_aperture = {


### PR DESCRIPTION
I forgot to include the new aperture IFU_binned in the velocity_dispersion_map options for Galkin, so it was computed with the Monte Carlo sampling instead of a grid. This pull request solves this issue.