### PR TITLE
Add log-scaled point mass parameterization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,5 @@ repos:
     hooks:
       - id: docformatter
         args: [-r, --black, --in-place]
+        language_version: python3.12
 

--- a/lenstronomy/LensModel/Profiles/point_mass_log_scaled.py
+++ b/lenstronomy/LensModel/Profiles/point_mass_log_scaled.py
@@ -1,0 +1,79 @@
+__author__ = "ajshajib"
+
+
+import numpy as np
+
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from lenstronomy.LensModel.Profiles.point_mass import PointMass
+
+__all__ = ["PointMassLogScaled"]
+
+
+class PointMassLogScaled(LensProfileBase):
+    """Point-mass lens profile parameterized by ``log10_theta_E``."""
+
+    param_names = ["log10_theta_E", "center_x", "center_y"]
+    lower_limit_default = {"log10_theta_E": -6, "center_x": -100, "center_y": -100}
+    upper_limit_default = {"log10_theta_E": 2, "center_x": 100, "center_y": 100}
+
+    def __init__(self):
+        self.point_mass = PointMass()
+        self.r_min = 10 ** (-25)
+        super(PointMassLogScaled, self).__init__()
+
+    @staticmethod
+    def _theta_e(log10_theta_E):
+        """Converts log10_theta_E to theta_E.
+
+        :param log10_theta_E: log10 of the Einstein radius (in arcsec)
+        :return: Einstein radius (in angles)
+        """
+        return 10.0**log10_theta_E
+
+    def function(self, x, y, log10_theta_E, center_x=0, center_y=0):
+        """Compute the lensing potential at (x, y) for the given log10_theta_E.
+
+        :param x: x-coord (in angles)
+        :param y: y-coord (in angles)
+        :param log10_theta_E: log10 of the Einstein radius (in arcsec)
+        :return: lensing potential
+        """
+        theta_E = self._theta_e(log10_theta_E)
+        return self.point_mass.function(
+            x, y, theta_E, center_x=center_x, center_y=center_y
+        )
+
+    def derivatives(self, x, y, log10_theta_E, center_x=0, center_y=0):
+        """Compute the deflection angles at (x, y) for the given log10_theta_E.
+
+        :param x: x-coord (in angles)
+        :param y: y-coord (in angles)
+        :param log10_theta_E: log10 of the Einstein radius (in arcsec)
+        :return: deflection angles
+        """
+
+        theta_E = self._theta_e(log10_theta_E)
+        return self.point_mass.derivatives(
+            x, y, theta_E, center_x=center_x, center_y=center_y
+        )
+
+    def hessian(self, x, y, log10_theta_E, center_x=0, center_y=0):
+        """Compute the Hessian matrix at (x, y) for the given log10_theta_E.
+
+        :param x: x-coord (in angles)
+        :param y: y-coord (in angles)
+        :param log10_theta_E: log10 of the Einstein radius (in arcsec)
+        :return: Hessian matrix components"""
+        theta_E = self._theta_e(log10_theta_E)
+        return self.point_mass.hessian(
+            x, y, theta_E, center_x=center_x, center_y=center_y
+        )
+
+    def mass_3d_lens(self, r, log10_theta_E):
+        """Compute the 3D mass enclosed within radius r for the given log10_theta_E.
+
+        :param r: radius (in angles)
+        :param log10_theta_E: log10 of the Einstein radius (in arcsec)
+        :return: 3D mass enclosed within radius r"""
+        theta_E = self._theta_e(log10_theta_E)
+        return self.point_mass.mass_3d_lens(r, theta_E)

--- a/lenstronomy/LensModel/Profiles/point_mass_log_scaled.py
+++ b/lenstronomy/LensModel/Profiles/point_mass_log_scaled.py
@@ -18,7 +18,6 @@ class PointMassLogScaled(LensProfileBase):
 
     def __init__(self):
         self.point_mass = PointMass()
-        self.r_min = 10 ** (-25)
         super(PointMassLogScaled, self).__init__()
 
     @staticmethod

--- a/lenstronomy/LensModel/Profiles/point_mass_log_scaled.py
+++ b/lenstronomy/LensModel/Profiles/point_mass_log_scaled.py
@@ -63,7 +63,8 @@ class PointMassLogScaled(LensProfileBase):
         :param x: x-coord (in angles)
         :param y: y-coord (in angles)
         :param log10_theta_E: log10 of the Einstein radius (in arcsec)
-        :return: Hessian matrix components"""
+        :return: Hessian matrix components
+        """
         theta_E = self._theta_e(log10_theta_E)
         return self.point_mass.hessian(
             x, y, theta_E, center_x=center_x, center_y=center_y
@@ -74,6 +75,7 @@ class PointMassLogScaled(LensProfileBase):
 
         :param r: radius (in angles)
         :param log10_theta_E: log10 of the Einstein radius (in arcsec)
-        :return: 3D mass enclosed within radius r"""
+        :return: 3D mass enclosed within radius r
+        """
         theta_E = self._theta_e(log10_theta_E)
         return self.point_mass.mass_3d_lens(r, theta_E)

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -77,6 +77,7 @@ _SUPPORTED_MODELS = [
     "PJAFFE",
     "PJAFFE_ELLIPSE_POTENTIAL",
     "POINT_MASS",
+    "POINT_MASS_LOG_SCALED",
     "PSEUDO_DPL",
     "SERSIC",
     "SERSIC_ELLIPSE_GAUSS_DEC",
@@ -664,6 +665,12 @@ def lens_class(
         from lenstronomy.LensModel.Profiles.point_mass import PointMass
 
         return PointMass(**profile_kwargs)
+    elif lens_type == "POINT_MASS_LOG_SCALED":
+        from lenstronomy.LensModel.Profiles.point_mass_log_scaled import (
+            PointMassLogScaled,
+        )
+
+        return PointMassLogScaled(**profile_kwargs)
     elif lens_type == "PSEUDO_DPL":
         from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import (
             PseudoDoublePowerlaw,

--- a/test/test_LensModel/test_Profiles/test_point_mass_log_scaled.py
+++ b/test/test_LensModel/test_Profiles/test_point_mass_log_scaled.py
@@ -1,0 +1,61 @@
+__author__ = "ajshajib"
+
+
+from lenstronomy.LensModel.Profiles.point_mass import PointMass
+from lenstronomy.LensModel.Profiles.point_mass_log_scaled import PointMassLogScaled
+from lenstronomy.LensModel.profile_list_base import lens_class
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestPointMassLogScaled(object):
+    """Tests the PointMassLogScaled class routines."""
+
+    def setup_method(self):
+        self.pointmass = PointMass()
+        self.pointmass_log_scaled = PointMassLogScaled()
+        self.theta_E = 1.7
+        self.log10_theta_E = np.log10(self.theta_E)
+
+    def test_function(self):
+        x = np.array([1.0, 3.0, 4.0])
+        y = np.array([0.0, 1.0, 1.0])
+        values = self.pointmass_log_scaled.function(x, y, self.log10_theta_E)
+        values_ref = self.pointmass.function(x, y, self.theta_E)
+        npt.assert_allclose(values, values_ref)
+
+    def test_derivatives(self):
+        x = np.array([1.0, 3.0, 4.0])
+        y = np.array([0.0, 1.0, 1.0])
+        values = self.pointmass_log_scaled.derivatives(x, y, self.log10_theta_E)
+        values_ref = self.pointmass.derivatives(x, y, self.theta_E)
+        for value, value_ref in zip(values, values_ref):
+            npt.assert_allclose(value, value_ref)
+
+    def test_hessian(self):
+        x = np.array([1.0, 3.0, 4.0])
+        y = np.array([0.0, 1.0, 1.0])
+        values = self.pointmass_log_scaled.hessian(x, y, self.log10_theta_E)
+        values_ref = self.pointmass.hessian(x, y, self.theta_E)
+        for value, value_ref in zip(values, values_ref):
+            npt.assert_allclose(value, value_ref)
+
+    def test_mass_3d_lens(self):
+        mass_3d = self.pointmass_log_scaled.mass_3d_lens(5.0, self.log10_theta_E)
+        mass_3d_ref = self.pointmass.mass_3d_lens(5.0, self.theta_E)
+        assert mass_3d == mass_3d_ref
+
+    def test_registered_lens_class(self):
+        point_mass_log_scaled = lens_class("POINT_MASS_LOG_SCALED")
+        assert isinstance(point_mass_log_scaled, PointMassLogScaled)
+        assert point_mass_log_scaled.param_names == [
+            "log10_theta_E",
+            "center_x",
+            "center_y",
+        ]
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
This pull request introduces a new lens profile, `POINT_MASS_LOG_SCALED`, which parameterizes the point-mass lens using the logarithm of the Einstein radius (`log10_theta_E`). This parametrization is easier to sample when a log-uniform prior is preferred.

This PR also fixes pre-commit CI, which is currently broken.