### PR TITLE
Reduce serialization overhead for faster MPI parallelization

### DIFF
--- a/lenstronomy/Sampling/Pool/parallelization_util.py
+++ b/lenstronomy/Sampling/Pool/parallelization_util.py
@@ -1,3 +1,5 @@
+__author__ = "ajshajib"
+
 import numpy as np
 
 _SAMPLER_LIKELIHOOD_MODULE = None

--- a/lenstronomy/Sampling/Pool/parallelization_util.py
+++ b/lenstronomy/Sampling/Pool/parallelization_util.py
@@ -11,7 +11,8 @@ _NESTED_HAS_WARNED = False
 def set_sampler_likelihood_module(likelihood_module):
     """Set the likelihood module used by worker log-likelihood evaluations.
 
-    :param likelihood_module: a likelihood module like in likelihood.py (should be callable)
+    :param likelihood_module: a likelihood module like in likelihood.py (should be
+        callable)
     :return: None
     """
     global _SAMPLER_LIKELIHOOD_MODULE
@@ -35,7 +36,8 @@ def sampler_logl_worker(args):
 def set_nested_likelihood_module(likelihood_module, n_dims):
     """Set the nested-sampler likelihood and dimensionality on each worker.
 
-    :param likelihood_module: a likelihood module like in likelihood.py (should be callable)
+    :param likelihood_module: a likelihood module like in likelihood.py (should be
+        callable)
     :param n_dims: number of dimensions in the parameter space
     :return: None
     """

--- a/lenstronomy/Sampling/Pool/parallelization_util.py
+++ b/lenstronomy/Sampling/Pool/parallelization_util.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+_SAMPLER_LIKELIHOOD_MODULE = None
+_NESTED_LIKELIHOOD_MODULE = None
+_NESTED_N_DIMS = None
+_NESTED_HAS_WARNED = False
+
+
+def set_sampler_likelihood_module(likelihood_module):
+    """Set the likelihood module used by worker log-likelihood evaluations.
+
+    :param likelihood_module: a likelihood module like in likelihood.py (should be callable)
+    :return: None
+    """
+    global _SAMPLER_LIKELIHOOD_MODULE
+    _SAMPLER_LIKELIHOOD_MODULE = likelihood_module
+
+
+def sampler_logl_worker(args):
+    """Evaluate the log-likelihood from worker-local sampler state.
+
+    :param args: parameter vector for which to evaluate the log-likelihood
+    :return: log-likelihood value
+    """
+    if _SAMPLER_LIKELIHOOD_MODULE is None:
+        raise RuntimeError(
+            "Worker likelihood module is not initialized. "
+            "Call set_sampler_likelihood_module before evaluating logL."
+        )
+    return _SAMPLER_LIKELIHOOD_MODULE.logL(args)
+
+
+def set_nested_likelihood_module(likelihood_module, n_dims):
+    """Set the nested-sampler likelihood and dimensionality on each worker.
+
+    :param likelihood_module: a likelihood module like in likelihood.py (should be callable)
+    :param n_dims: number of dimensions in the parameter space
+    :return: None
+    """
+    global _NESTED_LIKELIHOOD_MODULE, _NESTED_N_DIMS, _NESTED_HAS_WARNED
+    _NESTED_LIKELIHOOD_MODULE = likelihood_module
+    _NESTED_N_DIMS = n_dims
+    _NESTED_HAS_WARNED = False
+
+
+def nested_logl_worker(p, *args):
+    """Worker log-likelihood entrypoint used by MPI nested samplers.
+
+    :param p: parameter vector for which to evaluate the log-likelihood
+    :param args: additional arguments (ignored)
+    :return: log-likelihood value
+    """
+    if _NESTED_LIKELIHOOD_MODULE is None or _NESTED_N_DIMS is None:
+        raise RuntimeError(
+            "Worker nested likelihood is not initialized. "
+            "Call set_nested_likelihood_module before evaluating logL."
+        )
+
+    p = np.array([p[i] for i in range(_NESTED_N_DIMS)])
+    log_l = _NESTED_LIKELIHOOD_MODULE(p)
+
+    global _NESTED_HAS_WARNED
+    if not np.isfinite(log_l):
+        if not _NESTED_HAS_WARNED:
+            print("WARNING : logL is not finite : return very low value instead")
+        log_l = -1e15
+        _NESTED_HAS_WARNED = True
+    return float(log_l)

--- a/lenstronomy/Sampling/Pool/pool.py
+++ b/lenstronomy/Sampling/Pool/pool.py
@@ -72,12 +72,11 @@ def choose_pool(mpi=False, processes=1, **kwargs):
             raise SystemError("Tried to run with MPI but MPIPool not enabled.")
         try:
             pool = MPIPool(**kwargs)
-        except:
-            raise ImportError(
-                "MPIPool of schwimmbad can not be generated. lenstronomy uses a specific branch of "
-                "schwimmbad specified in the requirements.txt. Make sure you are using the correct "
-                'version of schwimmbad. In particular the "use_dill" argument is not supported in the '
-                "pypi version 0.3.0."
+        except Exception as e:
+            raise SystemError(
+                "Tried to run with MPI but failed to initialize MPIPool. Error message: {0}".format(
+                    e
+                )
             )
         if not pool.is_master():
             pool.wait()

--- a/lenstronomy/Sampling/Pool/pool.py
+++ b/lenstronomy/Sampling/Pool/pool.py
@@ -64,8 +64,8 @@ def choose_pool(mpi=False, processes=1, **kwargs):
     # Imports moved here to avoid crashing at import time if dependencies
     # are missing
     from lenstronomy.Sampling.Pool.multiprocessing import MultiPool
-    from schwimmbad.serial import SerialPool
-    from schwimmbad.mpi import MPIPool
+    from schwimmbad import SerialPool
+    from schwimmbad import MPIPool
 
     if mpi:
         if not MPIPool.enabled():

--- a/lenstronomy/Sampling/Samplers/dynesty_sampler.py
+++ b/lenstronomy/Sampling/Samplers/dynesty_sampler.py
@@ -61,8 +61,7 @@ class DynestySampler(NestedSampler):
 
             set_nested_likelihood_module(self._ll, self.n_dims)
 
-            # use_dill=True not supported for some versions of schwimmbad
-            pool = MPIPool(use_dill=True)
+            pool = MPIPool()
             if not pool.is_master():
                 pool.wait()
                 sys.exit(0)

--- a/lenstronomy/Sampling/Samplers/dynesty_sampler.py
+++ b/lenstronomy/Sampling/Samplers/dynesty_sampler.py
@@ -3,6 +3,10 @@ __author__ = "aymgal, johannesulf"
 import numpy as np
 
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler
+from lenstronomy.Sampling.Pool.parallelization_util import (
+    nested_logl_worker,
+    set_nested_likelihood_module,
+)
 import lenstronomy.Util.sampling_util as utils
 
 __all__ = ["DynestySampler"]
@@ -55,6 +59,8 @@ class DynestySampler(NestedSampler):
             from schwimmbad import MPIPool
             import sys
 
+            set_nested_likelihood_module(self._ll, self.n_dims)
+
             # use_dill=True not supported for some versions of schwimmbad
             pool = MPIPool(use_dill=True)
             if not pool.is_master():
@@ -62,7 +68,7 @@ class DynestySampler(NestedSampler):
                 sys.exit(0)
 
             self._sampler = self._dynesty.DynamicNestedSampler(
-                loglikelihood=self.log_likelihood,
+                loglikelihood=nested_logl_worker,
                 prior_transform=self.prior,
                 ndim=self.n_dims,
                 bound=bound,

--- a/lenstronomy/Sampling/Samplers/nautilus.py
+++ b/lenstronomy/Sampling/Samplers/nautilus.py
@@ -57,7 +57,7 @@ class Nautilus(object):
                 "prior_type %s is not supported for Nautilus wrapper." % prior_type
             )
         # loop through prior
-        pool = choose_pool(mpi=mpi, processes=thread_count, use_dill=True)
+        pool = choose_pool(mpi=mpi, processes=thread_count)
         sampler = Sampler(
             prior,
             likelihood=self.likelihood,

--- a/lenstronomy/Sampling/Samplers/nautilus_sampler.py
+++ b/lenstronomy/Sampling/Samplers/nautilus_sampler.py
@@ -4,6 +4,10 @@ __author__ = "aymgal, johannesulf"
 from inspect import signature
 import numpy as np
 from lenstronomy.Sampling.Samplers.base_nested_sampler import NestedSampler
+from lenstronomy.Sampling.Pool.parallelization_util import (
+    nested_logl_worker,
+    set_nested_likelihood_module,
+)
 
 __all__ = ["NautilusSampler"]
 
@@ -50,6 +54,8 @@ class NautilusSampler(NestedSampler):
             from schwimmbad import MPIPool
             import sys
 
+            set_nested_likelihood_module(self._ll, self.n_dims)
+
             # use_dill=True not supported for some versions of schwimmbad
             pool = MPIPool(use_dill=True)
             if not pool.is_master():
@@ -61,7 +67,10 @@ class NautilusSampler(NestedSampler):
         kwargs = {key: kwargs[key] for key in kwargs.keys() & keys}
 
         self._sampler = self._nautilus.Sampler(
-            self.prior, self.log_likelihood, self.n_dims, **kwargs
+            self.prior,
+            nested_logl_worker if mpi else self.log_likelihood,
+            self.n_dims,
+            **kwargs
         )
 
     def run(self, **kwargs):
@@ -108,7 +117,9 @@ class NautilusSampler(NestedSampler):
         try:
             import nautilus
         except ImportError:
-            print("Warning : nautilus not properly installed. \
-                  You can get it with $pip install nautilus-sampler.")
+            print(
+                "Warning : nautilus not properly installed. \
+                  You can get it with $pip install nautilus-sampler."
+            )
         else:
             self._nautilus = nautilus

--- a/lenstronomy/Sampling/Samplers/nautilus_sampler.py
+++ b/lenstronomy/Sampling/Samplers/nautilus_sampler.py
@@ -116,9 +116,7 @@ class NautilusSampler(NestedSampler):
         try:
             import nautilus
         except ImportError:
-            print(
-                "Warning : nautilus not properly installed. \
-                  You can get it with $pip install nautilus-sampler."
-            )
+            print("Warning : nautilus not properly installed. \
+                  You can get it with $pip install nautilus-sampler.")
         else:
             self._nautilus = nautilus

--- a/lenstronomy/Sampling/Samplers/nautilus_sampler.py
+++ b/lenstronomy/Sampling/Samplers/nautilus_sampler.py
@@ -56,8 +56,7 @@ class NautilusSampler(NestedSampler):
 
             set_nested_likelihood_module(self._ll, self.n_dims)
 
-            # use_dill=True not supported for some versions of schwimmbad
-            pool = MPIPool(use_dill=True)
+            pool = MPIPool()
             if not pool.is_master():
                 pool.wait()
                 sys.exit(0)

--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -44,13 +44,12 @@ class Sampler(object):
             pool = choose_pool(
                 mpi=mpi,
                 processes=threadCount,
-                use_dill=True,
                 initializer=set_sampler_likelihood_module,
                 initargs=(self.chain,),
             )
             return pool, sampler_logl_worker
 
-        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        pool = choose_pool(mpi=mpi, processes=threadCount)
         return pool, self.chain.logL
 
     def simplex(self, init_pos, n_iterations, method, print_key="SIMPLEX"):

--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -37,7 +37,7 @@ class Sampler(object):
     def _pool_and_logl(self, mpi, threadCount):
         """Build a pool and return the corresponding worker-safe logL callable."""
         if mpi:
-            pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+            pool = choose_pool(mpi=mpi, processes=threadCount)
             return pool, sampler_logl_worker
 
         if threadCount != 1:

--- a/lenstronomy/Sampling/sampler.py
+++ b/lenstronomy/Sampling/sampler.py
@@ -6,6 +6,10 @@ import numpy as np
 from lenstronomy.Sampling.Samplers.pso import ParticleSwarmOptimizer
 from lenstronomy.Util import sampling_util
 from lenstronomy.Sampling.Pool.pool import choose_pool
+from lenstronomy.Sampling.Pool.parallelization_util import (
+    sampler_logl_worker,
+    set_sampler_likelihood_module,
+)
 from scipy.optimize import minimize
 
 __all__ = ["Sampler"]
@@ -27,6 +31,27 @@ class Sampler(object):
         """
         self.chain = likelihoodModule
         self.lower_limit, self.upper_limit = self.chain.param_limits
+        # Keep the worker-local log-likelihood state in sync on ranks that construct this class.
+        set_sampler_likelihood_module(self.chain)
+
+    def _pool_and_logl(self, mpi, threadCount):
+        """Build a pool and return the corresponding worker-safe logL callable."""
+        if mpi:
+            pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+            return pool, sampler_logl_worker
+
+        if threadCount != 1:
+            pool = choose_pool(
+                mpi=mpi,
+                processes=threadCount,
+                use_dill=True,
+                initializer=set_sampler_likelihood_module,
+                initargs=(self.chain,),
+            )
+            return pool, sampler_logl_worker
+
+        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        return pool, self.chain.logL
 
     def simplex(self, init_pos, n_iterations, method, print_key="SIMPLEX"):
         """
@@ -98,13 +123,13 @@ class Sampler(object):
             lower_start = np.maximum(lower_start, self.lower_limit)
             upper_start = np.minimum(upper_start, self.upper_limit)
 
-        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        pool, logl_function = self._pool_and_logl(mpi=mpi, threadCount=threadCount)
 
         if mpi is True and pool.is_master():
             print("MPI option chosen for PSO.")
 
         pso = ParticleSwarmOptimizer(
-            self.chain.logL, lower_start, upper_start, n_particles, pool=pool
+            logl_function, lower_start, upper_start, n_particles, pool=pool
         )
 
         if init_pos is None:
@@ -192,7 +217,7 @@ class Sampler(object):
                 size=n_walkers,
             )
 
-        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        pool, logl_function = self._pool_and_logl(mpi=mpi, threadCount=threadCount)
 
         if backend_filename is not None:
             backend = emcee.backends.HDFBackend(
@@ -223,7 +248,7 @@ class Sampler(object):
         time_start = time.time()
 
         sampler = emcee.EnsembleSampler(
-            n_walkers, num_param, self.chain.logL, pool=pool, backend=backend
+            n_walkers, num_param, logl_function, pool=pool, backend=backend
         )
 
         sampler.run_mcmc(initpos, n_run_eff, progress=progress)
@@ -368,12 +393,12 @@ class Sampler(object):
         else:
             pass
 
-        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        pool, logl_function = self._pool_and_logl(mpi=mpi, threadCount=threadCount)
 
         sampler = zeus.EnsembleSampler(
             nwalkers=n_walkers,
             ndim=num_param,
-            logprob_fn=self.chain.logL,
+            logprob_fn=logl_function,
             moves=moves,
             tune=tune,
             tolerance=tolerance,

--- a/lenstronomy/Workflow/alignment_matching.py
+++ b/lenstronomy/Workflow/alignment_matching.py
@@ -64,7 +64,7 @@ class AlignmentFitting(object):
         """
         init_pos = self.chain.get_args(self.chain.kwargs_data_init)
         lower_limit, upper_limit = self.chain.lower_upper_limit(delta_shift, delta_rot)
-        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        pool = choose_pool(mpi=mpi, processes=threadCount)
 
         pso = ParticleSwarmOptimizer(
             self.chain, lower_limit, upper_limit, n_particles, pool=pool

--- a/lenstronomy/Workflow/flux_calibration.py
+++ b/lenstronomy/Workflow/flux_calibration.py
@@ -63,7 +63,7 @@ class FluxCalibration(object):
         :return: multi_band_list, [chi2_list, pos_list, vel_list]
         """
         init_pos = self.chain.get_args(self.chain.multi_band_list)
-        pool = choose_pool(mpi=mpi, processes=threadCount, use_dill=True)
+        pool = choose_pool(mpi=mpi, processes=threadCount)
         num_param = self.chain.num_param
         lower_limit = [scaling_lower_limit] * num_param
         upper_limit = [scaling_upper_limit] * num_param

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,6 @@ nautilus-sampler>=0.7
 
 
 schwimmbad>=0.3.2
-# schwimmbad version that is supporting dill, which was not implemented yet in the pip release version at or before 0.3.0
-# -e git://github.com/adrn/schwimmbad.git@master#egg=schwimmbad
 multiprocess>=0.70.8
 # fastell is not a direct requirement as it needs a fortran compiler and is optional
 #-e git://github.com/sibirrer/fastell4py.git#egg=fastell4py

--- a/test/test_Sampling/test_Pool/test_parallelization_util.py
+++ b/test/test_Sampling/test_Pool/test_parallelization_util.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from lenstronomy.Sampling.Pool import parallelization_util as pu
+
+
+class _FakeSamplerLikelihood(object):
+    def logL(self, args):
+        return float(np.sum(args))
+
+
+class _FakeNestedLikelihood(object):
+    def __call__(self, p):
+        return float(np.sum(p))
+
+
+class _FakeNonFiniteNestedLikelihood(object):
+    def __call__(self, p):
+        return np.nan
+
+
+def setup_function():
+    pu._SAMPLER_LIKELIHOOD_MODULE = None
+    pu._NESTED_LIKELIHOOD_MODULE = None
+    pu._NESTED_N_DIMS = None
+    pu._NESTED_HAS_WARNED = False
+
+
+def test_sampler_logl_worker_requires_initialization():
+    with pytest.raises(RuntimeError):
+        pu.sampler_logl_worker(np.array([1.0, 2.0]))
+
+
+def test_sampler_logl_worker_evaluates_logl():
+    pu.set_sampler_likelihood_module(_FakeSamplerLikelihood())
+    result = pu.sampler_logl_worker(np.array([1.0, 2.0, 3.0]))
+    assert result == 6.0
+
+
+def test_nested_logl_worker_requires_initialization():
+    with pytest.raises(RuntimeError):
+        pu.nested_logl_worker(np.array([1.0, 2.0]))
+
+
+def test_nested_logl_worker_finite_value_and_extra_args():
+    pu.set_nested_likelihood_module(_FakeNestedLikelihood(), n_dims=2)
+    result = pu.nested_logl_worker(np.array([1.5, 2.5, 99.0]), "unused")
+    assert result == 4.0
+
+
+def test_nested_logl_worker_non_finite_warns_once(capsys):
+    pu.set_nested_likelihood_module(_FakeNonFiniteNestedLikelihood(), n_dims=2)
+
+    result_1 = pu.nested_logl_worker(np.array([1.0, 2.0]))
+    captured_1 = capsys.readouterr()
+
+    result_2 = pu.nested_logl_worker(np.array([1.0, 2.0]))
+    captured_2 = capsys.readouterr()
+
+    assert result_1 == -1e15
+    assert result_2 == -1e15
+    assert "WARNING : logL is not finite" in captured_1.out
+    assert captured_2.out == ""

--- a/test/test_Sampling/test_Pool/test_pool.py
+++ b/test/test_Sampling/test_Pool/test_pool.py
@@ -23,6 +23,22 @@ class TestPool(object):
         # assert pool.is_master() is True
         # assert isinstance(pool, schwimmbad.mpi.MPIPool)
 
+    def test_choose_pool_mpi_init_error(self, monkeypatch):
+        import schwimmbad
+
+        class _FailingMPIPool(object):
+            @staticmethod
+            def enabled():
+                return True
+
+            def __init__(self, **kwargs):
+                raise RuntimeError("mpi init failed")
+
+        monkeypatch.setattr(schwimmbad, "MPIPool", _FailingMPIPool)
+
+        with pytest.raises(SystemError, match="failed to initialize MPIPool"):
+            choose_pool(mpi=True, processes=1)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_Samplers/test_dynesty_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_dynesty_sampler.py
@@ -1,5 +1,7 @@
 __author__ = "aymgal"
 
+import sys
+import types
 import pytest
 import numpy as np
 import numpy.testing as npt
@@ -83,6 +85,58 @@ class TestDynestySampler(object):
         assert logL < 0
         # npt.assert_almost_equal(logL, -47.167446538898204)
         # assert logL == -1e15
+
+    def test_sampler_init_mpi_branch(
+        self, simple_einstein_ring_likelihood, monkeypatch
+    ):
+        likelihood, kwargs_truths = simple_einstein_ring_likelihood
+        prior_means = likelihood.param.kwargs2args(**kwargs_truths)
+        prior_sigmas = np.ones_like(prior_means)
+
+        class _FakeDynamicNestedSampler(object):
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        def _fake_check_install(self):
+            self._dynesty_installed = True
+            self._dynesty = types.SimpleNamespace(
+                DynamicNestedSampler=_FakeDynamicNestedSampler
+            )
+
+        pool_kwargs = []
+
+        class _FakeMPIPool(object):
+            def __init__(self, **kwargs):
+                pool_kwargs.append(kwargs)
+
+            @staticmethod
+            def is_master():
+                return True
+
+        nested_calls = []
+
+        def _fake_set_nested(likelihood_module, n_dims):
+            nested_calls.append((likelihood_module, n_dims))
+
+        monkeypatch.setattr(DynestySampler, "_check_install", _fake_check_install)
+        fake_schwimmbad = types.SimpleNamespace(MPIPool=_FakeMPIPool)
+        monkeypatch.setitem(sys.modules, "schwimmbad", fake_schwimmbad)
+        monkeypatch.setattr(
+            "lenstronomy.Sampling.Samplers.dynesty_sampler.set_nested_likelihood_module",
+            _fake_set_nested,
+        )
+
+        sampler = DynestySampler(
+            likelihood,
+            prior_type="uniform",
+            prior_means=prior_means,
+            prior_sigmas=prior_sigmas,
+            use_mpi=True,
+        )
+
+        assert pool_kwargs == [{}]
+        assert len(nested_calls) == 1
+        assert sampler._sampler.kwargs["loglikelihood"].__name__ == "nested_logl_worker"
 
 
 if __name__ == "__main__":

--- a/test/test_Sampling/test_Samplers/test_nautilus.py
+++ b/test/test_Sampling/test_Samplers/test_nautilus.py
@@ -1,0 +1,84 @@
+import types
+import numpy as np
+
+from lenstronomy.Sampling.Samplers.nautilus import Nautilus
+
+
+class _FakeParam(object):
+    @staticmethod
+    def num_param():
+        return 2, None
+
+    @staticmethod
+    def param_limits():
+        return np.array([-1.0, -2.0]), np.array([1.0, 2.0])
+
+
+class _FakeLikelihoodModule(object):
+    def __init__(self):
+        self.param = _FakeParam()
+
+    @staticmethod
+    def likelihood(a):
+        return -float(np.sum(np.square(a)))
+
+
+class _FakePool(object):
+    @staticmethod
+    def is_master():
+        return True
+
+
+class _FakePrior(object):
+    def __init__(self):
+        self.params = []
+
+    def add_parameter(self, dist):
+        self.params.append(dist)
+
+
+class _FakeSampler(object):
+    def __init__(self, prior, likelihood, pool, pass_dict=False, **kwargs):
+        self.prior = prior
+        self._likelihood = likelihood
+
+    def add_bound(self):
+        return None
+
+    def fill_bound(self):
+        return None
+
+    @staticmethod
+    def posterior(return_as_dict=False):
+        points = np.zeros((2, 2))
+        log_w = np.zeros(2)
+        log_l = np.zeros(2)
+        return points, log_w, log_l
+
+    @staticmethod
+    def evidence():
+        return 0.0
+
+
+def test_nautilus_sampling_uses_choose_pool(monkeypatch):
+    def _fake_choose_pool(mpi, processes):
+        assert mpi is False
+        assert processes == 3
+        return _FakePool()
+
+    fake_nautilus_module = types.SimpleNamespace(Prior=_FakePrior, Sampler=_FakeSampler)
+
+    monkeypatch.setattr(
+        "lenstronomy.Sampling.Samplers.nautilus.choose_pool", _fake_choose_pool
+    )
+    monkeypatch.setitem(__import__("sys").modules, "nautilus", fake_nautilus_module)
+
+    wrapper = Nautilus(_FakeLikelihoodModule())
+    points, log_w, log_l, log_z = wrapper.nautilus_sampling(
+        prior_type="uniform", mpi=False, thread_count=3, one_step=True
+    )
+
+    assert points.shape == (2, 2)
+    assert len(log_w) == 2
+    assert len(log_l) == 2
+    assert log_z == 0.0

--- a/test/test_Sampling/test_Samplers/test_nautilus_sampler.py
+++ b/test/test_Sampling/test_Samplers/test_nautilus_sampler.py
@@ -1,4 +1,6 @@
 import copy
+import sys
+import types
 import numpy as np
 import pytest
 
@@ -42,6 +44,50 @@ class TestNautilusSampler(object):
         assert "points" in results
         assert "log_w" in results
         assert "log_l" in results
+
+    def test_sampler_init_mpi_branch(
+        self, simple_einstein_ring_likelihood_2d, monkeypatch
+    ):
+        likelihood, _ = simple_einstein_ring_likelihood_2d
+
+        class _FakeNautilusSamplerBackend(object):
+            def __init__(self, prior, loglikelihood, n_dims, pool=None, **kwargs):
+                self.loglikelihood = loglikelihood
+                self.pool = pool
+                self.kwargs = kwargs
+
+        def _fake_check_install(self):
+            self._nautilus = types.SimpleNamespace(Sampler=_FakeNautilusSamplerBackend)
+
+        pool_kwargs = []
+
+        class _FakeMPIPool(object):
+            def __init__(self, **kwargs):
+                pool_kwargs.append(kwargs)
+
+            @staticmethod
+            def is_master():
+                return True
+
+        nested_calls = []
+
+        def _fake_set_nested(likelihood_module, n_dims):
+            nested_calls.append((likelihood_module, n_dims))
+
+        monkeypatch.setattr(NautilusSampler, "_check_install", _fake_check_install)
+        fake_schwimmbad = types.SimpleNamespace(MPIPool=_FakeMPIPool)
+        monkeypatch.setitem(sys.modules, "schwimmbad", fake_schwimmbad)
+        monkeypatch.setattr(
+            "lenstronomy.Sampling.Samplers.nautilus_sampler.set_nested_likelihood_module",
+            _fake_set_nested,
+        )
+
+        sampler = NautilusSampler(likelihood_module=likelihood, mpi=True)
+
+        assert pool_kwargs == [{}]
+        assert len(nested_calls) == 1
+        assert sampler._sampler.loglikelihood.__name__ == "nested_logl_worker"
+        assert sampler._sampler.pool is not None
 
 
 if __name__ == "__main__":

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -12,6 +12,15 @@ from lenstronomy.LightModel.light_model import LightModel
 from lenstronomy.Sampling.sampler import Sampler, choose_pool
 from lenstronomy.Data.imaging_data import ImageData
 from lenstronomy.Data.psf import PSF
+from lenstronomy.Sampling.Pool.parallelization_util import sampler_logl_worker
+
+
+class _MiniLikelihood(object):
+    param_limits = ([-1.0, -1.0], [1.0, 1.0])
+
+    @staticmethod
+    def logL(args):
+        return -np.sum(np.asarray(args) ** 2)
 
 
 class TestSampler(object):
@@ -260,6 +269,69 @@ class TestSampler(object):
             miniter_callback=miniter_callback,
         )
         assert len(samples_mi) == n_walkers * n_run
+
+
+def test_pool_and_logl_mpi(monkeypatch):
+    calls = []
+
+    class _FakePool(object):
+        pass
+
+    def _fake_choose_pool(**kwargs):
+        calls.append(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr("lenstronomy.Sampling.sampler.choose_pool", _fake_choose_pool)
+
+    sampler = Sampler(likelihoodModule=_MiniLikelihood())
+    pool, logl_function = sampler._pool_and_logl(mpi=True, threadCount=8)
+
+    assert isinstance(pool, _FakePool)
+    assert logl_function is sampler_logl_worker
+    assert calls[0] == {"mpi": True, "processes": 8}
+
+
+def test_pool_and_logl_multiprocess(monkeypatch):
+    calls = []
+
+    class _FakePool(object):
+        pass
+
+    def _fake_choose_pool(**kwargs):
+        calls.append(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr("lenstronomy.Sampling.sampler.choose_pool", _fake_choose_pool)
+
+    sampler = Sampler(likelihoodModule=_MiniLikelihood())
+    pool, logl_function = sampler._pool_and_logl(mpi=False, threadCount=4)
+
+    assert isinstance(pool, _FakePool)
+    assert logl_function is sampler_logl_worker
+    assert calls[0]["mpi"] is False
+    assert calls[0]["processes"] == 4
+    assert "initializer" in calls[0]
+    assert "initargs" in calls[0]
+
+
+def test_pool_and_logl_serial(monkeypatch):
+    calls = []
+
+    class _FakePool(object):
+        pass
+
+    def _fake_choose_pool(**kwargs):
+        calls.append(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr("lenstronomy.Sampling.sampler.choose_pool", _fake_choose_pool)
+
+    sampler = Sampler(likelihoodModule=_MiniLikelihood())
+    pool, logl_function = sampler._pool_and_logl(mpi=False, threadCount=1)
+
+    assert isinstance(pool, _FakePool)
+    assert calls[0] == {"mpi": False, "processes": 1}
+    assert logl_function is sampler.chain.logL
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request reduces serialization overhead in MPI parallelization in the following ways.

1. It introduces module-level wrappers around the relevant `log_likelihood()` entry points, so workers no longer need to receive bound methods from large sampler or likelihood objects. Instead, each worker initializes its likelihood state once and then only receives parameter vectors and returns log-likelihood values. This substantially reduces message size and avoids repeatedly serializing the full enclosing object graph. In practice, this makes parallelization effective even for relatively fast likelihood evaluations, around $O(0.1\,\mathrm{s})$. In a PSO run with 200 particles, scaling improved by a factor of $3.32\times$ when increasing from 20 to 100 cores, whereas previously there was essentially no scaling benefit. For Nautilus, this also resolved the out-of-memory crashes caused by retaining large serialized objects on workers.

2. It removes `use_dill=True` from these MPI code paths. With the new worker-function design, dill-based serialization is no longer needed, and using the simpler default serialization path provides an additional 12-14% speedup.

Given the **large improvements** in MPI-scaling, I would suggest pushing this out to a minor release as quickly as possible after approval and merging, unless there are some other quick features currently in development worth waiting for until the next minor release.

### Changes

**Parallelization Utilities and Worker Initialization:**

* Added a new module `parallelization_util.py` that provides utility functions for setting up and accessing log-likelihood functions in worker processes, including `set_sampler_likelihood_module`, `sampler_logl_worker`, `set_nested_likelihood_module`, and `nested_logl_worker`. This centralizes and standardizes the way likelihood functions are managed in parallel/MPI environments.

**Sampler Refactoring for Parallel and MPI Execution:**

* Updated both the `DynestySampler` and `NautilusSampler` classes to use the new utilities for setting up and invoking log-likelihood functions in MPI pools. The samplers now explicitly call `set_nested_likelihood_module` and use `nested_logl_worker` as the log-likelihood entry point for MPI execution. [[1]](diffhunk://#diff-087fe8370719526e9e2cd8eaa982e4e464f3f446134bc9b778bcf08f9e37e2abR6-R9) [[2]](diffhunk://#diff-087fe8370719526e9e2cd8eaa982e4e464f3f446134bc9b778bcf08f9e37e2abL58-R70) [[3]](diffhunk://#diff-4c7809978e8e592a1e87c0ece5d80d2cbcc40c758b4b2c909b0c832217d94018R7-R10) [[4]](diffhunk://#diff-4c7809978e8e592a1e87c0ece5d80d2cbcc40c758b4b2c909b0c832217d94018L53-R59) [[5]](diffhunk://#diff-4c7809978e8e592a1e87c0ece5d80d2cbcc40c758b4b2c909b0c832217d94018L64-R72)
* Refactored the main `Sampler` class to use the new utility functions for setting up pools and log-likelihood functions, ensuring correct worker initialization and consistent log-likelihood access in parallel execution. This affects methods such as `pso`, `mcmc_emcee`, and `mcmc_zeus`, which now use a helper method `_pool_and_logl` to obtain the appropriate pool and log-likelihood function. [[1]](diffhunk://#diff-684c4b9ce5fcfbed1d61fe275a4b4d759c7106c1143f3404bf75052a797dd39eR9-R12) [[2]](diffhunk://#diff-684c4b9ce5fcfbed1d61fe275a4b4d759c7106c1143f3404bf75052a797dd39eR34-R53) [[3]](diffhunk://#diff-684c4b9ce5fcfbed1d61fe275a4b4d759c7106c1143f3404bf75052a797dd39eL101-R131) [[4]](diffhunk://#diff-684c4b9ce5fcfbed1d61fe275a4b4d759c7106c1143f3404bf75052a797dd39eL195-R219) [[5]](diffhunk://#diff-684c4b9ce5fcfbed1d61fe275a4b4d759c7106c1143f3404bf75052a797dd39eL226-R250) [[6]](diffhunk://#diff-684c4b9ce5fcfbed1d61fe275a4b4d759c7106c1143f3404bf75052a797dd39eL371-R400)

**Pool Creation and Dependency Handling:**

* Removed the `use_dill` argument from all calls to `choose_pool`, as it is no longer required due to the new worker initialization approach. [[1]](diffhunk://#diff-01a82436efbae872df67c8f5ac5c18f0ef2f1fd2f040a3f95b1be8140371f0c8L60-R60) [[2]](diffhunk://#diff-1445f5ab94941d8b1be236aca454e2c188a2ffd9b5dd6ab8280dd1cbf1103733L67-R67) [[3]](diffhunk://#diff-64f2355226a13de14bad8171c7888f5c3a023fd30c47e0d678a6c86b23fb7522L66-R66)
* Updated imports of `SerialPool` and `MPIPool` to use direct imports from `schwimmbad` rather than submodules, improving compatibility with newer versions of the library.