### PR TITLE
Fix calculation of log_z_err in nautilus_sampler

### DIFF
--- a/lenstronomy/Sampling/Samplers/nautilus_sampler.py
+++ b/lenstronomy/Sampling/Samplers/nautilus_sampler.py
@@ -80,7 +80,7 @@ class NautilusSampler(NestedSampler):
         self._sampler.run(**kwargs)
         points, log_w, log_l_weighted = self._sampler.posterior()
         log_z = self._sampler.log_z
-        log_z_err = log_z / np.sqrt(self._sampler.n_eff)
+        log_z_err = 1.0 / np.sqrt(self._sampler.n_eff)
 
         results = {
             "points": points,


### PR DESCRIPTION
This pull request makes a minor fix to the calculation of the log-evidence error in `nautilus_sampler.py`, based on [Nautilus documentation](https://nautilus-sampler.readthedocs.io/en/latest/discussion/faqs.html). Previous implementation assumed that $\sqrt{N_{\rm eff}}$ is a relative error, but it is actually an absolute error.

- Bug fix:
  * Corrected the computation of `log_z_err` in the `run` method of `nautilus_sampler.py` from `log_z / np.sqrt(self._sampler.n_eff)` to `1.0 / np.sqrt(self._sampler.n_eff)`.