### PR TITLE
fix missing supersampling in pixelated convolution for jampy

### DIFF
--- a/lenstronomy/GalKin/aperture.py
+++ b/lenstronomy/GalKin/aperture.py
@@ -10,7 +10,7 @@ from lenstronomy.GalKin.aperture_types import (
     downsample_values_to_bins,
 )
 
-__all__ = ["Aperture"]
+__all__ = ["Aperture", "downsample_values_to_bins"]
 """Class that defines the aperture of the measurement (e.g. slit, integral field
 spectroscopy regions etc).
 

--- a/lenstronomy/JAMPy/jam_wrapper.py
+++ b/lenstronomy/JAMPy/jam_wrapper.py
@@ -79,7 +79,9 @@ class JAMWrapper(JAMWrapperBase, GalkinObservation):
             )
             sigma2_lum_weighted_sup = vrms_sup**2 * surf_bright_sup
             if convolved:
-                sigma2_lum_weighted_sup = self.convolve(sigma2_lum_weighted_sup, supersampling_factor)
+                sigma2_lum_weighted_sup = self.convolve(
+                    sigma2_lum_weighted_sup, supersampling_factor
+                )
                 surf_bright_sup = self.convolve(surf_bright_sup, supersampling_factor)
         else:
             vrms_sup, surf_bright_sup = self.dispersion_points(

--- a/lenstronomy/JAMPy/jam_wrapper.py
+++ b/lenstronomy/JAMPy/jam_wrapper.py
@@ -79,7 +79,7 @@ class JAMWrapper(JAMWrapperBase, GalkinObservation):
             )
             sigma2_lum_weighted_sup = vrms_sup**2 * surf_bright_sup
             if convolved:
-                sigma2_lum_weighted_sup = self.convolve(sigma2_lum_weighted_sup)
+                sigma2_lum_weighted_sup = self.convolve(sigma2_lum_weighted_sup, supersampling_factor)
                 surf_bright_sup = self.convolve(surf_bright_sup, supersampling_factor)
         else:
             vrms_sup, surf_bright_sup = self.dispersion_points(

--- a/test/test_JAMPy/test_jam_wrapper.py
+++ b/test/test_JAMPy/test_jam_wrapper.py
@@ -153,8 +153,8 @@ class TestJAMWrapperSpherical(object):
             "psf_type": "PIXEL",
             "fwhm": 0.5,
             "kernel": self.pix_kernel,
-            "supersampling_factor": 1,
-            "delta_pix": x[1] - x[0],
+            "supersampling_factor": 3,
+            "delta_pix": (x[1] - x[0]) / 3,
         }
         self.jam_spherical_grid_pixel = JAMWrapper(
             kwargs_model=kwargs_model_jampy | {"symmetry": "spherical"},


### PR DESCRIPTION
I realized the Jampy wrapper was missing the supersampling argument for PSF convolution on the pixelated case, which I had missed before because the test was run only with supersampling=1. Now I've fixed the issue and updated the test.