### PR TITLE
introduce jax flag for when param class is called from jaxtronomy

### DIFF
--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -291,6 +291,7 @@ class Param(object):
         # Required for JAXtronomy to initialize Image2SourceMapping class with JAXtronomy profiles
         if _jax:
             from jaxtronomy.Util import class_creator as class_creator_jax
+
             _class_creator = class_creator_jax
         else:
             _class_creator = class_creator

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -158,6 +158,7 @@ class Param(object):
         distance_ratio_sampling=False,
         cosmology_sampling=False,
         solver_param_module=None,
+        _jax=False,
     ):
         """
 
@@ -238,6 +239,7 @@ class Param(object):
         :param cosmology_model: str, name of the cosmology model to use for
         :param solver_param_module: a class that performs conversions update_kwargs, extract_array, and add_fixed_lens
          for the Solver4Point class with the solver_type = 'CUSTOM' option
+        :param _jax: bool, flag that is set whenever this class is called from JAXtronomy
         """
 
         self._lens_model_list = kwargs_model.get("lens_model_list", [])
@@ -286,13 +288,19 @@ class Param(object):
         else:
             num_lens_planes = len(list(set(self._lens_redshift_list)))
 
+        # Required for JAXtronomy to initialize Image2SourceMapping class with JAXtronomy profiles
+        if _jax:
+            from jaxtronomy.Util import class_creator as class_creator_jax
+            _class_creator = class_creator_jax
+        else:
+            _class_creator = class_creator
         (
             self._lens_model_class,
             self._source_model_class,
             _,
             _,
             _,
-        ) = class_creator.create_class_instances(all_models=True, **kwargs_model)
+        ) = _class_creator.create_class_instances(all_models=True, **kwargs_model)
         self._image2SourceMapping = Image2SourceMapping(
             lens_model=self._lens_model_class, source_model=self._source_model_class
         )
@@ -379,7 +387,7 @@ class Param(object):
         except:
             self._num_images = 0
         self._solver_type = solver_type
-        if self._solver_type == "NONE":
+        if self._solver_type == "NONE" or self._solver_type is None:
             self._solver = False
         else:
             self._solver = True

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -654,6 +654,37 @@ class TestParam(object):
         )
         self.param_class.print_setting()
 
+    def test_jax_flag(self):
+        kwargs_model = {
+            "lens_model_list": ["EPL"],
+            "source_light_model_list": ["GAUSSIAN"],
+            "lens_light_model_list": ["SERSIC"],
+            "point_source_model_list": ["LENSED_POSITION"],
+            "multi_plane": True,
+            "lens_redshift_list": [0.5],
+            "z_source": 2,
+            "distance_ratio_sampling": None,
+        }
+        kwargs_param = {
+            "num_point_source_list": [2],
+        }
+        kwargs_fixed_lens = [{"gamma": 1.9}]
+        kwargs_fixed_source = [{"sigma": 0.1, "center_x": 0.2, "center_y": 0.2}]
+        kwargs_fixed_ps = [{"ra_image": [-1, 1], "dec_image": [-1, 1]}]
+        kwargs_fixed_lens_light = [{}]
+        kwargs_fixed_cosmo = [{}]
+        self.param_class = Param(
+            kwargs_model,
+            kwargs_fixed_lens=kwargs_fixed_lens,
+            kwargs_fixed_source=kwargs_fixed_source,
+            kwargs_fixed_lens_light=kwargs_fixed_lens_light,
+            kwargs_fixed_ps=kwargs_fixed_ps,
+            kwargs_fixed_special=kwargs_fixed_cosmo,
+            _jax=True,
+            **kwargs_param
+        )
+        self.param_class.print_setting()
+
 
 class TestRaise(unittest.TestCase):
     def test_raise(self):

--- a/test/test_Sampling/test_parameters.py
+++ b/test/test_Sampling/test_parameters.py
@@ -660,10 +660,7 @@ class TestParam(object):
             "source_light_model_list": ["GAUSSIAN"],
             "lens_light_model_list": ["SERSIC"],
             "point_source_model_list": ["LENSED_POSITION"],
-            "multi_plane": True,
-            "lens_redshift_list": [0.5],
-            "z_source": 2,
-            "distance_ratio_sampling": None,
+            "multi_plane": False,
         }
         kwargs_param = {
             "num_point_source_list": [2],


### PR DESCRIPTION
1. introduce jax flag for when param class is called from jaxtronomy
2. Allow `solver_type` to be `None`