### PR TITLE
fixed if statement in AdaptiveGrid

### DIFF
--- a/lenstronomy/ImSim/Numerics/grid.py
+++ b/lenstronomy/ImSim/Numerics/grid.py
@@ -87,7 +87,7 @@ class AdaptiveGrid(Coordinates1D):
 
         :return: 1d arrays of subpixel grid coordinates
         """
-        if not hasattr(self, "_x_sub_grid"):
+        if not hasattr(self, "_x_high_res"):
             self._subpixel_coordinates()
         return self._x_high_res, self._y_high_res
 


### PR DESCRIPTION
This PR fixes an if statement that would _always_ execute during image simulation if using AdaptiveGrid, since the `_x_sub_grid` attribute doesn't actually exist.