### PR TITLE
Add point mass handling to Jampy API

### DIFF
--- a/lenstronomy/Analysis/kinematics_api.py
+++ b/lenstronomy/Analysis/kinematics_api.py
@@ -186,6 +186,7 @@ class KinematicsAPI(object):
         self._kwargs_mge_light = kwargs_mge_light
         self._kwargs_numerics_galkin = kwargs_numerics_galkin
         self._kwargs_numerics_jampy = kwargs_numerics_jampy
+        self._black_hole_mass = 0.0
         self._anisotropy_model = anisotropy_model
         self._analytic_kinematics = analytic_kinematics
         self._Hernquist_approx = Hernquist_approx
@@ -244,6 +245,7 @@ class KinematicsAPI(object):
                     kwargs_light_i,
                     kwargs_anisotropy,
                     inclination=inclination,
+                    black_hole_mass=self._black_hole_mass,
                 )
             sigma_v = np.append(sigma_v, sigma_v_)
         sigma_v = self.transform_kappa_ext(sigma_v, kappa_ext=kappa_ext)
@@ -320,6 +322,7 @@ class KinematicsAPI(object):
                     inclination=inclination,
                     supersampling_factor=supersampling_factor,
                     voronoi_bins=voronoi_bins,
+                    black_hole_mass=self._black_hole_mass,
                 )
             sigma_v_map = np.append(sigma_v_map, sigma_v_map_)
         sigma_v_map = self.transform_kappa_ext(sigma_v_map, kappa_ext=kappa_ext)
@@ -539,10 +542,21 @@ class KinematicsAPI(object):
             return None, {"theta_E": theta_E, "gamma": gamma}
         mass_profile_list = []
         kwargs_profile = []
+        self._black_hole_mass = 0.0
         if model_kinematics_bool is None:
             model_kinematics_bool = [True] * len(kwargs_lens)
         for i, lens_model in enumerate(self._lens_model_list):
             if model_kinematics_bool[i] is True:
+                if self.kinematics_backend == "jampy" and lens_model in [
+                    "POINT_MASS",
+                    "POINT_MASS_LOG_SCALED",
+                ]:
+                    if lens_model == "POINT_MASS":
+                        theta_E_i = kwargs_lens[i]["theta_E"]
+                    else:
+                        theta_E_i = 10.0 ** kwargs_lens[i]["log10_theta_E"]
+                    self._black_hole_mass += self.lensCosmo.mass_in_theta_E(theta_E_i)
+                    continue
                 mass_profile_list.append(lens_model)
                 if lens_model in ["INTERPOL", "INTERPOL_SCLAED"]:
                     center_x_i, center_y_i = self._lensMassProfile.convergence_peak(
@@ -571,14 +585,20 @@ class KinematicsAPI(object):
                 kwargs_profile.append(kwargs_lens_i)
 
         if MGE_fit is True:
+            kwargs_lens_mge = [
+                kwargs_lens[i]
+                for i, lens_model in enumerate(self._lens_model_list)
+                if model_kinematics_bool[i]
+                and lens_model not in ["POINT_MASS", "POINT_MASS_LOG_SCALED"]
+            ]
             MGE_mass_fitter = MGEMass(mass_profile_list, kwargs_mge)
-            amps, sigmas = MGE_mass_fitter.mge_fit(kwargs_lens, theta_E)
+            amps, sigmas = MGE_mass_fitter.mge_fit(kwargs_lens_mge, theta_E)
             kwargs_profile = [{"amp": amps, "sigma": sigmas}]
             if self.axial_symmetry == "spherical":
                 mass_profile_list = ["MULTI_GAUSSIAN"]
             else:
                 mass_profile_list = ["MULTI_GAUSSIAN_ELLIPSE_KAPPA"]
-                kwargs_profile = self._copy_ellip(kwargs_profile, kwargs_lens)
+                kwargs_profile = self._copy_ellip(kwargs_profile, kwargs_lens_mge)
         kwargs_profile = self._copy_centers(kwargs_profile, kwargs_lens)
         return mass_profile_list, kwargs_profile
 

--- a/test/test_Analysis/test_kinematics_api.py
+++ b/test/test_Analysis/test_kinematics_api.py
@@ -1622,6 +1622,91 @@ class TestRaise(unittest.TestCase):
 
 class TestKinematicsAPIJAMPy(object):
 
+    @pytest.mark.parametrize(
+        "point_mass_model, point_mass_kwargs",
+        [
+            ("POINT_MASS", {"theta_E": 0.03}),
+            ("POINT_MASS_LOG_SCALED", {"log10_theta_E": np.log10(0.03)}),
+        ],
+    )
+    def test_point_mass_is_converted_to_black_hole_mass(
+        self, point_mass_model, point_mass_kwargs
+    ):
+        z_lens = 0.5
+        z_source = 1.5
+        kwargs_model = {
+            "lens_model_list": ["EPL", point_mass_model],
+            "lens_light_model_list": ["SERSIC_ELLIPSE"],
+        }
+        kwargs_lens = [
+            {
+                "theta_E": 1.5,
+                "e1": 0,
+                "center_x": -0.044798916793300093,
+                "center_y": 0.0054408937891703788,
+                "e2": 0,
+                "gamma": 1.8,
+            },
+            {
+                "center_x": 0.0,
+                "center_y": 0.0,
+                **point_mass_kwargs,
+            },
+        ]
+
+        phi, q = -0.52624727893702705, 0.79703498156919605
+        e1, e2 = param_util.phi_q2_ellipticity(phi, q)
+        kwargs_lens_light = [
+            {
+                "n_sersic": 1.1212528655709217,
+                "center_x": -0.019674496231393473,
+                "e1": e1,
+                "e2": e2,
+                "amp": 1.1091367792010356,
+                "center_y": 0.076914975081560991,
+                "R_sersic": 0.42691611878867058,
+            },
+        ]
+        kwargs_anisotropy = {"r_ani": 0.62}
+        kwargs_aperture = {
+            "aperture_type": "slit",
+            "center_ra": 0,
+            "width": 1.0,
+            "length": 3.8,
+            "angle": 0,
+            "center_dec": 0,
+        }
+        kwargs_psf = {"psf_type": "GAUSSIAN", "fwhm": 0.7}
+
+        kinematicAPI = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_model,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_psf,
+            anisotropy_model="OM",
+            kwargs_mge_light={"n_comp": 20},
+            kwargs_mge_mass={"n_comp": 20},
+            kinematics_backend="jampy",
+            MGE_light=True,
+            MGE_mass=True,
+        )
+
+        mass_profile_list, kwargs_profile = kinematicAPI.kinematic_lens_profiles(
+            kwargs_lens, MGE_fit=False
+        )
+
+        if "theta_E" in point_mass_kwargs:
+            expected_theta_E = point_mass_kwargs["theta_E"]
+        else:
+            expected_theta_E = 10.0 ** point_mass_kwargs["log10_theta_E"]
+        npt.assert_allclose(
+            kinematicAPI._black_hole_mass,
+            kinematicAPI.lensCosmo.mass_in_theta_E(expected_theta_E),
+        )
+        assert mass_profile_list == ["EPL"]
+        assert len(kwargs_profile) == 1
+
     def test_velocity_dispersion(self):
         z_lens = 0.5
         z_source = 1.5


### PR DESCRIPTION
This pull request updates the kinematics API to properly handle point mass lens models (`POINT_MASS` and `POINT_MASS_LOG_SCALED`) by converting them to a central black hole mass when using the "jampy" backend. It also ensures these point mass models are excluded from MGE mass fitting and adds a test to verify the new behavior.