### PR TITLE
expand support to python 3.12 and 3.13

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -8,15 +8,12 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.version }}
-  cancel-in-progress: false
-
 jobs:
   build:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false  # Prevents cancellation of other versions if one fails
       matrix:
         python-version: [3.11, 3.12, 3.13]
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.version }}
+  cancel-in-progress: false
+
 jobs:
   build:
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.11, 3.12, 3.13]
 
     steps:
       - uses: actions/checkout@v4

--- a/lenstronomy/Util/package_util.py
+++ b/lenstronomy/Util/package_util.py
@@ -47,6 +47,8 @@ def short(_laconic=False):
         image_model = ls.ImSim.image_model.ImageModel(...)
     """
     import pkgutil
+    import sys
+    from importlib.util import module_from_spec
     import lenstronomy
 
     to_add = dict()
@@ -59,9 +61,10 @@ def short(_laconic=False):
             continue
 
         # Load the module
-        module = all_modules[module_name] = loader.find_module(module_name).load_module(
-            module_name
-        )
+        spec = loader.find_spec(module_name)
+        module = all_modules[module_name] = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        sys.modules[module_name] = module
 
         if "." in module_name:
             # Submodule, e.g. Data.psf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 astropy
-scipy>=0.19.1
+scipy>=0.19.1, <1.18.0
 mpmath
 emcee>=3.0.0
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,9 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     tests_require=tests_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ requires = [
     "pyxdg",
     "schwimmbad",
     "multiprocess>=0.70.8",
-    "jampy",
+    "jampy<9.0.0",
     "mgefit",  # required by jampy
 ]
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ history = open("HISTORY.rst").read().replace(".. :changelog:", "")
 desc = open("README.rst").read()
 requires = [
     "numpy>=1.13",
-    "scipy>=0.19.1",
+    "scipy>=0.19.1,<1.18.0",
     "configparser",
     "astropy",
     "mpmath",


### PR DESCRIPTION
JAX will be dropping support for Python 3.11 on July 15th. Since JAXtronomy relies partially on lenstronomy, this PR ensures that lenstronomy supports Python versions 3.12 and 3.13.

This PR also addresses #845.