### PR TITLE
Fix DeprecationWarning in Numpy>=2

### DIFF
--- a/lenstronomy/ImSim/Numerics/convolution.py
+++ b/lenstronomy/ImSim/Numerics/convolution.py
@@ -118,8 +118,10 @@ class PixelKernelConvolution(object):
         # sure we only call rfftn/irfftn from one thread at a time.
         if not complex_result and (_rfft_mt_safe or _rfft_lock.acquire(False)):
             try:
-                sp1 = np.fft.rfftn(in1, fshape)
-                ret = np.fft.irfftn(sp1 * sp2, fshape)[fslice].copy()
+                sp1 = np.fft.rfftn(in1, fshape, axes=tuple(range(in1.ndim)))
+                ret = np.fft.irfftn(sp1 * sp2, fshape, axes=tuple(range(sp1.ndim)))[
+                    fslice
+                ].copy()
             finally:
                 if not _rfft_mt_safe:
                     _rfft_lock.release()
@@ -171,7 +173,7 @@ class PixelKernelConvolution(object):
         # sure we only call rfftn/irfftn from one thread at a time.
         if not complex_result and (_rfft_mt_safe or _rfft_lock.acquire(False)):
             try:
-                sp2 = np.fft.rfftn(in2, fshape)
+                sp2 = np.fft.rfftn(in2, fshape, axes=tuple(range(in2.ndim)))
             finally:
                 if not _rfft_mt_safe:
                     _rfft_lock.release()


### PR DESCRIPTION
`lenstronomy.ImSim.Numerics.convolution.PixelKernelConvolution.convolution2d()` raises the following deprecation warning on Numpy>=2.0:

`DeprecationWarning at /Users/brycewedig/Documents/GitHub/lenstronomy/lenstronomy/ImSim/Numerics/convolution.py:121
    `axes` should not be `None` if `s` is not `None` (Deprecated in NumPy 2.0). In a future version of NumPy, this will raise an error and `s[i]` will correspond to the size along the transformed axis specified by `axes[i]`. To retain current behaviour, pass a sequence [0, ..., k-1] to `axes` for an array of dimension k.`

Following the recommendation, pass a tuple of the appropriate length as `axes` to retain the current behavior.