### PR TITLE
Add multiband offset sampling support

### DIFF
--- a/lenstronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/image_likelihood.py
@@ -1,5 +1,6 @@
 import numpy as np
 from lenstronomy.Util import class_creator
+from lenstronomy.Util import util
 
 __all__ = ["ImageLikelihood"]
 
@@ -50,6 +51,7 @@ class ImageLikelihood(object):
         self._source_marg = source_marg
         self._linear_prior = linear_prior
         self._check_positive_flux = check_positive_flux
+        self.num_bands = len(multi_band_list)
 
     def logL(
         self,
@@ -71,19 +73,27 @@ class ImageLikelihood(object):
         :param kwargs_extinction: extinction parameter keyword argument list according to LightModel module
         :return: log likelihood of the data given the model, linear parameter inversion list
         """
-        logL, param = self.imSim.likelihood_data_given_model(
-            kwargs_lens,
-            kwargs_source,
-            kwargs_lens_light,
-            kwargs_ps,
-            kwargs_extinction=kwargs_extinction,
-            kwargs_special=kwargs_special,
-            source_marg=self._source_marg,
-            linear_prior=self._linear_prior,
-            check_positive_flux=self._check_positive_flux,
-        )
-        if np.isnan(logL) is True:
-            return -(10**15), param
+
+        backup_grids = self._apply_multiband_offsets(kwargs_special)
+        try:
+            logL, param = self.imSim.likelihood_data_given_model(
+                kwargs_lens,
+                kwargs_source,
+                kwargs_lens_light,
+                kwargs_ps,
+                kwargs_extinction=kwargs_extinction,
+                kwargs_special=kwargs_special,
+                source_marg=self._source_marg,
+                linear_prior=self._linear_prior,
+                check_positive_flux=self._check_positive_flux,
+            )
+
+            if np.isnan(logL) is True:
+                return -(10**15), param
+            
+        finally:
+            self._restore_multiband_offsets(backup_grids)
+        
         return logL, param
 
     @property
@@ -119,3 +129,149 @@ class ImageLikelihood(object):
         :return: None
         """
         self.imSim.reset_point_source_cache(cache=cache)
+
+    def _apply_multiband_offsets(self, kwargs_special):
+            """
+            Temporarily apply model-side astrometric corrections (shift and rotation) to the coordinate grid.
+
+            The sampled offsets represent corrections applied to the model coordinate system during likelihood evaluation.
+            Therefore, when interpreting recovered parameters as astrometric offsets between observed bands, the sign is
+            opposite.
+
+            :param kwargs_special: contains 'kwargs_offsets', where each dictionary specifies the correction for the corresponding band.
+            :return: dict; backup of the original coordinate states to be restored after logL evaluation
+            """
+            if kwargs_special is None or 'kwargs_offsets' not in kwargs_special:
+                return None
+
+            kwargs_offsets = kwargs_special['kwargs_offsets']
+            backup_grids = {}
+
+            for band_index, offset in enumerate(kwargs_offsets):
+                if not offset:  # Skip if dict is empty or None
+                    continue
+                if band_index >= self.num_bands:
+                    break
+                
+                dx = offset.get('dx', 0)
+                dy = offset.get('dy', 0)
+                angle = offset.get('angle', 0)
+
+                if dx == 0 and dy == 0 and angle == 0:
+                    continue
+                
+                # Get the list containing SingleBandMultiModel objects
+                if hasattr(self.imSim, '_imageModel_list'):
+                    image_model_list = self.imSim._imageModel_list
+                elif hasattr(self.imSim, 'imageModel_list'):
+                    image_model_list = self.imSim.imageModel_list
+                else:
+                    image_model_list = [self.imSim] # single band case
+
+                # Backup original state
+                data_class = image_model_list[band_index].Data
+                grid = image_model_list[band_index].ImageNumerics._numerics_subframe._grid
+
+                backup_grids[band_index] = {
+                    'data_ra_at_xy_0': data_class._ra_at_xy_0,
+                    'data_dec_at_xy_0': data_class._dec_at_xy_0,
+                    'data_Mpix2a': np.copy(data_class._Mpix2a),
+
+                    'grid_ra_at_xy_0': grid._ra_at_xy_0,
+                    'grid_dec_at_xy_0': grid._dec_at_xy_0,
+                    'grid_Mpix2a': np.copy(grid._Mpix2a),
+                    'grid_Ma2pix': np.copy(grid._Ma2pix),
+                    'grid_x_grid': np.copy(grid._x_grid),
+                    'grid_y_grid': np.copy(grid._y_grid),
+                    'grid_ra_subgrid': np.copy(grid._ra_subgrid),
+                    'grid_dec_subgrid': np.copy(grid._dec_subgrid),
+                }
+
+                # Calculate rotation around the geometric center
+                nx, ny = data_class._nx, data_class._ny
+                cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
+                M_old = data_class._Mpix2a
+                ra_0_old = data_class._ra_at_xy_0
+                dec_0_old = data_class._dec_at_xy_0
+
+                ra_center = ra_0_old + M_old[0, 0] * cx + M_old[0, 1] * cy
+                dec_center = dec_0_old + M_old[1, 0] * cx + M_old[1, 1] * cy
+
+                cos_a, sin_a = np.cos(angle), np.sin(angle)
+                rot_matrix = np.array([[cos_a, -sin_a], 
+                                    [sin_a,  cos_a]])
+                M_new = np.dot(rot_matrix, M_old)
+
+                ra_0_new = ra_center - (M_new[0, 0] * cx + M_new[0, 1] * cy) + dx
+                dec_0_new = dec_center - (M_new[1, 0] * cx + M_new[1, 1] * cy) + dy
+
+                # Mutate internal attributes
+                data_class._ra_at_xy_0 = ra_0_new
+                data_class._dec_at_xy_0 = dec_0_new
+                data_class._Mpix2a = M_new
+                
+                # Force grid re-evaluation
+                x_grid, y_grid = data_class.coordinate_grid(nx, ny)
+                data_class._x_grid = np.atleast_1d(x_grid)
+                data_class._y_grid = np.atleast_1d(y_grid)
+
+                # Update RegularGrid cache used by ImageNumerics
+                grid = image_model_list[band_index].ImageNumerics._numerics_subframe._grid
+
+                grid._ra_at_xy_0 = data_class._ra_at_xy_0
+                grid._dec_at_xy_0 = data_class._dec_at_xy_0
+                grid._Mpix2a = data_class._Mpix2a
+                grid._Ma2pix = data_class._Ma2pix
+
+                grid._x_grid, grid._y_grid = grid.coordinate_grid(
+                    grid._nx,
+                    grid._ny,
+                )
+
+                x_sub, y_sub = util.make_subgrid(
+                    grid._x_grid,
+                    grid._y_grid,
+                    grid._supersampling_factor,
+                )
+
+                grid._ra_subgrid = x_sub[grid._compute_indexes]
+                grid._dec_subgrid = y_sub[grid._compute_indexes]
+
+            return backup_grids
+
+    def _restore_multiband_offsets(self, backup_grids):
+        """
+        Restore the original coordinate grids after logL evaluation.
+
+        :param backup_grids: dict; coordinate states returned by _apply_multiband_offsets
+        """
+        if backup_grids is None:
+            return
+
+        # Get the list containing SingleBandMultiModel objects
+        if hasattr(self.imSim, '_imageModel_list'):
+            image_model_list = self.imSim._imageModel_list
+        elif hasattr(self.imSim, 'imageModel_list'):
+            image_model_list = self.imSim.imageModel_list
+        else:
+            image_model_list = [self.imSim] # single band case
+
+        for band_index, backup in backup_grids.items():
+            data_class = image_model_list[band_index].Data
+
+            data_class._ra_at_xy_0 = backup['data_ra_at_xy_0']
+            data_class._dec_at_xy_0 = backup['data_dec_at_xy_0']
+            data_class._Mpix2a = backup['data_Mpix2a']
+
+            grid = image_model_list[band_index].ImageNumerics._numerics_subframe._grid
+
+            grid._ra_at_xy_0 = backup['grid_ra_at_xy_0']
+            grid._dec_at_xy_0 = backup['grid_dec_at_xy_0']
+            grid._Mpix2a = backup['grid_Mpix2a']
+            grid._Ma2pix = backup['grid_Ma2pix']
+
+            grid._x_grid = backup['grid_x_grid']
+            grid._y_grid = backup['grid_y_grid']
+
+            grid._ra_subgrid = backup['grid_ra_subgrid']
+            grid._dec_subgrid = backup['grid_dec_subgrid']

--- a/lenstronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/lenstronomy/Sampling/Likelihoods/image_likelihood.py
@@ -74,26 +74,21 @@ class ImageLikelihood(object):
         :return: log likelihood of the data given the model, linear parameter inversion list
         """
 
-        backup_grids = self._apply_multiband_offsets(kwargs_special)
-        try:
-            logL, param = self.imSim.likelihood_data_given_model(
-                kwargs_lens,
-                kwargs_source,
-                kwargs_lens_light,
-                kwargs_ps,
-                kwargs_extinction=kwargs_extinction,
-                kwargs_special=kwargs_special,
-                source_marg=self._source_marg,
-                linear_prior=self._linear_prior,
-                check_positive_flux=self._check_positive_flux,
-            )
+        logL, param = self.imSim.likelihood_data_given_model(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
+            kwargs_extinction=kwargs_extinction,
+            kwargs_special=kwargs_special,
+            source_marg=self._source_marg,
+            linear_prior=self._linear_prior,
+            check_positive_flux=self._check_positive_flux,
+        )
 
-            if np.isnan(logL) is True:
-                return -(10**15), param
-            
-        finally:
-            self._restore_multiband_offsets(backup_grids)
-        
+        if np.isnan(logL) is True:
+            return -(10**15), param
+
         return logL, param
 
     @property
@@ -129,149 +124,3 @@ class ImageLikelihood(object):
         :return: None
         """
         self.imSim.reset_point_source_cache(cache=cache)
-
-    def _apply_multiband_offsets(self, kwargs_special):
-            """
-            Temporarily apply model-side astrometric corrections (shift and rotation) to the coordinate grid.
-
-            The sampled offsets represent corrections applied to the model coordinate system during likelihood evaluation.
-            Therefore, when interpreting recovered parameters as astrometric offsets between observed bands, the sign is
-            opposite.
-
-            :param kwargs_special: contains 'kwargs_offsets', where each dictionary specifies the correction for the corresponding band.
-            :return: dict; backup of the original coordinate states to be restored after logL evaluation
-            """
-            if kwargs_special is None or 'kwargs_offsets' not in kwargs_special:
-                return None
-
-            kwargs_offsets = kwargs_special['kwargs_offsets']
-            backup_grids = {}
-
-            for band_index, offset in enumerate(kwargs_offsets):
-                if not offset:  # Skip if dict is empty or None
-                    continue
-                if band_index >= self.num_bands:
-                    break
-                
-                dx = offset.get('dx', 0)
-                dy = offset.get('dy', 0)
-                angle = offset.get('angle', 0)
-
-                if dx == 0 and dy == 0 and angle == 0:
-                    continue
-                
-                # Get the list containing SingleBandMultiModel objects
-                if hasattr(self.imSim, '_imageModel_list'):
-                    image_model_list = self.imSim._imageModel_list
-                elif hasattr(self.imSim, 'imageModel_list'):
-                    image_model_list = self.imSim.imageModel_list
-                else:
-                    image_model_list = [self.imSim] # single band case
-
-                # Backup original state
-                data_class = image_model_list[band_index].Data
-                grid = image_model_list[band_index].ImageNumerics._numerics_subframe._grid
-
-                backup_grids[band_index] = {
-                    'data_ra_at_xy_0': data_class._ra_at_xy_0,
-                    'data_dec_at_xy_0': data_class._dec_at_xy_0,
-                    'data_Mpix2a': np.copy(data_class._Mpix2a),
-
-                    'grid_ra_at_xy_0': grid._ra_at_xy_0,
-                    'grid_dec_at_xy_0': grid._dec_at_xy_0,
-                    'grid_Mpix2a': np.copy(grid._Mpix2a),
-                    'grid_Ma2pix': np.copy(grid._Ma2pix),
-                    'grid_x_grid': np.copy(grid._x_grid),
-                    'grid_y_grid': np.copy(grid._y_grid),
-                    'grid_ra_subgrid': np.copy(grid._ra_subgrid),
-                    'grid_dec_subgrid': np.copy(grid._dec_subgrid),
-                }
-
-                # Calculate rotation around the geometric center
-                nx, ny = data_class._nx, data_class._ny
-                cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
-                M_old = data_class._Mpix2a
-                ra_0_old = data_class._ra_at_xy_0
-                dec_0_old = data_class._dec_at_xy_0
-
-                ra_center = ra_0_old + M_old[0, 0] * cx + M_old[0, 1] * cy
-                dec_center = dec_0_old + M_old[1, 0] * cx + M_old[1, 1] * cy
-
-                cos_a, sin_a = np.cos(angle), np.sin(angle)
-                rot_matrix = np.array([[cos_a, -sin_a], 
-                                    [sin_a,  cos_a]])
-                M_new = np.dot(rot_matrix, M_old)
-
-                ra_0_new = ra_center - (M_new[0, 0] * cx + M_new[0, 1] * cy) + dx
-                dec_0_new = dec_center - (M_new[1, 0] * cx + M_new[1, 1] * cy) + dy
-
-                # Mutate internal attributes
-                data_class._ra_at_xy_0 = ra_0_new
-                data_class._dec_at_xy_0 = dec_0_new
-                data_class._Mpix2a = M_new
-                
-                # Force grid re-evaluation
-                x_grid, y_grid = data_class.coordinate_grid(nx, ny)
-                data_class._x_grid = np.atleast_1d(x_grid)
-                data_class._y_grid = np.atleast_1d(y_grid)
-
-                # Update RegularGrid cache used by ImageNumerics
-                grid = image_model_list[band_index].ImageNumerics._numerics_subframe._grid
-
-                grid._ra_at_xy_0 = data_class._ra_at_xy_0
-                grid._dec_at_xy_0 = data_class._dec_at_xy_0
-                grid._Mpix2a = data_class._Mpix2a
-                grid._Ma2pix = data_class._Ma2pix
-
-                grid._x_grid, grid._y_grid = grid.coordinate_grid(
-                    grid._nx,
-                    grid._ny,
-                )
-
-                x_sub, y_sub = util.make_subgrid(
-                    grid._x_grid,
-                    grid._y_grid,
-                    grid._supersampling_factor,
-                )
-
-                grid._ra_subgrid = x_sub[grid._compute_indexes]
-                grid._dec_subgrid = y_sub[grid._compute_indexes]
-
-            return backup_grids
-
-    def _restore_multiband_offsets(self, backup_grids):
-        """
-        Restore the original coordinate grids after logL evaluation.
-
-        :param backup_grids: dict; coordinate states returned by _apply_multiband_offsets
-        """
-        if backup_grids is None:
-            return
-
-        # Get the list containing SingleBandMultiModel objects
-        if hasattr(self.imSim, '_imageModel_list'):
-            image_model_list = self.imSim._imageModel_list
-        elif hasattr(self.imSim, 'imageModel_list'):
-            image_model_list = self.imSim.imageModel_list
-        else:
-            image_model_list = [self.imSim] # single band case
-
-        for band_index, backup in backup_grids.items():
-            data_class = image_model_list[band_index].Data
-
-            data_class._ra_at_xy_0 = backup['data_ra_at_xy_0']
-            data_class._dec_at_xy_0 = backup['data_dec_at_xy_0']
-            data_class._Mpix2a = backup['data_Mpix2a']
-
-            grid = image_model_list[band_index].ImageNumerics._numerics_subframe._grid
-
-            grid._ra_at_xy_0 = backup['grid_ra_at_xy_0']
-            grid._dec_at_xy_0 = backup['grid_dec_at_xy_0']
-            grid._Mpix2a = backup['grid_Mpix2a']
-            grid._Ma2pix = backup['grid_Ma2pix']
-
-            grid._x_grid = backup['grid_x_grid']
-            grid._y_grid = backup['grid_y_grid']
-
-            grid._ra_subgrid = backup['grid_ra_subgrid']
-            grid._dec_subgrid = backup['grid_dec_subgrid']

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -5,7 +5,7 @@ parameters you can safely ignore this.
 """
 
 __author__ = "jhodonnell"
-__all__ = ["ModelParamGroup", "SingleParam", "ArrayParam"]
+__all__ = ["ModelParamGroup", "SingleParam", "ArrayParam", "MultiBandOffsetParam"]
 
 import numpy as np
 
@@ -340,6 +340,221 @@ class ArrayParam(ModelParamGroup):
         for name, count in self.param_names.items():
             out[name] = [self._kwargs_upper[name]] * count
         return out
+
+    @property
+    def on(self):
+        return self._on
+
+class MultiBandOffsetParam(ModelParamGroup):
+    """
+    Parameter group for jointly sampling multi-band astrometric offsets.
+
+    Each non-reference band has three possible parameters:
+    dx, dy, and rotation angle.
+
+    The reference band is fixed and therefore has no sampled parameters.
+    """
+
+    def __init__(self, on=False, num_bands=1, reference_band=0):
+        self._on = bool(on)
+        self._num_bands = num_bands
+        self._reference_band = reference_band
+
+
+    def num_params(self, kwargs_fixed):
+
+        if not self.on:
+            return 0, []
+        n_params = 0
+        names = []
+
+        fixed_offsets = kwargs_fixed.get(
+            "kwargs_offsets",
+            [{} for _ in range(self._num_bands)]
+        )
+
+        for band in range(self._num_bands):
+            if band == self._reference_band:
+                continue
+
+            fixed_band = (
+                fixed_offsets[band]
+                if band < len(fixed_offsets)
+                else {}
+            )
+
+            for param in ["dx", "dy", "angle"]:
+                if param not in fixed_band:
+                    n_params += 1
+                    names.append(
+                        f"{param}_band_{band}"
+                    )
+
+        return n_params, names
+
+
+    def set_params(self, kwargs, kwargs_fixed):
+        if not self.on:
+            return []
+        args = []
+
+        sampled_offsets = kwargs.get("kwargs_offsets")
+        if sampled_offsets is None:
+            sampled_offsets = [
+                {}
+                for _ in range(self._num_bands)
+            ]
+
+        fixed_offsets = kwargs_fixed.get(
+            "kwargs_offsets",
+            [{} for _ in range(self._num_bands)]
+        )
+
+        for band in range(self._num_bands):
+            # The reference band is fixed and does not contribute sampled parameters.
+            if band == self._reference_band:
+                continue
+
+            offset = (
+                sampled_offsets[band]
+                if band < len(sampled_offsets)
+                else {}
+            )
+            fixed_band = (
+                fixed_offsets[band]
+                if band < len(fixed_offsets)
+                else {}
+            )
+            for param in ["dx", "dy", "angle"]:
+                if param not in fixed_band:
+                    args.append(
+                        offset.get(param, 0)
+                    )
+        return args
+
+    def get_params(
+        self,
+        args,
+        i,
+        kwargs_fixed,
+        kwargs_lower=None,
+        kwargs_upper=None
+    ):
+        if not self.on:
+            return {}, i
+
+        kwargs_offsets = [
+            {}
+            for _ in range(self._num_bands)
+        ]
+
+        fixed_offsets = kwargs_fixed.get(
+            "kwargs_offsets",
+            [{} for _ in range(self._num_bands)]
+        )
+
+        lower_offsets = (
+            kwargs_lower.get("kwargs_offsets", [])
+            if kwargs_lower is not None
+            else []
+        )
+        if lower_offsets is None:
+            lower_offsets = []
+
+        upper_offsets = (
+            kwargs_upper.get("kwargs_offsets", [])
+            if kwargs_upper is not None
+            else []
+        )
+        if upper_offsets is None:
+            upper_offsets = []
+
+        for band in range(self._num_bands):
+            if band == self._reference_band:
+                continue
+
+            fixed_band = (
+                fixed_offsets[band]
+                if band < len(fixed_offsets)
+                else {}
+            )
+
+            lower_band = (
+                lower_offsets[band]
+                if band < len(lower_offsets)
+                else {}
+            )
+
+            upper_band = (
+                upper_offsets[band]
+                if band < len(upper_offsets)
+                else {}
+            )
+
+            band_dict = {}
+
+            for param in ["dx", "dy", "angle"]:
+                if param not in fixed_band:
+                    value = args[i]
+                    i += 1
+                    
+                    if param in lower_band:
+                        value = np.maximum(
+                            value,
+                            lower_band[param]
+                        )
+
+                    if param in upper_band:
+                        value = np.minimum(
+                            value,
+                            upper_band[param]
+                        )
+
+                    band_dict[param] = value
+
+                else:
+                    band_dict[param] = fixed_band[param]
+
+            kwargs_offsets[band] = band_dict
+
+        return {"kwargs_offsets": kwargs_offsets}, i
+
+    @property
+    def kwargs_lower(self):
+        if not self.on:
+            return {}
+
+        return {
+            "kwargs_offsets":
+            [
+                {}
+                if band == self._reference_band
+                else {
+                    "dx": -1,
+                    "dy": -1,
+                    "angle": -0.5
+                }
+                for band in range(self._num_bands)
+            ]
+        }
+
+    @property
+    def kwargs_upper(self):
+        if not self.on:
+            return {}
+        return {
+            "kwargs_offsets":
+            [
+                {}
+                if band == self._reference_band
+                else {
+                    "dx": 1,
+                    "dy": 1,
+                    "angle": 0.5
+                }
+                for band in range(self._num_bands)
+            ]
+        }
 
     @property
     def on(self):

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -350,12 +350,19 @@ class MultiBandOffsetParam(ModelParamGroup):
     Parameter group for jointly sampling multi-band astrometric offsets.
 
     Each non-reference band has three possible parameters:
-    dx, dy, and rotation angle.
+    "ra_shift", "dec_shift", and "phi_rot".
 
     The reference band is fixed and therefore has no sampled parameters.
     """
 
     def __init__(self, on=False, num_bands=1, reference_band=0):
+        """
+        Initialize the multi-band offset parameter group.
+
+        :param on: whether multi-band offsets are sampled
+        :param num_bands: number of bands
+        :param reference_band: index of the reference band
+        """
         self._on = bool(on)
         self._num_bands = num_bands
         self._reference_band = reference_band
@@ -383,7 +390,7 @@ class MultiBandOffsetParam(ModelParamGroup):
                 else {}
             )
 
-            for param in ["dx", "dy", "angle"]:
+            for param in ["ra_shift", "dec_shift", "phi_rot"]:
                 if param not in fixed_band:
                     n_params += 1
                     names.append(
@@ -425,7 +432,7 @@ class MultiBandOffsetParam(ModelParamGroup):
                 if band < len(fixed_offsets)
                 else {}
             )
-            for param in ["dx", "dy", "angle"]:
+            for param in ["ra_shift", "dec_shift", "phi_rot"]:
                 if param not in fixed_band:
                     args.append(
                         offset.get(param, 0)
@@ -438,15 +445,12 @@ class MultiBandOffsetParam(ModelParamGroup):
         i,
         kwargs_fixed,
         kwargs_lower=None,
-        kwargs_upper=None
+        kwargs_upper=None,
     ):
         if not self.on:
             return {}, i
 
-        kwargs_offsets = [
-            {}
-            for _ in range(self._num_bands)
-        ]
+        kwargs_offsets = [{} for _ in range(self._num_bands)]
 
         fixed_offsets = kwargs_fixed.get(
             "kwargs_offsets",
@@ -478,13 +482,11 @@ class MultiBandOffsetParam(ModelParamGroup):
                 if band < len(fixed_offsets)
                 else {}
             )
-
             lower_band = (
                 lower_offsets[band]
                 if band < len(lower_offsets)
                 else {}
             )
-
             upper_band = (
                 upper_offsets[band]
                 if band < len(upper_offsets)
@@ -493,25 +495,18 @@ class MultiBandOffsetParam(ModelParamGroup):
 
             band_dict = {}
 
-            for param in ["dx", "dy", "angle"]:
+            for param in ["ra_shift", "dec_shift", "phi_rot"]:
                 if param not in fixed_band:
                     value = args[i]
                     i += 1
-                    
+
                     if param in lower_band:
-                        value = np.maximum(
-                            value,
-                            lower_band[param]
-                        )
+                        value = np.maximum(value, lower_band[param])
 
                     if param in upper_band:
-                        value = np.minimum(
-                            value,
-                            upper_band[param]
-                        )
+                        value = np.minimum(value, upper_band[param])
 
                     band_dict[param] = value
-
                 else:
                     band_dict[param] = fixed_band[param]
 
@@ -530,9 +525,9 @@ class MultiBandOffsetParam(ModelParamGroup):
                 {}
                 if band == self._reference_band
                 else {
-                    "dx": -1,
-                    "dy": -1,
-                    "angle": -0.5
+                    "ra_shift": -1,
+                    "dec_shift": -1,
+                    "phi_rot": -0.5
                 }
                 for band in range(self._num_bands)
             ]
@@ -548,9 +543,9 @@ class MultiBandOffsetParam(ModelParamGroup):
                 {}
                 if band == self._reference_band
                 else {
-                    "dx": 1,
-                    "dy": 1,
-                    "angle": 0.5
+                    "ra_shift": 1,
+                    "dec_shift": 1,
+                    "phi_rot": 0.5
                 }
                 for band in range(self._num_bands)
             ]

--- a/lenstronomy/Sampling/param_group.py
+++ b/lenstronomy/Sampling/param_group.py
@@ -345,9 +345,9 @@ class ArrayParam(ModelParamGroup):
     def on(self):
         return self._on
 
+
 class MultiBandOffsetParam(ModelParamGroup):
-    """
-    Parameter group for jointly sampling multi-band astrometric offsets.
+    """Parameter group for jointly sampling multi-band astrometric offsets.
 
     Each non-reference band has three possible parameters:
     "ra_shift", "dec_shift", and "phi_rot".
@@ -356,8 +356,7 @@ class MultiBandOffsetParam(ModelParamGroup):
     """
 
     def __init__(self, on=False, num_bands=1, reference_band=0):
-        """
-        Initialize the multi-band offset parameter group.
+        """Initialize the multi-band offset parameter group.
 
         :param on: whether multi-band offsets are sampled
         :param num_bands: number of bands
@@ -367,7 +366,6 @@ class MultiBandOffsetParam(ModelParamGroup):
         self._num_bands = num_bands
         self._reference_band = reference_band
 
-
     def num_params(self, kwargs_fixed):
 
         if not self.on:
@@ -376,29 +374,21 @@ class MultiBandOffsetParam(ModelParamGroup):
         names = []
 
         fixed_offsets = kwargs_fixed.get(
-            "kwargs_offsets",
-            [{} for _ in range(self._num_bands)]
+            "kwargs_offsets", [{} for _ in range(self._num_bands)]
         )
 
         for band in range(self._num_bands):
             if band == self._reference_band:
                 continue
 
-            fixed_band = (
-                fixed_offsets[band]
-                if band < len(fixed_offsets)
-                else {}
-            )
+            fixed_band = fixed_offsets[band] if band < len(fixed_offsets) else {}
 
             for param in ["ra_shift", "dec_shift", "phi_rot"]:
                 if param not in fixed_band:
                     n_params += 1
-                    names.append(
-                        f"{param}_band_{band}"
-                    )
+                    names.append(f"{param}_band_{band}")
 
         return n_params, names
-
 
     def set_params(self, kwargs, kwargs_fixed):
         if not self.on:
@@ -407,14 +397,10 @@ class MultiBandOffsetParam(ModelParamGroup):
 
         sampled_offsets = kwargs.get("kwargs_offsets")
         if sampled_offsets is None:
-            sampled_offsets = [
-                {}
-                for _ in range(self._num_bands)
-            ]
+            sampled_offsets = [{} for _ in range(self._num_bands)]
 
         fixed_offsets = kwargs_fixed.get(
-            "kwargs_offsets",
-            [{} for _ in range(self._num_bands)]
+            "kwargs_offsets", [{} for _ in range(self._num_bands)]
         )
 
         for band in range(self._num_bands):
@@ -422,21 +408,11 @@ class MultiBandOffsetParam(ModelParamGroup):
             if band == self._reference_band:
                 continue
 
-            offset = (
-                sampled_offsets[band]
-                if band < len(sampled_offsets)
-                else {}
-            )
-            fixed_band = (
-                fixed_offsets[band]
-                if band < len(fixed_offsets)
-                else {}
-            )
+            offset = sampled_offsets[band] if band < len(sampled_offsets) else {}
+            fixed_band = fixed_offsets[band] if band < len(fixed_offsets) else {}
             for param in ["ra_shift", "dec_shift", "phi_rot"]:
                 if param not in fixed_band:
-                    args.append(
-                        offset.get(param, 0)
-                    )
+                    args.append(offset.get(param, 0))
         return args
 
     def get_params(
@@ -453,22 +429,17 @@ class MultiBandOffsetParam(ModelParamGroup):
         kwargs_offsets = [{} for _ in range(self._num_bands)]
 
         fixed_offsets = kwargs_fixed.get(
-            "kwargs_offsets",
-            [{} for _ in range(self._num_bands)]
+            "kwargs_offsets", [{} for _ in range(self._num_bands)]
         )
 
         lower_offsets = (
-            kwargs_lower.get("kwargs_offsets", [])
-            if kwargs_lower is not None
-            else []
+            kwargs_lower.get("kwargs_offsets", []) if kwargs_lower is not None else []
         )
         if lower_offsets is None:
             lower_offsets = []
 
         upper_offsets = (
-            kwargs_upper.get("kwargs_offsets", [])
-            if kwargs_upper is not None
-            else []
+            kwargs_upper.get("kwargs_offsets", []) if kwargs_upper is not None else []
         )
         if upper_offsets is None:
             upper_offsets = []
@@ -477,21 +448,9 @@ class MultiBandOffsetParam(ModelParamGroup):
             if band == self._reference_band:
                 continue
 
-            fixed_band = (
-                fixed_offsets[band]
-                if band < len(fixed_offsets)
-                else {}
-            )
-            lower_band = (
-                lower_offsets[band]
-                if band < len(lower_offsets)
-                else {}
-            )
-            upper_band = (
-                upper_offsets[band]
-                if band < len(upper_offsets)
-                else {}
-            )
+            fixed_band = fixed_offsets[band] if band < len(fixed_offsets) else {}
+            lower_band = lower_offsets[band] if band < len(lower_offsets) else {}
+            upper_band = upper_offsets[band] if band < len(upper_offsets) else {}
 
             band_dict = {}
 
@@ -520,15 +479,12 @@ class MultiBandOffsetParam(ModelParamGroup):
             return {}
 
         return {
-            "kwargs_offsets":
-            [
-                {}
-                if band == self._reference_band
-                else {
-                    "ra_shift": -1,
-                    "dec_shift": -1,
-                    "phi_rot": -0.5
-                }
+            "kwargs_offsets": [
+                (
+                    {}
+                    if band == self._reference_band
+                    else {"ra_shift": -1, "dec_shift": -1, "phi_rot": -0.5}
+                )
                 for band in range(self._num_bands)
             ]
         }
@@ -538,15 +494,12 @@ class MultiBandOffsetParam(ModelParamGroup):
         if not self.on:
             return {}
         return {
-            "kwargs_offsets":
-            [
-                {}
-                if band == self._reference_band
-                else {
-                    "ra_shift": 1,
-                    "dec_shift": 1,
-                    "phi_rot": 0.5
-                }
+            "kwargs_offsets": [
+                (
+                    {}
+                    if band == self._reference_band
+                    else {"ra_shift": 1, "dec_shift": 1, "phi_rot": 0.5}
+                )
                 for band in range(self._num_bands)
             ]
         }

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -159,6 +159,9 @@ class Param(object):
         cosmology_sampling=False,
         solver_param_module=None,
         _jax=False,
+        multi_band_offset=False,
+        num_bands=1,
+        reference_band=0,
     ):
         """
 
@@ -520,6 +523,9 @@ class Param(object):
             num_z_sampling=num_z_sampling,
             source_grid_offset=source_grid_offset,
             kinematic_sampling=kinematic_sampling,
+            multi_band_offset=multi_band_offset,
+            num_bands=num_bands,
+            reference_band=reference_band,
         )
         self.tracer_source_params = LightParam(
             self._tracer_source_model_list,

--- a/lenstronomy/Sampling/parameters.py
+++ b/lenstronomy/Sampling/parameters.py
@@ -243,6 +243,9 @@ class Param(object):
         :param solver_param_module: a class that performs conversions update_kwargs, extract_array, and add_fixed_lens
          for the Solver4Point class with the solver_type = 'CUSTOM' option
         :param _jax: bool, flag that is set to True whenever this class is called from JAXtronomy
+        :param multi_band_offset: whether to sample multi-band astrometric offsets
+        :param num_bands: number of bands for multi-band offset sampling
+        :param reference_band: index of the reference band
         """
 
         self._lens_model_list = kwargs_model.get("lens_model_list", [])

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -356,8 +356,10 @@ class SpecialParam(object):
         self._tau0 = Tau0ListParam(num_tau0)
         self._z_sampling = ZSamplingParam(num_z_sampling)
         self._source_grid_offset = SourceGridOffsetParam(source_grid_offset)
-        self._multiband_offset = MultiBandOffsetParam(multi_band_offset, num_bands, reference_band)
-        
+        self._multiband_offset = MultiBandOffsetParam(
+            multi_band_offset, num_bands, reference_band
+        )
+
         if kwargs_fixed is None:
             kwargs_fixed = {}
         self.kwargs_fixed = kwargs_fixed

--- a/lenstronomy/Sampling/special_param.py
+++ b/lenstronomy/Sampling/special_param.py
@@ -3,7 +3,7 @@ __author__ = "sibirrer"
 __all__ = ["SpecialParam"]
 
 import numpy as np
-from .param_group import ModelParamGroup, SingleParam, ArrayParam
+from .param_group import ModelParamGroup, SingleParam, ArrayParam, MultiBandOffsetParam
 import warnings
 
 # ==================================== #
@@ -266,6 +266,9 @@ class SpecialParam(object):
         num_lens_planes=1,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
+        multi_band_offset=False,
+        num_bands=1,
+        reference_band=0,
     ):
         """
 
@@ -353,7 +356,8 @@ class SpecialParam(object):
         self._tau0 = Tau0ListParam(num_tau0)
         self._z_sampling = ZSamplingParam(num_z_sampling)
         self._source_grid_offset = SourceGridOffsetParam(source_grid_offset)
-
+        self._multiband_offset = MultiBandOffsetParam(multi_band_offset, num_bands, reference_band)
+        
         if kwargs_fixed is None:
             kwargs_fixed = {}
         self.kwargs_fixed = kwargs_fixed
@@ -429,4 +433,5 @@ class SpecialParam(object):
             self._source_grid_offset,
             self._distance_ratio_sampling,
             self._cosmology_param_sampling,
+            self._multiband_offset,
         ]

--- a/test/test_Sampling/test_multiband_offset.py
+++ b/test/test_Sampling/test_multiband_offset.py
@@ -1,0 +1,837 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+# Same transformation logic as implemented in ImageLikelihood
+def apply_coordinate_transformation(
+    ra_0_old,
+    dec_0_old,
+    M_old,
+    nx,
+    ny,
+    dx,
+    dy,
+    angle,
+):
+    """
+    Apply rotation around the geometric center and translation.
+
+    This reproduces the coordinate transformation implemented
+    in the multi-band offset feature.
+    """
+
+    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
+
+    # Compute the original geometric center
+    ra_center = (
+        ra_0_old
+        + M_old[0, 0] * cx
+        + M_old[0, 1] * cy
+    )
+
+    dec_center = (
+        dec_0_old
+        + M_old[1, 0] * cx
+        + M_old[1, 1] * cy
+    )
+
+    # Apply rotation
+    cos_a, sin_a = np.cos(angle), np.sin(angle)
+
+    rot_matrix = np.array(
+        [
+            [cos_a, -sin_a],
+            [sin_a, cos_a],
+        ]
+    )
+
+    M_new = np.dot(rot_matrix, M_old)
+
+    # Keep the geometric center fixed during rotation,
+    # then apply the requested translation
+    ra_0_new = (
+        ra_center
+        - (M_new[0, 0] * cx + M_new[0, 1] * cy)
+        + dx
+    )
+
+    dec_0_new = (
+        dec_center
+        - (M_new[1, 0] * cx + M_new[1, 1] * cy)
+        + dy
+    )
+
+    return ra_0_new, dec_0_new, M_new
+
+
+def test_transformation():
+    """
+    Test combined rotation and translation.
+    """
+
+    # Set up a 10x10 grid with pixel scale of 0.1
+    nx, ny = 10, 10
+
+    M_old = np.array(
+        [
+            [0.1, 0.0],
+            [0.0, 0.1],
+        ]
+    )
+
+    # Initial coordinate origin.
+    # The geometric center is located at (0, 0).
+    ra_0_old = -0.45
+    dec_0_old = -0.45
+
+    # Apply translation and 90-degree rotation
+    dx, dy = 0.2, 0.1
+    angle = np.pi / 2
+
+    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
+        ra_0_old,
+        dec_0_old,
+        M_old,
+        nx,
+        ny,
+        dx,
+        dy,
+        angle,
+    )
+
+    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
+
+    # Verify that the new center only changes due to translation
+    new_ra_center = (
+        ra_0_new
+        + M_new[0, 0] * cx
+        + M_new[0, 1] * cy
+    )
+
+    new_dec_center = (
+        dec_0_new
+        + M_new[1, 0] * cx
+        + M_new[1, 1] * cy
+    )
+
+    assert_almost_equal(new_ra_center, dx)
+    assert_almost_equal(new_dec_center, dy)
+
+    # Verify that the transformation matrix is rotated correctly
+    assert_almost_equal(M_new[0, 0], 0.0)
+    assert_almost_equal(M_new[1, 0], 0.1)
+
+    print("Test passed: rotation around the center and translation.")
+
+
+def test_translation_only():
+
+    nx, ny = 10, 10
+
+    M_old = np.array(
+        [
+            [0.1, 0.0],
+            [0.0, 0.1],
+        ]
+    )
+
+    ra_0_old = -0.45
+    dec_0_old = -0.45
+
+    dx = 0.2
+    dy = -0.1
+    angle = 0.0
+
+    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
+        ra_0_old,
+        dec_0_old,
+        M_old,
+        nx,
+        ny,
+        dx,
+        dy,
+        angle,
+    )
+
+    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
+
+    # Check the updated coordinate center
+    ra_center_new = (
+        ra_0_new
+        + M_new[0, 0] * cx
+        + M_new[0, 1] * cy
+    )
+
+    dec_center_new = (
+        dec_0_new
+        + M_new[1, 0] * cx
+        + M_new[1, 1] * cy
+    )
+
+    assert_almost_equal(ra_center_new, dx)
+    assert_almost_equal(dec_center_new, dy)
+
+    # Translation should not modify the transformation matrix
+    assert_almost_equal(M_new, M_old)
+
+    print("Test passed: translation only.")
+
+
+def test_rotation_only():
+
+    nx, ny = 10, 10
+
+    M_old = np.array(
+        [
+            [0.1, 0.0],
+            [0.0, 0.1],
+        ]
+    )
+
+    ra_0_old = -0.45
+    dec_0_old = -0.45
+
+    dx = 0.0
+    dy = 0.0
+    angle = np.pi / 2
+
+    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
+        ra_0_old,
+        dec_0_old,
+        M_old,
+        nx,
+        ny,
+        dx,
+        dy,
+        angle,
+    )
+
+    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
+
+    # Original center
+    ra_center_old = (
+        ra_0_old
+        + M_old[0, 0] * cx
+        + M_old[0, 1] * cy
+    )
+
+    dec_center_old = (
+        dec_0_old
+        + M_old[1, 0] * cx
+        + M_old[1, 1] * cy
+    )
+
+    # New center after rotation
+    ra_center_new = (
+        ra_0_new
+        + M_new[0, 0] * cx
+        + M_new[0, 1] * cy
+    )
+
+    dec_center_new = (
+        dec_0_new
+        + M_new[1, 0] * cx
+        + M_new[1, 1] * cy
+    )
+
+    # Rotation around the center should preserve the center position
+    assert_almost_equal(ra_center_new, ra_center_old)
+    assert_almost_equal(dec_center_new, dec_center_old)
+
+    # Verify axis rotation
+    assert_almost_equal(M_new[0, 0], 0.0)
+    assert_almost_equal(M_new[1, 0], 0.1)
+
+    print("Test passed: rotation only.")
+
+
+def test_shift_and_rotation():
+
+    nx, ny = 10, 10
+
+    M_old = np.array(
+        [
+            [0.1, 0.0],
+            [0.0, 0.1],
+        ]
+    )
+
+    ra_0_old = -0.45
+    dec_0_old = -0.45
+
+    dx = 0.2
+    dy = 0.1
+    angle = np.pi / 2
+
+    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
+        ra_0_old,
+        dec_0_old,
+        M_old,
+        nx,
+        ny,
+        dx,
+        dy,
+        angle,
+    )
+
+    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
+
+    ra_center_new = (
+        ra_0_new
+        + M_new[0, 0] * cx
+        + M_new[0, 1] * cy
+    )
+
+    dec_center_new = (
+        dec_0_new
+        + M_new[1, 0] * cx
+        + M_new[1, 1] * cy
+    )
+
+    # The final center should match the applied translation
+    assert_almost_equal(ra_center_new, dx)
+    assert_almost_equal(dec_center_new, dy)
+
+    print("Test passed: combined shift and rotation.")
+
+
+def test_center_preservation_without_shift():
+
+    nx, ny = 20, 15
+
+    M_old = np.array(
+        [
+            [0.1, 0.0],
+            [0.0, 0.1],
+        ]
+    )
+
+    ra_0_old = -0.95
+    dec_0_old = -0.70
+
+    dx = 0
+    dy = 0
+    angle = 0.3
+
+    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
+        ra_0_old,
+        dec_0_old,
+        M_old,
+        nx,
+        ny,
+        dx,
+        dy,
+        angle,
+    )
+
+    cx, cy = (nx - 1)/2, (ny - 1)/2
+
+    old_center = np.array([
+        ra_0_old + M_old[0,0]*cx + M_old[0,1]*cy,
+        dec_0_old + M_old[1,0]*cx + M_old[1,1]*cy,
+    ])
+
+    new_center = np.array([
+        ra_0_new + M_new[0,0]*cx + M_new[0,1]*cy,
+        dec_0_new + M_new[1,0]*cx + M_new[1,1]*cy,
+    ])
+
+    assert_almost_equal(old_center, new_center)
+
+    print("Test passed: rotation preserves geometric center.")
+
+if __name__ == "__main__":
+
+    test_transformation()
+    test_translation_only()
+    test_rotation_only()
+    test_shift_and_rotation()
+    test_center_preservation_without_shift()
+
+# ============================================================
+
+import copy
+import numpy as np
+from numpy.testing import assert_allclose
+
+from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.Data.psf import PSF
+from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
+from lenstronomy.LensModel.lens_model import LensModel
+from lenstronomy.LightModel.light_model import LightModel
+from lenstronomy.Util import util
+from lenstronomy.Sampling.Likelihoods.image_likelihood import ImageLikelihood
+
+# ============================================================
+# 1. Generate simple two-band mock data
+# ============================================================
+
+def make_mock_multiband_data():
+    num_pix = 40
+    delta_pix = 0.1
+
+    background_rms = 0.01
+    exposure_time = 1000
+
+    psf_kwargs = {
+        "psf_type": "GAUSSIAN",
+        "fwhm": 0.1,
+        "pixel_size": delta_pix,
+    }
+
+    numerics_kwargs = {
+        "supersampling_factor": 1,
+        "supersampling_convolution": False,
+    }
+
+
+    # same coordinate system initially
+    _, _, ra_at_xy_0, dec_at_xy_0, _, _, Mpix2coord, _ = (
+        util.make_grid_with_coordtransform(
+            numPix=num_pix,
+            deltapix=delta_pix,
+            center_ra=0,
+            center_dec=0,
+            subgrid_res=1,
+            inverse=False,
+        )
+    )
+
+    kwargs_data_1 = {
+        "image_data": np.zeros((num_pix, num_pix)),
+        "background_rms": background_rms,
+        "exposure_time": exposure_time,
+        "ra_at_xy_0": ra_at_xy_0,
+        "dec_at_xy_0": dec_at_xy_0,
+        "transform_pix2angle": Mpix2coord,
+    }
+
+    # band 2 starts from identical coordinate system
+    kwargs_data_2 = copy.deepcopy(kwargs_data_1)
+
+    multi_band_list = [
+        [kwargs_data_1,
+            psf_kwargs,
+            numerics_kwargs,],
+        [kwargs_data_2,
+            psf_kwargs,
+            numerics_kwargs,],]
+
+    # --------------------------------------------------------
+    # lens model
+    # --------------------------------------------------------
+
+    lens_model_list = [
+        "SIE",
+    ]
+
+    lens_model = LensModel(
+        lens_model_list=lens_model_list
+    )
+
+    kwargs_lens = [
+        {
+            "theta_E": 1.0,
+            "center_x": 0,
+            "center_y": 0,
+            "e1": 0.05,
+            "e2": 0.05,
+        }
+    ]
+
+    # --------------------------------------------------------
+    # source
+    # --------------------------------------------------------
+    source_model_list = [
+        "SERSIC_ELLIPSE",
+        "SERSIC_ELLIPSE",
+    ]
+
+    source_model = LightModel(
+        light_model_list=source_model_list
+    )
+
+    kwargs_source = [
+        {
+            "amp": 10,
+            "R_sersic": 0.2,
+            "n_sersic": 2,
+            "e1": 0,
+            "e2": 0,
+            "center_x": 0,
+            "center_y": 0,
+        },
+        {
+            "amp": 5,
+            "R_sersic": 0.2,
+            "n_sersic": 2,
+            "e1": 0,
+            "e2": 0,
+            "center_x": 0,
+            "center_y": 0,
+        },
+    ]
+
+    kwargs_model = {
+        "lens_model_list": lens_model_list,
+        "source_light_model_list": source_model_list,
+        "lens_light_model_list": [],
+        "index_source_light_model_list": [
+            [0],
+            [1],
+        ],
+    }
+
+    # generate images
+    sim_band_1 = SingleBandMultiModel(
+        multi_band_list=multi_band_list,
+        kwargs_model=kwargs_model,
+        likelihood_mask_list=None,
+        band_index=0,
+    )
+    sim_band_2 = SingleBandMultiModel(
+        multi_band_list=multi_band_list,
+        kwargs_model=kwargs_model,
+        likelihood_mask_list=None,
+        band_index=1,
+    )
+
+    image_1 = sim_band_1.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+    )
+    image_2 = sim_band_2.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+    )
+
+    kwargs_data_1["image_data"] = image_1
+    kwargs_data_2["image_data"] = image_2
+
+    kwargs_data_joint = {
+        "multi_band_list": multi_band_list,
+        "multi_band_type": "multi-linear",
+    }
+
+    return (
+        kwargs_data_joint,
+        kwargs_model,
+        kwargs_lens,
+        kwargs_source,
+        [],
+    )
+
+
+# ============================================================
+# 2. Build likelihood
+# ============================================================
+
+def make_likelihood():
+
+    (
+        kwargs_data_joint,
+        kwargs_model,
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+    ) = make_mock_multiband_data()
+
+
+    kwargs_likelihood = {
+        "source_marg": False,
+    }
+
+    likelihood = ImageLikelihood(
+        multi_band_list=kwargs_data_joint["multi_band_list"],
+        multi_band_type=kwargs_data_joint["multi_band_type"],
+        kwargs_model=kwargs_model,
+        **kwargs_likelihood,
+    )
+
+    return (
+        likelihood,
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+    )
+
+# ============================================================
+# 3. Test apply / restore
+# ============================================================
+
+def test_apply_restore_multiband_offsets():
+
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+    image_model_list = (
+        likelihood.imSim._imageModel_list
+    )
+    data_band_1 = (
+        image_model_list[1].Data
+    )
+
+    original_ra = data_band_1._ra_at_xy_0
+    original_dec = data_band_1._dec_at_xy_0
+    original_M = np.copy(
+        data_band_1._Mpix2a
+    )
+
+    kwargs_special = {
+        "kwargs_offsets": [
+            {},
+            {
+                "dx": 0.05,
+                "dy": -0.03,
+                "angle": 0.02,
+            },
+
+        ]
+
+    }
+    # --------------------------------------------------------
+    # Apply
+    # --------------------------------------------------------
+    backup = (
+        likelihood._apply_multiband_offsets(
+            kwargs_special
+        )
+    )
+
+    assert not np.isclose(
+        data_band_1._ra_at_xy_0,
+        original_ra,
+    )
+
+    assert not np.isclose(
+        data_band_1._dec_at_xy_0,
+        original_dec,
+    )
+
+    assert not np.allclose(
+        data_band_1._Mpix2a,
+        original_M,
+    )
+
+    print(
+        "PASS: apply_multiband_offsets modifies coordinates"
+    )
+
+    # --------------------------------------------------------
+    # Restore
+    # --------------------------------------------------------
+
+    likelihood._restore_multiband_offsets(
+        backup
+    )
+
+
+    assert_allclose(
+        data_band_1._ra_at_xy_0,
+        original_ra,
+    )
+
+    assert_allclose(
+        data_band_1._dec_at_xy_0,
+        original_dec,
+    )
+
+    assert_allclose(
+        data_band_1._Mpix2a,
+        original_M,
+    )
+
+    print(
+        "PASS: restore_multiband_offsets restores coordinates"
+    )
+
+# ============================================================
+# 4. Test image response to multiband offsets
+# ============================================================
+def test_multiband_offsets_change_image_and_restore():
+
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+
+    image_model = likelihood.imSim._imageModel_list[1]
+
+    kwargs_lens = [
+        {
+            "theta_E": 1.0,
+            "center_x": 0,
+            "center_y": 0,
+            "e1": 0.05,
+            "e2": 0.05,
+        }
+    ]
+
+    kwargs_source = [
+        {
+            "amp": 10,
+            "R_sersic": 0.2,
+            "n_sersic": 2,
+            "e1": 0,
+            "e2": 0,
+            "center_x": 0,
+            "center_y": 0,
+        },
+        {
+            "amp": 5,
+            "R_sersic": 0.2,
+            "n_sersic": 2,
+            "e1": 0,
+            "e2": 0,
+            "center_x": 0,
+            "center_y": 0,
+        },
+    ]
+
+
+    kwargs_special_zero = {
+        "kwargs_offsets": [
+            {},
+            {
+                "dx": 0,
+                "dy": 0,
+                "angle": 0,
+            },
+        ]
+    }
+
+
+    kwargs_special_true = {
+        "kwargs_offsets": [
+            {},
+            {
+                "dx": 0.05,
+                "dy": -0.03,
+                "angle": 0.02,
+            },
+        ]
+    }
+
+
+    # --------------------------------------------------------
+    # image without offset
+    # --------------------------------------------------------
+
+    image_zero = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    # --------------------------------------------------------
+    # image with offset
+    # --------------------------------------------------------
+
+    backup = likelihood._apply_multiband_offsets(
+        kwargs_special_true
+    )
+
+    image_true = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+    )
+
+    likelihood._restore_multiband_offsets(
+        backup
+    )
+
+    # image should change
+    assert np.max(np.abs(image_true-image_zero)) > 0
+
+    # --------------------------------------------------------
+    # coordinate should change
+    # --------------------------------------------------------
+
+    ra0, dec0 = image_model.ImageNumerics.coordinates_evaluate
+
+    backup = likelihood._apply_multiband_offsets(
+        kwargs_special_true
+    )
+
+    ra1, dec1 = image_model.ImageNumerics.coordinates_evaluate
+
+    assert np.max(np.abs(ra1-ra0)) > 0
+    assert np.max(np.abs(dec1-dec0)) > 0
+
+
+    likelihood._restore_multiband_offsets(
+        backup
+    )
+
+
+    ra2, dec2 = image_model.ImageNumerics.coordinates_evaluate
+
+    assert_allclose(ra2, ra0)
+    assert_allclose(dec2, dec0)
+
+    print(
+        "PASS: multiband offsets change image and restore correctly"
+    )
+
+def test_repeated_apply_gives_same_image():
+
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+
+    model = likelihood.imSim._imageModel_list[1]
+
+    kwargs_special = {
+        "kwargs_offsets":[
+            {},
+            {
+                "dx":0.05,
+                "dy":-0.03,
+                "angle":0.02,
+            }
+        ]
+    }
+
+    backup = likelihood._apply_multiband_offsets(
+        kwargs_special
+    )
+
+    image1 = model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+        kwargs_ps=None,
+    )
+
+    likelihood._restore_multiband_offsets(
+        backup
+    )
+
+    backup = likelihood._apply_multiband_offsets(
+        kwargs_special
+    )
+
+    image2 = model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+        kwargs_ps=None,
+    )
+
+    assert_allclose(
+        image1,
+        image2,
+    )
+
+    likelihood._restore_multiband_offsets(
+        backup
+    )
+
+    print(
+        "PASS: repeated apply gives identical result"
+    )
+
+if __name__ == "__main__":
+    test_apply_restore_multiband_offsets()
+    test_multiband_offsets_change_image_and_restore()
+    test_repeated_apply_gives_same_image()

--- a/test/test_Sampling/test_multiband_offset.py
+++ b/test/test_Sampling/test_multiband_offset.py
@@ -1,370 +1,13 @@
-import numpy as np
-from numpy.testing import assert_almost_equal
-
-# Same transformation logic as implemented in ImageLikelihood
-def apply_coordinate_transformation(
-    ra_0_old,
-    dec_0_old,
-    M_old,
-    nx,
-    ny,
-    dx,
-    dy,
-    angle,
-):
-    """
-    Apply rotation around the geometric center and translation.
-
-    This reproduces the coordinate transformation implemented
-    in the multi-band offset feature.
-    """
-
-    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
-
-    # Compute the original geometric center
-    ra_center = (
-        ra_0_old
-        + M_old[0, 0] * cx
-        + M_old[0, 1] * cy
-    )
-
-    dec_center = (
-        dec_0_old
-        + M_old[1, 0] * cx
-        + M_old[1, 1] * cy
-    )
-
-    # Apply rotation
-    cos_a, sin_a = np.cos(angle), np.sin(angle)
-
-    rot_matrix = np.array(
-        [
-            [cos_a, -sin_a],
-            [sin_a, cos_a],
-        ]
-    )
-
-    M_new = np.dot(rot_matrix, M_old)
-
-    # Keep the geometric center fixed during rotation,
-    # then apply the requested translation
-    ra_0_new = (
-        ra_center
-        - (M_new[0, 0] * cx + M_new[0, 1] * cy)
-        + dx
-    )
-
-    dec_0_new = (
-        dec_center
-        - (M_new[1, 0] * cx + M_new[1, 1] * cy)
-        + dy
-    )
-
-    return ra_0_new, dec_0_new, M_new
-
-
-def test_transformation():
-    """
-    Test combined rotation and translation.
-    """
-
-    # Set up a 10x10 grid with pixel scale of 0.1
-    nx, ny = 10, 10
-
-    M_old = np.array(
-        [
-            [0.1, 0.0],
-            [0.0, 0.1],
-        ]
-    )
-
-    # Initial coordinate origin.
-    # The geometric center is located at (0, 0).
-    ra_0_old = -0.45
-    dec_0_old = -0.45
-
-    # Apply translation and 90-degree rotation
-    dx, dy = 0.2, 0.1
-    angle = np.pi / 2
-
-    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
-        ra_0_old,
-        dec_0_old,
-        M_old,
-        nx,
-        ny,
-        dx,
-        dy,
-        angle,
-    )
-
-    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
-
-    # Verify that the new center only changes due to translation
-    new_ra_center = (
-        ra_0_new
-        + M_new[0, 0] * cx
-        + M_new[0, 1] * cy
-    )
-
-    new_dec_center = (
-        dec_0_new
-        + M_new[1, 0] * cx
-        + M_new[1, 1] * cy
-    )
-
-    assert_almost_equal(new_ra_center, dx)
-    assert_almost_equal(new_dec_center, dy)
-
-    # Verify that the transformation matrix is rotated correctly
-    assert_almost_equal(M_new[0, 0], 0.0)
-    assert_almost_equal(M_new[1, 0], 0.1)
-
-    print("Test passed: rotation around the center and translation.")
-
-
-def test_translation_only():
-
-    nx, ny = 10, 10
-
-    M_old = np.array(
-        [
-            [0.1, 0.0],
-            [0.0, 0.1],
-        ]
-    )
-
-    ra_0_old = -0.45
-    dec_0_old = -0.45
-
-    dx = 0.2
-    dy = -0.1
-    angle = 0.0
-
-    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
-        ra_0_old,
-        dec_0_old,
-        M_old,
-        nx,
-        ny,
-        dx,
-        dy,
-        angle,
-    )
-
-    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
-
-    # Check the updated coordinate center
-    ra_center_new = (
-        ra_0_new
-        + M_new[0, 0] * cx
-        + M_new[0, 1] * cy
-    )
-
-    dec_center_new = (
-        dec_0_new
-        + M_new[1, 0] * cx
-        + M_new[1, 1] * cy
-    )
-
-    assert_almost_equal(ra_center_new, dx)
-    assert_almost_equal(dec_center_new, dy)
-
-    # Translation should not modify the transformation matrix
-    assert_almost_equal(M_new, M_old)
-
-    print("Test passed: translation only.")
-
-
-def test_rotation_only():
-
-    nx, ny = 10, 10
-
-    M_old = np.array(
-        [
-            [0.1, 0.0],
-            [0.0, 0.1],
-        ]
-    )
-
-    ra_0_old = -0.45
-    dec_0_old = -0.45
-
-    dx = 0.0
-    dy = 0.0
-    angle = np.pi / 2
-
-    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
-        ra_0_old,
-        dec_0_old,
-        M_old,
-        nx,
-        ny,
-        dx,
-        dy,
-        angle,
-    )
-
-    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
-
-    # Original center
-    ra_center_old = (
-        ra_0_old
-        + M_old[0, 0] * cx
-        + M_old[0, 1] * cy
-    )
-
-    dec_center_old = (
-        dec_0_old
-        + M_old[1, 0] * cx
-        + M_old[1, 1] * cy
-    )
-
-    # New center after rotation
-    ra_center_new = (
-        ra_0_new
-        + M_new[0, 0] * cx
-        + M_new[0, 1] * cy
-    )
-
-    dec_center_new = (
-        dec_0_new
-        + M_new[1, 0] * cx
-        + M_new[1, 1] * cy
-    )
-
-    # Rotation around the center should preserve the center position
-    assert_almost_equal(ra_center_new, ra_center_old)
-    assert_almost_equal(dec_center_new, dec_center_old)
-
-    # Verify axis rotation
-    assert_almost_equal(M_new[0, 0], 0.0)
-    assert_almost_equal(M_new[1, 0], 0.1)
-
-    print("Test passed: rotation only.")
-
-
-def test_shift_and_rotation():
-
-    nx, ny = 10, 10
-
-    M_old = np.array(
-        [
-            [0.1, 0.0],
-            [0.0, 0.1],
-        ]
-    )
-
-    ra_0_old = -0.45
-    dec_0_old = -0.45
-
-    dx = 0.2
-    dy = 0.1
-    angle = np.pi / 2
-
-    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
-        ra_0_old,
-        dec_0_old,
-        M_old,
-        nx,
-        ny,
-        dx,
-        dy,
-        angle,
-    )
-
-    cx, cy = (nx - 1) / 2.0, (ny - 1) / 2.0
-
-    ra_center_new = (
-        ra_0_new
-        + M_new[0, 0] * cx
-        + M_new[0, 1] * cy
-    )
-
-    dec_center_new = (
-        dec_0_new
-        + M_new[1, 0] * cx
-        + M_new[1, 1] * cy
-    )
-
-    # The final center should match the applied translation
-    assert_almost_equal(ra_center_new, dx)
-    assert_almost_equal(dec_center_new, dy)
-
-    print("Test passed: combined shift and rotation.")
-
-
-def test_center_preservation_without_shift():
-
-    nx, ny = 20, 15
-
-    M_old = np.array(
-        [
-            [0.1, 0.0],
-            [0.0, 0.1],
-        ]
-    )
-
-    ra_0_old = -0.95
-    dec_0_old = -0.70
-
-    dx = 0
-    dy = 0
-    angle = 0.3
-
-    ra_0_new, dec_0_new, M_new = apply_coordinate_transformation(
-        ra_0_old,
-        dec_0_old,
-        M_old,
-        nx,
-        ny,
-        dx,
-        dy,
-        angle,
-    )
-
-    cx, cy = (nx - 1)/2, (ny - 1)/2
-
-    old_center = np.array([
-        ra_0_old + M_old[0,0]*cx + M_old[0,1]*cy,
-        dec_0_old + M_old[1,0]*cx + M_old[1,1]*cy,
-    ])
-
-    new_center = np.array([
-        ra_0_new + M_new[0,0]*cx + M_new[0,1]*cy,
-        dec_0_new + M_new[1,0]*cx + M_new[1,1]*cy,
-    ])
-
-    assert_almost_equal(old_center, new_center)
-
-    print("Test passed: rotation preserves geometric center.")
-
-if __name__ == "__main__":
-
-    test_transformation()
-    test_translation_only()
-    test_rotation_only()
-    test_shift_and_rotation()
-    test_center_preservation_without_shift()
-
-# ============================================================
-
 import copy
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from lenstronomy.Data.imaging_data import ImageData
-from lenstronomy.Data.psf import PSF
 from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiModel
-from lenstronomy.LensModel.lens_model import LensModel
-from lenstronomy.LightModel.light_model import LightModel
 from lenstronomy.Util import util
 from lenstronomy.Sampling.Likelihoods.image_likelihood import ImageLikelihood
 
-# ============================================================
-# 1. Generate simple two-band mock data
-# ============================================================
-
+# Generate simple two-band mock data
 def make_mock_multiband_data():
     num_pix = 40
     delta_pix = 0.1
@@ -387,8 +30,8 @@ def make_mock_multiband_data():
     # same coordinate system initially
     _, _, ra_at_xy_0, dec_at_xy_0, _, _, Mpix2coord, _ = (
         util.make_grid_with_coordtransform(
-            numPix=num_pix,
-            deltapix=delta_pix,
+            num_pix=num_pix,
+            delta_pix=delta_pix,
             center_ra=0,
             center_dec=0,
             subgrid_res=1,
@@ -424,10 +67,6 @@ def make_mock_multiband_data():
         "SIE",
     ]
 
-    lens_model = LensModel(
-        lens_model_list=lens_model_list
-    )
-
     kwargs_lens = [
         {
             "theta_E": 1.0,
@@ -445,10 +84,6 @@ def make_mock_multiband_data():
         "SERSIC_ELLIPSE",
         "SERSIC_ELLIPSE",
     ]
-
-    source_model = LightModel(
-        light_model_list=source_model_list
-    )
 
     kwargs_source = [
         {
@@ -524,10 +159,21 @@ def make_mock_multiband_data():
         [],
     )
 
-
-# ============================================================
-# 2. Build likelihood
-# ============================================================
+def make_kwargs_special(
+    ra_shift=0.0,
+    dec_shift=0.0,
+    phi_rot=0.0,
+):
+    return {
+        "kwargs_offsets": [
+            {},
+            {
+                "ra_shift": ra_shift,
+                "dec_shift": dec_shift,
+                "phi_rot": phi_rot,
+            },
+        ]
+    }
 
 def make_likelihood():
 
@@ -558,162 +204,19 @@ def make_likelihood():
         kwargs_lens_light,
     )
 
-# ============================================================
-# 3. Test apply / restore
-# ============================================================
-
-def test_apply_restore_multiband_offsets():
-
-    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
-    image_model_list = (
-        likelihood.imSim._imageModel_list
-    )
-    data_band_1 = (
-        image_model_list[1].Data
-    )
-
-    original_ra = data_band_1._ra_at_xy_0
-    original_dec = data_band_1._dec_at_xy_0
-    original_M = np.copy(
-        data_band_1._Mpix2a
-    )
-
-    kwargs_special = {
-        "kwargs_offsets": [
-            {},
-            {
-                "dx": 0.05,
-                "dy": -0.03,
-                "angle": 0.02,
-            },
-
-        ]
-
-    }
-    # --------------------------------------------------------
-    # Apply
-    # --------------------------------------------------------
-    backup = (
-        likelihood._apply_multiband_offsets(
-            kwargs_special
-        )
-    )
-
-    assert not np.isclose(
-        data_band_1._ra_at_xy_0,
-        original_ra,
-    )
-
-    assert not np.isclose(
-        data_band_1._dec_at_xy_0,
-        original_dec,
-    )
-
-    assert not np.allclose(
-        data_band_1._Mpix2a,
-        original_M,
-    )
-
-    print(
-        "PASS: apply_multiband_offsets modifies coordinates"
-    )
-
-    # --------------------------------------------------------
-    # Restore
-    # --------------------------------------------------------
-
-    likelihood._restore_multiband_offsets(
-        backup
-    )
-
-
-    assert_allclose(
-        data_band_1._ra_at_xy_0,
-        original_ra,
-    )
-
-    assert_allclose(
-        data_band_1._dec_at_xy_0,
-        original_dec,
-    )
-
-    assert_allclose(
-        data_band_1._Mpix2a,
-        original_M,
-    )
-
-    print(
-        "PASS: restore_multiband_offsets restores coordinates"
-    )
-
-# ============================================================
-# 4. Test image response to multiband offsets
-# ============================================================
-def test_multiband_offsets_change_image_and_restore():
-
+# Test coordinate updates through the ImageModel API
+def test_multiband_offsets_change_image():
     likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
 
-    image_model = likelihood.imSim._imageModel_list[1]
+    image_model = likelihood.imSim._image_model_list[1]
 
-    kwargs_lens = [
-        {
-            "theta_E": 1.0,
-            "center_x": 0,
-            "center_y": 0,
-            "e1": 0.05,
-            "e2": 0.05,
-        }
-    ]
+    kwargs_special_zero = make_kwargs_special()
 
-    kwargs_source = [
-        {
-            "amp": 10,
-            "R_sersic": 0.2,
-            "n_sersic": 2,
-            "e1": 0,
-            "e2": 0,
-            "center_x": 0,
-            "center_y": 0,
-        },
-        {
-            "amp": 5,
-            "R_sersic": 0.2,
-            "n_sersic": 2,
-            "e1": 0,
-            "e2": 0,
-            "center_x": 0,
-            "center_y": 0,
-        },
-    ]
-
-
-    kwargs_special_zero = {
-        "kwargs_offsets": [
-            {},
-            {
-                "dx": 0,
-                "dy": 0,
-                "angle": 0,
-            },
-        ]
-    }
-
-
-    kwargs_special_true = {
-        "kwargs_offsets": [
-            {},
-            {
-                "dx": 0.05,
-                "dy": -0.03,
-                "angle": 0.02,
-            },
-        ]
-    }
-
-
-    # --------------------------------------------------------
-    # image without offset
-    # --------------------------------------------------------
+    kwargs_special_offset = make_kwargs_special(
+        ra_shift=0.05,
+        dec_shift=-0.03,
+        phi_rot=0.02,
+    )
 
     image_zero = image_model.image(
         kwargs_lens,
@@ -723,115 +226,291 @@ def test_multiband_offsets_change_image_and_restore():
         kwargs_special=kwargs_special_zero,
     )
 
-    # --------------------------------------------------------
-    # image with offset
-    # --------------------------------------------------------
-
-    backup = likelihood._apply_multiband_offsets(
-        kwargs_special_true
+    image_offset = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_offset,
     )
 
-    image_true = image_model.image(
+    assert np.max(np.abs(image_offset - image_zero)) > 0
+
+
+def test_multiband_offsets_restore_reference_image():
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+
+    image_model = likelihood.imSim._image_model_list[1]
+
+    kwargs_special_zero = make_kwargs_special()
+    
+    kwargs_special_offset = make_kwargs_special(
+        ra_shift=0.05,
+        dec_shift=-0.03,
+        phi_rot=0.02,
+    )
+
+    image_zero = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    image_offset = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_offset,
+    )
+
+    image_restored = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    assert np.max(np.abs(image_offset - image_zero)) > 0
+    assert_allclose(image_restored, image_zero)
+
+    
+def test_multiband_offsets_restore_reference_coordinates():
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+
+    image_model = likelihood.imSim._image_model_list[1]
+
+    kwargs_special_zero = make_kwargs_special()
+        
+    kwargs_special_offset = make_kwargs_special(
+        ra_shift=0.05,
+        dec_shift=-0.03,
+        phi_rot=0.02,
+    )
+
+    image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    ra_zero, dec_zero = image_model.ImageNumerics.coordinates_evaluate
+    ra_zero = np.copy(ra_zero)
+    dec_zero = np.copy(dec_zero)
+
+    image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_offset,
+    )
+
+    ra_offset, dec_offset = image_model.ImageNumerics.coordinates_evaluate
+
+    assert not np.allclose(ra_offset, ra_zero)
+    assert not np.allclose(dec_offset, dec_zero)
+
+    image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    ra_restored, dec_restored = image_model.ImageNumerics.coordinates_evaluate
+
+    assert_allclose(ra_restored, ra_zero)
+    assert_allclose(dec_restored, dec_zero)
+
+
+def test_repeated_multiband_offsets_are_consistent():
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+
+    image_model = likelihood.imSim._image_model_list[1]
+
+    kwargs_special_zero = make_kwargs_special()
+        
+    kwargs_special_offset = make_kwargs_special(
+        ra_shift=0.05,
+        dec_shift=-0.03,
+        phi_rot=0.02,
+    )
+
+    # First application
+    image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    image_offset_1 = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_offset,
+    )
+
+    # Return to reference frame
+    image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    # Apply the same offset again
+    image_offset_2 = image_model.image(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light=[],
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_offset,
+    )
+
+    assert_allclose(image_offset_1, image_offset_2)
+
+
+# Test likelihood response to offsets
+def test_multiband_offsets_change_likelihood():
+    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
+
+    kwargs_special_zero = make_kwargs_special()
+        
+    kwargs_special_offset = make_kwargs_special(
+        ra_shift=0.05,
+        dec_shift=-0.03,
+        phi_rot=0.02,
+    )
+
+    logL_zero, _ = likelihood.logL(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
+    )
+
+    logL_offset, _ = likelihood.logL(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_offset,
+    )
+
+    assert np.isfinite(logL_zero)
+    assert np.isfinite(logL_offset)
+    assert logL_zero != logL_offset
+
+def test_correct_multiband_offsets_improve_likelihood():
+    (
+        kwargs_data_joint,
+        kwargs_model,
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+    ) = make_mock_multiband_data()
+
+    true_offsets = {
+        "ra_shift": 0.05,
+        "dec_shift": -0.03,
+        "phi_rot": 0.02,
+    }
+
+    # Generate band 2 with a known coordinate offset.
+
+    multi_band_list_offset = copy.deepcopy(
+        kwargs_data_joint["multi_band_list"]
+    )
+
+    multi_band_list_offset[1][0].update(true_offsets)
+
+    sim_band_2 = SingleBandMultiModel(
+        multi_band_list=multi_band_list_offset,
+        kwargs_model=kwargs_model,
+        likelihood_mask_list=None,
+        band_index=1,
+    )
+
+    image_2_offset = sim_band_2.image(
         kwargs_lens,
         kwargs_source,
         kwargs_lens_light=[],
         kwargs_ps=None,
     )
 
-    likelihood._restore_multiband_offsets(
-        backup
+    # Use the offset image as the observed data with the nominal
+    # coordinate frame for fitting.
+    kwargs_data_joint["multi_band_list"][1][0]["image_data"] = (
+        image_2_offset
     )
 
-    # image should change
-    assert np.max(np.abs(image_true-image_zero)) > 0
-
-    # --------------------------------------------------------
-    # coordinate should change
-    # --------------------------------------------------------
-
-    ra0, dec0 = image_model.ImageNumerics.coordinates_evaluate
-
-    backup = likelihood._apply_multiband_offsets(
-        kwargs_special_true
+    likelihood = ImageLikelihood(
+        multi_band_list=kwargs_data_joint["multi_band_list"],
+        multi_band_type=kwargs_data_joint["multi_band_type"],
+        kwargs_model=kwargs_model,
+        source_marg=False,
     )
 
-    ra1, dec1 = image_model.ImageNumerics.coordinates_evaluate
+    kwargs_special_zero = make_kwargs_special()
 
-    assert np.max(np.abs(ra1-ra0)) > 0
-    assert np.max(np.abs(dec1-dec0)) > 0
-
-
-    likelihood._restore_multiband_offsets(
-        backup
-    )
-
-
-    ra2, dec2 = image_model.ImageNumerics.coordinates_evaluate
-
-    assert_allclose(ra2, ra0)
-    assert_allclose(dec2, dec0)
-
-    print(
-        "PASS: multiband offsets change image and restore correctly"
-    )
-
-def test_repeated_apply_gives_same_image():
-
-    likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
-
-    model = likelihood.imSim._imageModel_list[1]
-
-    kwargs_special = {
-        "kwargs_offsets":[
+    kwargs_special_true = {
+        "kwargs_offsets": [
             {},
-            {
-                "dx":0.05,
-                "dy":-0.03,
-                "angle":0.02,
-            }
+            true_offsets,
         ]
     }
 
-    backup = likelihood._apply_multiband_offsets(
-        kwargs_special
-    )
+    kwargs_special_wrong = {
+        "kwargs_offsets": [
+            {},
+            {
+                "ra_shift": -true_offsets["ra_shift"],
+                "dec_shift": -true_offsets["dec_shift"],
+                "phi_rot": -true_offsets["phi_rot"],
+            },
+        ]
+    }
 
-    image1 = model.image(
+    logL_zero, _ = likelihood.logL(
         kwargs_lens,
         kwargs_source,
         kwargs_lens_light,
         kwargs_ps=None,
+        kwargs_special=kwargs_special_zero,
     )
 
-    likelihood._restore_multiband_offsets(
-        backup
-    )
-
-    backup = likelihood._apply_multiband_offsets(
-        kwargs_special
-    )
-
-    image2 = model.image(
+    logL_true, _ = likelihood.logL(
         kwargs_lens,
         kwargs_source,
         kwargs_lens_light,
         kwargs_ps=None,
+        kwargs_special=kwargs_special_true,
     )
 
-    assert_allclose(
-        image1,
-        image2,
+    logL_wrong, _ = likelihood.logL(
+        kwargs_lens,
+        kwargs_source,
+        kwargs_lens_light,
+        kwargs_ps=None,
+        kwargs_special=kwargs_special_wrong,
     )
 
-    likelihood._restore_multiband_offsets(
-        backup
-    )
-
-    print(
-        "PASS: repeated apply gives identical result"
-    )
+    # Verify that the same-sign offset used to generate the mock data
+    # gives a higher likelihood than both zero and the opposite offset.
+    assert logL_true > logL_zero
+    assert logL_true > logL_wrong
 
 if __name__ == "__main__":
-    test_apply_restore_multiband_offsets()
-    test_multiband_offsets_change_image_and_restore()
-    test_repeated_apply_gives_same_image()
+    pytest.main()

--- a/test/test_Sampling/test_multiband_offset.py
+++ b/test/test_Sampling/test_multiband_offset.py
@@ -7,6 +7,7 @@ from lenstronomy.ImSim.MultiBand.single_band_multi_model import SingleBandMultiM
 from lenstronomy.Util import util
 from lenstronomy.Sampling.Likelihoods.image_likelihood import ImageLikelihood
 
+
 # Generate simple two-band mock data
 def make_mock_multiband_data():
     num_pix = 40
@@ -25,7 +26,6 @@ def make_mock_multiband_data():
         "supersampling_factor": 1,
         "supersampling_convolution": False,
     }
-
 
     # same coordinate system initially
     _, _, ra_at_xy_0, dec_at_xy_0, _, _, Mpix2coord, _ = (
@@ -52,12 +52,17 @@ def make_mock_multiband_data():
     kwargs_data_2 = copy.deepcopy(kwargs_data_1)
 
     multi_band_list = [
-        [kwargs_data_1,
+        [
+            kwargs_data_1,
             psf_kwargs,
-            numerics_kwargs,],
-        [kwargs_data_2,
+            numerics_kwargs,
+        ],
+        [
+            kwargs_data_2,
             psf_kwargs,
-            numerics_kwargs,],]
+            numerics_kwargs,
+        ],
+    ]
 
     # --------------------------------------------------------
     # lens model
@@ -159,6 +164,7 @@ def make_mock_multiband_data():
         [],
     )
 
+
 def make_kwargs_special(
     ra_shift=0.0,
     dec_shift=0.0,
@@ -175,6 +181,7 @@ def make_kwargs_special(
         ]
     }
 
+
 def make_likelihood():
 
     (
@@ -184,7 +191,6 @@ def make_likelihood():
         kwargs_source,
         kwargs_lens_light,
     ) = make_mock_multiband_data()
-
 
     kwargs_likelihood = {
         "source_marg": False,
@@ -203,6 +209,7 @@ def make_likelihood():
         kwargs_source,
         kwargs_lens_light,
     )
+
 
 # Test coordinate updates through the ImageModel API
 def test_multiband_offsets_change_image():
@@ -243,7 +250,7 @@ def test_multiband_offsets_restore_reference_image():
     image_model = likelihood.imSim._image_model_list[1]
 
     kwargs_special_zero = make_kwargs_special()
-    
+
     kwargs_special_offset = make_kwargs_special(
         ra_shift=0.05,
         dec_shift=-0.03,
@@ -277,14 +284,14 @@ def test_multiband_offsets_restore_reference_image():
     assert np.max(np.abs(image_offset - image_zero)) > 0
     assert_allclose(image_restored, image_zero)
 
-    
+
 def test_multiband_offsets_restore_reference_coordinates():
     likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
 
     image_model = likelihood.imSim._image_model_list[1]
 
     kwargs_special_zero = make_kwargs_special()
-        
+
     kwargs_special_offset = make_kwargs_special(
         ra_shift=0.05,
         dec_shift=-0.03,
@@ -336,7 +343,7 @@ def test_repeated_multiband_offsets_are_consistent():
     image_model = likelihood.imSim._image_model_list[1]
 
     kwargs_special_zero = make_kwargs_special()
-        
+
     kwargs_special_offset = make_kwargs_special(
         ra_shift=0.05,
         dec_shift=-0.03,
@@ -386,7 +393,7 @@ def test_multiband_offsets_change_likelihood():
     likelihood, kwargs_lens, kwargs_source, kwargs_lens_light = make_likelihood()
 
     kwargs_special_zero = make_kwargs_special()
-        
+
     kwargs_special_offset = make_kwargs_special(
         ra_shift=0.05,
         dec_shift=-0.03,
@@ -413,6 +420,7 @@ def test_multiband_offsets_change_likelihood():
     assert np.isfinite(logL_offset)
     assert logL_zero != logL_offset
 
+
 def test_correct_multiband_offsets_improve_likelihood():
     (
         kwargs_data_joint,
@@ -430,9 +438,7 @@ def test_correct_multiband_offsets_improve_likelihood():
 
     # Generate band 2 with a known coordinate offset.
 
-    multi_band_list_offset = copy.deepcopy(
-        kwargs_data_joint["multi_band_list"]
-    )
+    multi_band_list_offset = copy.deepcopy(kwargs_data_joint["multi_band_list"])
 
     multi_band_list_offset[1][0].update(true_offsets)
 
@@ -452,9 +458,7 @@ def test_correct_multiband_offsets_improve_likelihood():
 
     # Use the offset image as the observed data with the nominal
     # coordinate frame for fitting.
-    kwargs_data_joint["multi_band_list"][1][0]["image_data"] = (
-        image_2_offset
-    )
+    kwargs_data_joint["multi_band_list"][1][0]["image_data"] = image_2_offset
 
     likelihood = ImageLikelihood(
         multi_band_list=kwargs_data_joint["multi_band_list"],
@@ -511,6 +515,7 @@ def test_correct_multiband_offsets_improve_likelihood():
     # gives a higher likelihood than both zero and the opposite offset.
     assert logL_true > logL_zero
     assert logL_true > logL_wrong
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -214,3 +214,140 @@ class TestParam(object):
 
 if __name__ == "__main__":
     pytest.main()
+
+
+# ============================================================
+
+import numpy as np
+from lenstronomy.Sampling.special_param import SpecialParam
+
+def test_get_params_multiband_offset():
+    special = SpecialParam(
+        multi_band_offset=True,
+        num_bands=3,
+        reference_band=0,
+    )
+    args = [
+        0.10, -0.20, 0.05,     # band 1
+        0.30,  0.40, -0.02,    # band 2
+    ]
+
+    kwargs_special, i = special.get_params(args, 0)
+
+    assert i == len(args)
+
+    expected = [
+        {},
+        {
+            "dx": 0.10,
+            "dy": -0.20,
+            "angle": 0.05,
+        },
+        {
+            "dx": 0.30,
+            "dy": 0.40,
+            "angle": -0.02,
+        },
+    ]
+
+    assert kwargs_special["kwargs_offsets"] == expected
+
+    print("✓ args -> kwargs_special passed")
+
+def test_set_params_multiband_offset():
+    special = SpecialParam(
+        multi_band_offset=True,
+        num_bands=3,
+        reference_band=0,
+    )
+
+    kwargs_special = {
+        "kwargs_offsets": [
+            {},
+            {
+                "dx": 0.10,
+                "dy": -0.20,
+                "angle": 0.05,
+            },
+            {
+                "dx": 0.30,
+                "dy": 0.40,
+                "angle": -0.02,
+            },
+        ]
+    }
+
+    args = special.set_params(kwargs_special)
+
+    expected = [
+        0.10,
+        -0.20,
+        0.05,
+        0.30,
+        0.40,
+        -0.02,
+    ]
+
+    np.testing.assert_allclose(args, expected)
+
+    print("✓ kwargs_special -> args passed")
+
+def test_round_trip():
+    special = SpecialParam(
+        multi_band_offset=True,
+        num_bands=4,
+        reference_band=1,
+    )
+
+    args = [
+        # band 0
+        0.2,
+        0.1,
+        0.05,
+
+        # band 1 is the reference band and has no sampled parameters
+
+        # band 2
+        -0.4,
+        0.6,
+        -0.01,
+        
+        # band 3
+        0.3,
+        -0.7,
+        0.15,
+    ]
+
+    kwargs_special, i = special.get_params(args, 0)
+    recovered = special.set_params(kwargs_special)
+    np.testing.assert_allclose(
+        recovered,
+        args,
+    )
+
+    print("✓ round-trip passed")
+
+def test_reference_band_is_empty():
+
+    special = SpecialParam(
+        multi_band_offset=True,
+        num_bands=3,
+        reference_band=1,
+    )
+
+    args = [
+        0.1,0.2,0.01,
+        0.3,0.4,0.02,
+    ]
+
+    kwargs_special, _ = special.get_params(args,0)
+
+    assert kwargs_special["kwargs_offsets"][1] == {}
+
+    print("✓ reference band fixed")
+
+if __name__ == "__main__":
+    test_get_params_multiband_offset()
+    test_set_params_multiband_offset()
+    test_round_trip()
+    test_reference_band_is_empty()

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -211,6 +211,7 @@ class TestParam(object):
         assert kwargs_new["param_scale_factor"] == [1, 2]
         assert kwargs_new["param_scale_pow"] == [3, 4]
 
+
 def test_get_params_multiband_offset():
     special = SpecialParam(
         multi_band_offset=True,
@@ -219,8 +220,12 @@ def test_get_params_multiband_offset():
     )
 
     args = [
-        0.10, -0.20, 0.05,     # band 1
-        0.30, 0.40, -0.02,     # band 2
+        0.10,
+        -0.20,
+        0.05,  # band 1
+        0.30,
+        0.40,
+        -0.02,  # band 2
     ]
 
     kwargs_special, i = special.get_params(args, 0)
@@ -293,14 +298,11 @@ def test_round_trip_multiband_offset():
         0.2,
         0.1,
         0.05,
-
         # band 1 is the reference band
-
         # band 2
         -0.4,
         0.6,
         -0.01,
-
         # band 3
         0.3,
         -0.7,
@@ -337,6 +339,7 @@ def test_reference_band_is_empty_multiband_offset():
     assert i == len(args)
     assert kwargs_special["kwargs_offsets"][1] == {}
 
+
 def test_multiband_offset_bounds():
     special = SpecialParam(
         multi_band_offset=True,
@@ -357,6 +360,7 @@ def test_multiband_offset_bounds():
         "dec_shift": 1,
         "phi_rot": 0.5,
     }
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_special_param.py
+++ b/test/test_Sampling/test_special_param.py
@@ -211,25 +211,16 @@ class TestParam(object):
         assert kwargs_new["param_scale_factor"] == [1, 2]
         assert kwargs_new["param_scale_pow"] == [3, 4]
 
-
-if __name__ == "__main__":
-    pytest.main()
-
-
-# ============================================================
-
-import numpy as np
-from lenstronomy.Sampling.special_param import SpecialParam
-
 def test_get_params_multiband_offset():
     special = SpecialParam(
         multi_band_offset=True,
         num_bands=3,
         reference_band=0,
     )
+
     args = [
         0.10, -0.20, 0.05,     # band 1
-        0.30,  0.40, -0.02,    # band 2
+        0.30, 0.40, -0.02,     # band 2
     ]
 
     kwargs_special, i = special.get_params(args, 0)
@@ -239,20 +230,19 @@ def test_get_params_multiband_offset():
     expected = [
         {},
         {
-            "dx": 0.10,
-            "dy": -0.20,
-            "angle": 0.05,
+            "ra_shift": 0.10,
+            "dec_shift": -0.20,
+            "phi_rot": 0.05,
         },
         {
-            "dx": 0.30,
-            "dy": 0.40,
-            "angle": -0.02,
+            "ra_shift": 0.30,
+            "dec_shift": 0.40,
+            "phi_rot": -0.02,
         },
     ]
 
     assert kwargs_special["kwargs_offsets"] == expected
 
-    print("✓ args -> kwargs_special passed")
 
 def test_set_params_multiband_offset():
     special = SpecialParam(
@@ -265,14 +255,14 @@ def test_set_params_multiband_offset():
         "kwargs_offsets": [
             {},
             {
-                "dx": 0.10,
-                "dy": -0.20,
-                "angle": 0.05,
+                "ra_shift": 0.10,
+                "dec_shift": -0.20,
+                "phi_rot": 0.05,
             },
             {
-                "dx": 0.30,
-                "dy": 0.40,
-                "angle": -0.02,
+                "ra_shift": 0.30,
+                "dec_shift": 0.40,
+                "phi_rot": -0.02,
             },
         ]
     }
@@ -290,9 +280,8 @@ def test_set_params_multiband_offset():
 
     np.testing.assert_allclose(args, expected)
 
-    print("✓ kwargs_special -> args passed")
 
-def test_round_trip():
+def test_round_trip_multiband_offset():
     special = SpecialParam(
         multi_band_offset=True,
         num_bands=4,
@@ -305,13 +294,13 @@ def test_round_trip():
         0.1,
         0.05,
 
-        # band 1 is the reference band and has no sampled parameters
+        # band 1 is the reference band
 
         # band 2
         -0.4,
         0.6,
         -0.01,
-        
+
         # band 3
         0.3,
         -0.7,
@@ -319,16 +308,15 @@ def test_round_trip():
     ]
 
     kwargs_special, i = special.get_params(args, 0)
+
+    assert i == len(args)
+
     recovered = special.set_params(kwargs_special)
-    np.testing.assert_allclose(
-        recovered,
-        args,
-    )
 
-    print("✓ round-trip passed")
+    np.testing.assert_allclose(recovered, args)
 
-def test_reference_band_is_empty():
 
+def test_reference_band_is_empty_multiband_offset():
     special = SpecialParam(
         multi_band_offset=True,
         num_bands=3,
@@ -336,18 +324,39 @@ def test_reference_band_is_empty():
     )
 
     args = [
-        0.1,0.2,0.01,
-        0.3,0.4,0.02,
+        0.1,
+        0.2,
+        0.01,
+        0.3,
+        0.4,
+        0.02,
     ]
 
-    kwargs_special, _ = special.get_params(args,0)
+    kwargs_special, i = special.get_params(args, 0)
 
+    assert i == len(args)
     assert kwargs_special["kwargs_offsets"][1] == {}
 
-    print("✓ reference band fixed")
+def test_multiband_offset_bounds():
+    special = SpecialParam(
+        multi_band_offset=True,
+        num_bands=3,
+        reference_band=0,
+    )
+
+    assert special.lower_limit["kwargs_offsets"][0] == {}
+    assert special.lower_limit["kwargs_offsets"][1] == {
+        "ra_shift": -1,
+        "dec_shift": -1,
+        "phi_rot": -0.5,
+    }
+
+    assert special.upper_limit["kwargs_offsets"][0] == {}
+    assert special.upper_limit["kwargs_offsets"][1] == {
+        "ra_shift": 1,
+        "dec_shift": 1,
+        "phi_rot": 0.5,
+    }
 
 if __name__ == "__main__":
-    test_get_params_multiband_offset()
-    test_set_params_multiband_offset()
-    test_round_trip()
-    test_reference_band_is_empty()
+    pytest.main()


### PR DESCRIPTION
PR description：
This PR adds support for jointly sampling multi-band astrometric offsets (shift and rotation) in the likelihood module.

Main changes:
- Add multi-band offset parameters in SpecialParam.
- Apply temporary coordinate transformations during likelihood evaluation.
- Restore original coordinate states after evaluation to avoid side effects.
- Add tests covering parameter conversion, coordinate updates, image response, and repeated evaluations.
- Add a demonstration notebook.

The implementation updates internal coordinate grids during likelihood evaluation while preserving the original data state.