### PR TITLE
perturber model to subtract shift and hessian 

### DIFF
--- a/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -32,6 +32,9 @@ class MultiPlaneDecoupled(MultiPlane):
         alpha_x_interp_background=None,
         alpha_y_interp_background=None,
         z_split=None,
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         use_jax=False,
     ):
         """A class for multiplane lensing in which the deflection angles at certain
@@ -63,6 +66,12 @@ class MultiPlaneDecoupled(MultiPlane):
             y-component of the deflection angle at (x,y)
         :param z_interp_list: a list of redshifts corresponding to the
             alpha_x_interp_list and alpha_y_interp_list entries
+        :param perturber_model_list: list of deflector models that are treated as perturbations
+            (subtract shear and convergence contributions at ra_0/dec_0)
+        :type perturber_model_list: None or list of bools
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy. Can also
             be a list of bools, selecting which models in the lens_model_list to use
             from jaxtronomy
@@ -90,6 +99,9 @@ class MultiPlaneDecoupled(MultiPlane):
             distance_ratio_sampling=distance_ratio_sampling,
             cosmology_sampling=cosmology_sampling,
             cosmology_model=cosmology_model,
+            perturber_model_list=perturber_model_list,
+            ra_0=ra_0,
+            dec_0=dec_0,
         )
 
         cosmo_bkg = Background(cosmo)

--- a/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -66,12 +66,13 @@ class MultiPlaneDecoupled(MultiPlane):
             y-component of the deflection angle at (x,y)
         :param z_interp_list: a list of redshifts corresponding to the
             alpha_x_interp_list and alpha_y_interp_list entries
-        :param perturber_model_list: list of deflector models that are treated as perturbations
-            (subtract shear and convergence contributions at ra_0/dec_0)
+        :param perturber_model_list: list of deflector models that are treated as
+            perturbations (subtract shear and convergence contributions at ra_0/dec_0)
         :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
-            (usually center of the main deflector)
+        :param ra_0: RA coordinate for which perturber models have zero shear and
+            convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and
+            convergence contributions (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy. Can also
             be a list of bools, selecting which models in the lens_model_list to use
             from jaxtronomy

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -35,6 +35,9 @@ class MultiPlane(object):
         distance_ratio_sampling=False,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         use_jax=False,
     ):
         """
@@ -68,6 +71,12 @@ class MultiPlane(object):
             distance ratios to update T_ij value in multi-lens plane computation.
         :param cosmology_sampling: bool, if True, will use sampled cosmology
         :param cosmology_model: str, name of the cosmology model to use for
+        :param perturber_model_list: list of deflector models that are treated as perturbations
+            (subtract shear and convergence contributions at ra_0/dec_0)
+        :type perturber_model_list: None or list of bools
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -113,6 +122,9 @@ class MultiPlane(object):
             "distance_ratio_sampling": distance_ratio_sampling,
             "cosmology_sampling": cosmology_sampling,
             "cosmology_model": cosmology_model,
+            "perturber_model_list": perturber_model_list,
+            "ra_0": ra_0,
+            "dec_0": dec_0,
         }
         if z_source_convention is None:
             z_source_convention = z_source
@@ -144,6 +156,9 @@ class MultiPlane(object):
             z_interp_stop=z_interp_stop,
             num_z_interp=num_z_interp,
             profile_kwargs_list=profile_kwargs_list,
+            perturber_model_list=perturber_model_list,
+            ra_0=ra_0,
+            dec_0=dec_0,
             use_jax=use_jax,
         )
         self._z_source = z_source

--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -23,6 +23,9 @@ class MultiPlaneBase(ProfileListBase):
         z_interp_stop=None,
         num_z_interp=100,
         profile_kwargs_list=None,
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         use_jax=False,
     ):
         """
@@ -41,6 +44,12 @@ class MultiPlaneBase(ProfileListBase):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
+        :param perturber_model_list: list of deflector models that are treated as perturbations
+            (subtract shear and convergence contributions at ra_0/dec_0)
+        :type perturber_model_list: None or list of bools
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -71,6 +80,9 @@ class MultiPlaneBase(ProfileListBase):
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
             profile_kwargs_list=profile_kwargs_list,
+            perturber_model_list=perturber_model_list,
+            ra_0=ra_0,
+            dec_0=dec_0,
             use_jax=use_jax,
         )
 

--- a/lenstronomy/LensModel/Profiles/constant_shift.py
+++ b/lenstronomy/LensModel/Profiles/constant_shift.py
@@ -23,7 +23,7 @@ class Shift(LensProfileBase):
         :return: lensing potential
         """
 
-        return np.zeros_like(x)
+        return alpha_x * x + alpha_y * y
 
     def derivatives(self, x, y, alpha_x, alpha_y):
         """

--- a/lenstronomy/LensModel/Profiles/perturber_model.py
+++ b/lenstronomy/LensModel/Profiles/perturber_model.py
@@ -1,0 +1,81 @@
+
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from lenstronomy.LensModel.Profiles.constant_shift import Shift
+from lenstronomy.LensModel.Profiles.hessian import Hessian
+
+
+class PerturberModel(LensProfileBase):
+    """
+    class to use a lens Profile and subtract shear and convergence contribution such that at specific point there
+    are only higher-order contributions.
+
+    """
+    def __init__(self, profile, ra_0, dec_0):
+        """
+
+        :param profile: LensModel.profile class
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
+        """
+        super(PerturberModel, self).__init__()
+        self._profile = profile
+        self._ra_0 = ra_0
+        self._dec_0 = dec_0
+        self.param_names = profile.param_names
+        self.lower_limit_default = profile.lower_limit_default
+        self.upper_limit_default = profile.upper_limit_default
+        self._hessian = Hessian()
+        self._shift = Shift()
+
+    def function(self, x, y, **kwargs):
+
+        f_ = self._profile.function(x, y, **kwargs)
+        alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
+        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(self._ra_0, self._dec_0, **kwargs)
+
+        f_shift = self._shift.function(x, y, alpha_x=alpha_x, alpha_y=alpha_y)
+        f_hessian = self._hessian.function(x, y, f_xx=f_xx, f_yy=f_yy, f_xy=f_xy, f_yx=f_yx,
+                                           ra_0=self._ra_0, dec_0=self._dec_0)
+
+        return f_ - f_shift - f_hessian
+
+    def derivatives(self, x, y, **kwargs):
+        """
+
+        :param x:
+        :param y:
+        :param kwargs:
+        :return:
+        """
+        f_x, f_y = self._profile.derivatives(x, y, **kwargs)
+        alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
+        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(self._ra_0, self._dec_0, **kwargs)
+
+        f_x_shift, f_y_shift = self._shift.derivatives(x, y, alpha_x=alpha_x, alpha_y=alpha_y)
+        f_x_hessian, f_y_hessian = self._hessian.derivatives(x, y, f_xx=f_xx, f_yy=f_yy, f_xy=f_xy, f_yx=f_yx,
+                                           ra_0=self._ra_0, dec_0=self._dec_0)
+
+        f_x_tot = f_x - f_x_shift - f_x_hessian
+        f_y_tot = f_y - f_y_shift - f_y_hessian
+        return f_x_tot, f_y_tot
+
+    def hessian(self, x, y, **kwargs):
+        """
+
+        :param x:
+        :param y:
+        :param kwargs:
+        :return:
+        """
+        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(x, y, **kwargs)
+        alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
+        f_xx0, f_xy0, f_yx0, f_yy0 = self._profile.hessian(self._ra_0, self._dec_0, **kwargs)
+
+        f_xx_shift, f_xy_shift, f_yx_shift, f_yy_shift = self._shift.hessian(x, y, alpha_x=alpha_x, alpha_y=alpha_y)
+
+        f_xx_tot = f_xx - f_xx_shift - f_xx0
+        f_xy_tot = f_xy - f_xy_shift - f_xy0
+        f_yx_tot = f_yx - f_yx_shift - f_yx0
+        f_yy_tot = f_yy - f_yy_shift - f_yy0
+        return f_xx_tot, f_xy_tot, f_yx_tot, f_yy_tot

--- a/lenstronomy/LensModel/Profiles/perturber_model.py
+++ b/lenstronomy/LensModel/Profiles/perturber_model.py
@@ -1,15 +1,12 @@
-
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from lenstronomy.LensModel.Profiles.constant_shift import Shift
 from lenstronomy.LensModel.Profiles.hessian import Hessian
 
 
 class PerturberModel(LensProfileBase):
-    """
-    class to use a lens Profile and subtract shear and convergence contribution such that at specific point there
-    are only higher-order contributions.
+    """Class to use a lens Profile and subtract shear and convergence contribution such
+    that at specific point there are only higher-order contributions."""
 
-    """
     def __init__(self, profile, ra_0, dec_0):
         """
 
@@ -32,11 +29,21 @@ class PerturberModel(LensProfileBase):
 
         f_ = self._profile.function(x, y, **kwargs)
         alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
-        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(self._ra_0, self._dec_0, **kwargs)
+        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(
+            self._ra_0, self._dec_0, **kwargs
+        )
 
         f_shift = self._shift.function(x, y, alpha_x=alpha_x, alpha_y=alpha_y)
-        f_hessian = self._hessian.function(x, y, f_xx=f_xx, f_yy=f_yy, f_xy=f_xy, f_yx=f_yx,
-                                           ra_0=self._ra_0, dec_0=self._dec_0)
+        f_hessian = self._hessian.function(
+            x,
+            y,
+            f_xx=f_xx,
+            f_yy=f_yy,
+            f_xy=f_xy,
+            f_yx=f_yx,
+            ra_0=self._ra_0,
+            dec_0=self._dec_0,
+        )
 
         return f_ - f_shift - f_hessian
 
@@ -50,11 +57,23 @@ class PerturberModel(LensProfileBase):
         """
         f_x, f_y = self._profile.derivatives(x, y, **kwargs)
         alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
-        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(self._ra_0, self._dec_0, **kwargs)
+        f_xx, f_xy, f_yx, f_yy = self._profile.hessian(
+            self._ra_0, self._dec_0, **kwargs
+        )
 
-        f_x_shift, f_y_shift = self._shift.derivatives(x, y, alpha_x=alpha_x, alpha_y=alpha_y)
-        f_x_hessian, f_y_hessian = self._hessian.derivatives(x, y, f_xx=f_xx, f_yy=f_yy, f_xy=f_xy, f_yx=f_yx,
-                                           ra_0=self._ra_0, dec_0=self._dec_0)
+        f_x_shift, f_y_shift = self._shift.derivatives(
+            x, y, alpha_x=alpha_x, alpha_y=alpha_y
+        )
+        f_x_hessian, f_y_hessian = self._hessian.derivatives(
+            x,
+            y,
+            f_xx=f_xx,
+            f_yy=f_yy,
+            f_xy=f_xy,
+            f_yx=f_yx,
+            ra_0=self._ra_0,
+            dec_0=self._dec_0,
+        )
 
         f_x_tot = f_x - f_x_shift - f_x_hessian
         f_y_tot = f_y - f_y_shift - f_y_hessian
@@ -70,9 +89,13 @@ class PerturberModel(LensProfileBase):
         """
         f_xx, f_xy, f_yx, f_yy = self._profile.hessian(x, y, **kwargs)
         alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
-        f_xx0, f_xy0, f_yx0, f_yy0 = self._profile.hessian(self._ra_0, self._dec_0, **kwargs)
+        f_xx0, f_xy0, f_yx0, f_yy0 = self._profile.hessian(
+            self._ra_0, self._dec_0, **kwargs
+        )
 
-        f_xx_shift, f_xy_shift, f_yx_shift, f_yy_shift = self._shift.hessian(x, y, alpha_x=alpha_x, alpha_y=alpha_y)
+        f_xx_shift, f_xy_shift, f_yx_shift, f_yy_shift = self._shift.hessian(
+            x, y, alpha_x=alpha_x, alpha_y=alpha_y
+        )
 
         f_xx_tot = f_xx - f_xx_shift - f_xx0
         f_xy_tot = f_xy - f_xy_shift - f_xy0

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -192,6 +192,9 @@ class LensModel(object):
                     num_z_interp=num_z_interp,
                     profile_kwargs_list=profile_kwargs_list,
                     use_jax=use_jax,
+                    perturber_model_list=perturber_model_list,
+                    ra_0=ra_0,
+                    dec_0=dec_0,
                     **kwargs_multiplane_model
                 )
                 self.type = "MultiPlaneDecoupled"

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -39,6 +39,9 @@ class LensModel(object):
         decouple_multi_plane=False,
         kwargs_multiplane_model=None,
         distance_ratio_sampling=False,
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
         use_jax=False,
@@ -77,6 +80,12 @@ class LensModel(object):
             to update T_ij value in multi-lens plane computation.
         :param cosmology_model: str, name of the cosmology model to be used for
             cosmology sampling. Default is 'FlatLambdaCDM'.
+        :param perturber_model_list: list of deflector models that are treated as perturbations
+            (subtract shear and convergence contributions at ra_0/dec_0)
+        :type perturber_model_list: None or list of bools
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
             Only supported for MultiPlane(), MultiPlaneDecoupled(), and SinglePlane() at the moment
@@ -202,6 +211,9 @@ class LensModel(object):
                     distance_ratio_sampling=distance_ratio_sampling,
                     cosmology_sampling=cosmology_sampling,
                     cosmology_model=cosmology_model,
+                    perturber_model_list=perturber_model_list,
+                    ra_0=ra_0,
+                    dec_0=dec_0,
                     use_jax=use_jax,
                 )
                 self.type = "MultiPlane"
@@ -232,6 +244,9 @@ class LensModel(object):
                     z_source_convention=z_source_convention,
                     profile_kwargs_list=profile_kwargs_list,
                     use_jax=use_jax,
+                    perturber_model_list=perturber_model_list,
+                    ra_0=ra_0,
+                    dec_0=dec_0,
                 )
                 self.type = "SinglePlane"
                 if z_source is not None and z_source_convention is not None:

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -116,15 +116,14 @@ class LensModelExtensions(object):
 
                 rotation_angle = np.arctan(v[1] / v[0]) - np.pi / 2
                 grid_x, grid_y = util.rotate(grid_x_0, grid_y_0, rotation_angle)
-
+                x_ = np.array(grid_x, dtype=float)
                 if axis_ratio == 0:
                     sort = np.argsort(_w)
                     q = _w[sort[0]] / _w[sort[1]]
-                    grid_r = np.hypot(grid_x, grid_y / q).ravel()
+                    y_ = np.array(grid_y / q, dtype=float)
                 else:
                     y_ = np.array(grid_y / axis_ratio, dtype=float)
-                    x_ = np.array(grid_x, dtype=float)
-                    grid_r = np.hypot(x_, y_).ravel()
+                grid_r = np.hypot(x_, y_).ravel()
 
             flux_array = np.zeros_like(grid_x_0)
             step = step_size * grid_radius_arcsec
@@ -549,7 +548,7 @@ class LensModelExtensions(object):
                 np.empty_like(x),
                 np.empty_like(x),
             )
-            for i in range(len(x)):
+            for i in range(len_x):
                 A = np.array([[1 - f_xx[i], f_xy[i]], [f_yx[i], 1 - f_yy[i]]])
                 w, v = np.linalg.eig(A)
                 w1[i], w2[i] = w[0], w[1]

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -534,11 +534,11 @@ class LensModelExtensions(object):
         """
 
         f_xx, f_xy, f_yx, f_yy = self._lensModel.hessian(x, y, kwargs_lens, diff=diff)
-        if isinstance(x, int) or isinstance(x, float) or isinstance(x, complex):
+        if isinstance(x, int) or isinstance(x, float):
             A = np.array([[1 - f_xx, f_xy], [f_yx, 1 - f_yy]])
             w, v = np.linalg.eig(A)
-            v11, v12, v21, v22 = v[0, 0], v[0, 1], v[1, 0], v[1, 1]
-            w1, w2 = w[0], w[1]
+            v11, v12, v21, v22 = np.real(v[0, 0]), np.real(v[0, 1]), np.real(v[1, 0]), np.real(v[1, 1])
+            w1, w2 = np.real(w[0]), np.real(w[1])
         else:
             len_x = len(np.atleast_1d(x))
             w1, w2, v11, v12, v21, v22 = (
@@ -552,6 +552,8 @@ class LensModelExtensions(object):
             for i in range(len_x):
                 A = np.array([[1 - f_xx[i], f_xy[i]], [f_yx[i], 1 - f_yy[i]]])
                 w, v = np.linalg.eig(A)
+                w = np.real(w)
+                v = np.real(v)
                 w1[i], w2[i] = w[0], w[1]
                 v11[i], v12[i], v21[i], v22[i] = v[0, 0], v[0, 1], v[1, 0], v[1, 1]
         return w1, w2, v11, v12, v21, v22

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -123,7 +123,8 @@ class LensModelExtensions(object):
                     grid_r = np.hypot(grid_x, grid_y / q).ravel()
                 else:
                     y_ = np.array(grid_y / axis_ratio, dtype=float)
-                    grid_r = np.hypot(grid_x, y_).ravel()
+                    x_ = np.array(grid_x, dtype=float)
+                    grid_r = np.hypot(x_, y_).ravel()
 
             flux_array = np.zeros_like(grid_x_0)
             step = step_size * grid_radius_arcsec
@@ -539,9 +540,10 @@ class LensModelExtensions(object):
             v11, v12, v21, v22 = v[0, 0], v[0, 1], v[1, 0], v[1, 1]
             w1, w2 = w[0], w[1]
         else:
+            len_x = len(np.atleast_1d(x))
             w1, w2, v11, v12, v21, v22 = (
-                np.empty(len(x), dtype=float),
-                np.empty(len(x), dtype=float),
+                np.empty(len_x, dtype=float),
+                np.empty(len_x, dtype=float),
                 np.empty_like(x),
                 np.empty_like(x),
                 np.empty_like(x),

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -532,8 +532,9 @@ class LensModelExtensions(object):
         :param kwargs_lens: lens model keyword arguments
         :return: radial stretch, tangential stretch
         """
+
         f_xx, f_xy, f_yx, f_yy = self._lensModel.hessian(x, y, kwargs_lens, diff=diff)
-        if isinstance(x, int) or isinstance(x, float):
+        if isinstance(x, int) or isinstance(x, float) or isinstance(x, complex):
             A = np.array([[1 - f_xx, f_xy], [f_yx, 1 - f_yy]])
             w, v = np.linalg.eig(A)
             v11, v12, v21, v22 = v[0, 0], v[0, 1], v[1, 0], v[1, 1]

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -537,7 +537,12 @@ class LensModelExtensions(object):
         if isinstance(x, int) or isinstance(x, float):
             A = np.array([[1 - f_xx, f_xy], [f_yx, 1 - f_yy]])
             w, v = np.linalg.eig(A)
-            v11, v12, v21, v22 = np.real(v[0, 0]), np.real(v[0, 1]), np.real(v[1, 0]), np.real(v[1, 1])
+            v11, v12, v21, v22 = (
+                np.real(v[0, 0]),
+                np.real(v[0, 1]),
+                np.real(v[1, 0]),
+                np.real(v[1, 1]),
+            )
             w1, w2 = np.real(w[0]), np.real(w[1])
         else:
             len_x = len(np.atleast_1d(x))

--- a/lenstronomy/LensModel/lens_model_extensions.py
+++ b/lenstronomy/LensModel/lens_model_extensions.py
@@ -122,7 +122,8 @@ class LensModelExtensions(object):
                     q = _w[sort[0]] / _w[sort[1]]
                     grid_r = np.hypot(grid_x, grid_y / q).ravel()
                 else:
-                    grid_r = np.hypot(grid_x, grid_y / axis_ratio).ravel()
+                    y_ = np.array(grid_y / axis_ratio, dtype=float)
+                    grid_r = np.hypot(grid_x, y_).ravel()
 
             flux_array = np.zeros_like(grid_x_0)
             step = step_size * grid_radius_arcsec

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -239,7 +239,10 @@ class ProfileListBase(object):
                     )
                     lensmodel_class = imported_classes[index]
             if perturber_model_list[i] is True:
-                from lenstronomy.LensModel.Profiles.perturber_model import PerturberModel
+                from lenstronomy.LensModel.Profiles.perturber_model import (
+                    PerturberModel,
+                )
+
                 lensmodel_class = PerturberModel(lensmodel_class, ra_0, dec_0)
             func_list.append(lensmodel_class)
         return func_list

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -140,6 +140,9 @@ class ProfileListBase(object):
         profile_kwargs_list=None,
         lens_redshift_list=None,
         z_source_convention=None,
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         use_jax=False,
     ):
         """
@@ -148,6 +151,12 @@ class ProfileListBase(object):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
+        :param perturber_model_list: list of deflector models that are treated as perturbations
+            (subtract shear and convergence contributions at ra_0/dec_0)
+        :type perturber_model_list: None or list of bools
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -156,6 +165,9 @@ class ProfileListBase(object):
             profile_kwargs_list=profile_kwargs_list,
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
+            perturber_model_list=perturber_model_list,
+            ra_0=ra_0,
+            dec_0=dec_0,
             use_jax=use_jax,
         )
         self._num_func = len(self.func_list)
@@ -172,12 +184,17 @@ class ProfileListBase(object):
         profile_kwargs_list=None,
         lens_redshift_list=None,
         z_source_convention=None,
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         use_jax=False,
     ):
         if lens_redshift_list is None:
             lens_redshift_list = [None] * len(lens_model_list)
         if profile_kwargs_list is None:
             profile_kwargs_list = [{} for _ in range(len(lens_model_list))]
+        if perturber_model_list is None:
+            perturber_model_list = [False] * len(lens_model_list)
 
         # use_jax can be either a bool or list of bools to select specific models to be imported from jaxtronomy
         # If it's a bool, convert to list of bools
@@ -221,7 +238,9 @@ class ProfileListBase(object):
                         (lens_type, profile_kwargs_list[i])
                     )
                     lensmodel_class = imported_classes[index]
-
+            if perturber_model_list[i] is True:
+                from lenstronomy.LensModel.Profiles.perturber_model import PerturberModel
+                lensmodel_class = PerturberModel(lensmodel_class, ra_0, dec_0)
             func_list.append(lensmodel_class)
         return func_list
 

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -16,6 +16,9 @@ class SinglePlane(ProfileListBase):
         lens_redshift_list=None,
         z_source_convention=None,
         alpha_scaling=1,
+        perturber_model_list=None,
+        ra_0=0,
+        dec_0=0,
         use_jax=False,
     ):
         """
@@ -25,6 +28,12 @@ class SinglePlane(ProfileListBase):
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
         :param alpha_scaling: scaling factor of deflection angle relative to z_source_convention
+        :param perturber_model_list: list of deflector models that are treated as perturbations
+            (subtract shear and convergence contributions at ra_0/dec_0)
+        :type perturber_model_list: None or list of bools
+        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
+        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
+            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -35,6 +44,9 @@ class SinglePlane(ProfileListBase):
             profile_kwargs_list=profile_kwargs_list,
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
+            perturber_model_list=perturber_model_list,
+            ra_0=ra_0,
+            dec_0=dec_0,
             use_jax=use_jax,
         )
 

--- a/test/test_LensModel/test_Profiles/test_constant_shift.py
+++ b/test/test_LensModel/test_Profiles/test_constant_shift.py
@@ -14,14 +14,14 @@ class TestShift(object):
     def setup_method(self):
         self.shift = Shift()
 
-        alpha_x, alpha_y = 10.0, 0.1
-        self.kwargs_lens = {"alpha_x": alpha_x, "alpha_y": alpha_y}
+        self.alpha_x, self.alpha_y = 10.0, 0.1
+        self.kwargs_lens = {"alpha_x": self.alpha_x, "alpha_y": self.alpha_y}
 
     def test_function(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([1.])
+        y = np.array([2.])
         values = self.shift.function(x, y, **self.kwargs_lens)
-        npt.assert_almost_equal(values[0], 0, decimal=5)
+        npt.assert_almost_equal(values[0], x[0] * self.alpha_x + self.alpha_y * y[0], decimal=5)
         x = np.array([0])
         y = np.array([0])
         values = self.shift.function(x, y, **self.kwargs_lens)
@@ -30,8 +30,8 @@ class TestShift(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.shift.function(x, y, **self.kwargs_lens)
-        npt.assert_almost_equal(values[0], 0, decimal=5)
-        npt.assert_almost_equal(values[1], 0, decimal=5)
+        npt.assert_almost_equal(values[0], x[0] * self.alpha_x + y[0] * self.alpha_y, decimal=5)
+        npt.assert_almost_equal(values[1], x[1] * self.alpha_x + y[1] * self.alpha_y, decimal=5)
 
     def test_derivatives(self):
         x = np.array([1])

--- a/test/test_LensModel/test_Profiles/test_constant_shift.py
+++ b/test/test_LensModel/test_Profiles/test_constant_shift.py
@@ -18,10 +18,12 @@ class TestShift(object):
         self.kwargs_lens = {"alpha_x": self.alpha_x, "alpha_y": self.alpha_y}
 
     def test_function(self):
-        x = np.array([1.])
-        y = np.array([2.])
+        x = np.array([1.0])
+        y = np.array([2.0])
         values = self.shift.function(x, y, **self.kwargs_lens)
-        npt.assert_almost_equal(values[0], x[0] * self.alpha_x + self.alpha_y * y[0], decimal=5)
+        npt.assert_almost_equal(
+            values[0], x[0] * self.alpha_x + self.alpha_y * y[0], decimal=5
+        )
         x = np.array([0])
         y = np.array([0])
         values = self.shift.function(x, y, **self.kwargs_lens)
@@ -30,8 +32,12 @@ class TestShift(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.shift.function(x, y, **self.kwargs_lens)
-        npt.assert_almost_equal(values[0], x[0] * self.alpha_x + y[0] * self.alpha_y, decimal=5)
-        npt.assert_almost_equal(values[1], x[1] * self.alpha_x + y[1] * self.alpha_y, decimal=5)
+        npt.assert_almost_equal(
+            values[0], x[0] * self.alpha_x + y[0] * self.alpha_y, decimal=5
+        )
+        npt.assert_almost_equal(
+            values[1], x[1] * self.alpha_x + y[1] * self.alpha_y, decimal=5
+        )
 
     def test_derivatives(self):
         x = np.array([1])

--- a/test/test_LensModel/test_Profiles/test_perturber_model.py
+++ b/test/test_LensModel/test_Profiles/test_perturber_model.py
@@ -27,4 +27,4 @@ class TestPerturberModel:
 
         f = self._model.function(self.ra0, self.dec0, **kwargs_lens)
         f_sis = self._sis.function(self.ra0, self.dec0, **kwargs_lens)
-        npt.assert_almost_equal(f, f_sis, decimal=10)
+        npt.assert_almost_equal(f, 0, decimal=10)

--- a/test/test_LensModel/test_Profiles/test_perturber_model.py
+++ b/test/test_LensModel/test_Profiles/test_perturber_model.py
@@ -1,0 +1,32 @@
+from lenstronomy.LensModel.Profiles.perturber_model import PerturberModel
+from lenstronomy.LensModel.Profiles.sis import SIS
+import numpy.testing as npt
+
+
+class TestPerturberModel():
+
+    def setup_method(self):
+        self._sis = SIS()
+        self.ra0 = 10
+        self.dec0 =5
+        self._model = PerturberModel(profile=self._sis, ra_0=self.ra0, dec_0=self.dec0)
+
+    def test_offset(self):
+
+        # test that evaluations of deflections and hessian at ra0/dec0 is zero
+        kwargs_lens = {"theta_E": 1, "center_x": 0, "center_y": 0}
+        alpha_x, alpha_y = self._model.derivatives(self.ra0, self.dec0, **kwargs_lens)
+        npt.assert_almost_equal(alpha_x, 0, decimal=10)
+        npt.assert_almost_equal(alpha_y, 0, decimal=10)
+
+        f_xx, f_xy, f_yx, f_yy = self._model.hessian(self.ra0, self.dec0, **kwargs_lens)
+        npt.assert_almost_equal(f_xx, 0, decimal=10)
+        npt.assert_almost_equal(f_xy, 0, decimal=10)
+        npt.assert_almost_equal(f_yx, 0, decimal=10)
+        npt.assert_almost_equal(f_yy, 0, decimal=10)
+
+        f = self._model.function(self.ra0, self.dec0, **kwargs_lens)
+        f_sis = self._sis.function(self.ra0, self.dec0, **kwargs_lens)
+        npt.assert_almost_equal(f, f_sis, decimal=10)
+
+

--- a/test/test_LensModel/test_Profiles/test_perturber_model.py
+++ b/test/test_LensModel/test_Profiles/test_perturber_model.py
@@ -3,12 +3,12 @@ from lenstronomy.LensModel.Profiles.sis import SIS
 import numpy.testing as npt
 
 
-class TestPerturberModel():
+class TestPerturberModel:
 
     def setup_method(self):
         self._sis = SIS()
         self.ra0 = 10
-        self.dec0 =5
+        self.dec0 = 5
         self._model = PerturberModel(profile=self._sis, ra_0=self.ra0, dec_0=self.dec0)
 
     def test_offset(self):
@@ -28,5 +28,3 @@ class TestPerturberModel():
         f = self._model.function(self.ra0, self.dec0, **kwargs_lens)
         f_sis = self._sis.function(self.ra0, self.dec0, **kwargs_lens)
         npt.assert_almost_equal(f, f_sis, decimal=10)
-
-

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -86,8 +86,10 @@ class TestNumericsProfile(object):
     ):
         x = np.linspace(start=0.1, stop=5.5, num=10)
         y = np.zeros_like(x)
-
-        lensModel = LensModel(lens_model)
+        if isinstance(lens_model, list):
+            lensModel = LensModel(lens_model)
+        else:
+            lensModel = lens_model
         f_xx, f_xy, f_yx, f_yy = lensModel.hessian(x, y, [kwargs])
         f_xx_num, f_xy_num, f_yx_num, f_yy_num = lensModel.hessian(
             x, y, [kwargs], diff=diff
@@ -107,7 +109,6 @@ class TestNumericsProfile(object):
         y = np.linspace(start=0.1, stop=5.5, num=10)
         x = np.zeros_like(y)
 
-        lensModel = LensModel(lens_model)
         f_xx, f_xy, f_yx, f_yy = lensModel.hessian(x, y, [kwargs])
         f_xx_num, f_xy_num, f_yx_num, f_yy_num = lensModel.hessian(
             x, y, [kwargs], diff=diff
@@ -191,7 +192,7 @@ class TestNumericsProfile(object):
         self.assert_differentials(lens_model, kwargs)
 
     def test_hessian(self):
-        kwargs = {"f_xx": 0.1, "f_yy": -0.1, "f_xy": 0.1, "f_yx": 0.1}
+        kwargs = {"f_xx": 0.1, "f_yy": -0.1, "f_xy": 0.1, "f_yx": 0.1, "ra_0": 10, "dec_0": 10}
         lens_model = ["HESSIAN"]
         self.assert_differentials(lens_model, kwargs)
 
@@ -433,6 +434,18 @@ class TestNumericsProfile(object):
         kwargs = {"theta_E": 2.0, "theta_c": 1.0, "e1": 0.1, "e2": 0.1}
         lens_model = ["NIE_POTENTIAL"]
         self.assert_differentials(lens_model, kwargs)
+
+    def test_shift(self):
+        kwargs = {"alpha_x": 1, "alpha_y": -1}
+        lens_model = ["SHIFT"]
+        self.assert_differentials(lens_model, kwargs)
+
+    def test_perturber_model(self):
+
+        lensModel = LensModel(lens_model_list=["SIS"], perturber_model_list=[True], ra_0=10, dec_0=10)
+        kwargs_sis = {"theta_E": 1, "center_x": 0, "center_y": 0}
+        self.assert_differentials(lens_model=lensModel, kwargs=kwargs_sis, potential=True)
+
 
     def test_multipole(self):
         kwargs = {"m": 4, "a_m": 0.05, "phi_m": 0.1, "center_x": 0.0, "center_y": 0.0}

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -192,7 +192,14 @@ class TestNumericsProfile(object):
         self.assert_differentials(lens_model, kwargs)
 
     def test_hessian(self):
-        kwargs = {"f_xx": 0.1, "f_yy": -0.1, "f_xy": 0.1, "f_yx": 0.1, "ra_0": 10, "dec_0": 10}
+        kwargs = {
+            "f_xx": 0.1,
+            "f_yy": -0.1,
+            "f_xy": 0.1,
+            "f_yx": 0.1,
+            "ra_0": 10,
+            "dec_0": 10,
+        }
         lens_model = ["HESSIAN"]
         self.assert_differentials(lens_model, kwargs)
 
@@ -442,10 +449,13 @@ class TestNumericsProfile(object):
 
     def test_perturber_model(self):
 
-        lensModel = LensModel(lens_model_list=["SIS"], perturber_model_list=[True], ra_0=10, dec_0=10)
+        lensModel = LensModel(
+            lens_model_list=["SIS"], perturber_model_list=[True], ra_0=10, dec_0=10
+        )
         kwargs_sis = {"theta_E": 1, "center_x": 0, "center_y": 0}
-        self.assert_differentials(lens_model=lensModel, kwargs=kwargs_sis, potential=True)
-
+        self.assert_differentials(
+            lens_model=lensModel, kwargs=kwargs_sis, potential=True
+        )
 
     def test_multipole(self):
         kwargs = {"m": 4, "a_m": 0.05, "phi_m": 0.1, "center_x": 0.0, "center_y": 0.0}


### PR DESCRIPTION
This PR adds a feature "perturber_model_list" that can flag deflector models that are only treated at higher order (without constant shift, shear and convergence) to not cause degeneracy with other modeled quantities