### PR TITLE
consolidate perturber model class

### DIFF
--- a/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -32,9 +32,6 @@ class MultiPlaneDecoupled(MultiPlane):
         alpha_x_interp_background=None,
         alpha_y_interp_background=None,
         z_split=None,
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         use_jax=False,
     ):
         """A class for multiplane lensing in which the deflection angles at certain
@@ -66,13 +63,6 @@ class MultiPlaneDecoupled(MultiPlane):
             y-component of the deflection angle at (x,y)
         :param z_interp_list: a list of redshifts corresponding to the
             alpha_x_interp_list and alpha_y_interp_list entries
-        :param perturber_model_list: list of deflector models that are treated as
-            perturbations (subtract shear and convergence contributions at ra_0/dec_0)
-        :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and
-            convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and
-            convergence contributions (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy. Can also
             be a list of bools, selecting which models in the lens_model_list to use
             from jaxtronomy
@@ -100,9 +90,6 @@ class MultiPlaneDecoupled(MultiPlane):
             distance_ratio_sampling=distance_ratio_sampling,
             cosmology_sampling=cosmology_sampling,
             cosmology_model=cosmology_model,
-            perturber_model_list=perturber_model_list,
-            ra_0=ra_0,
-            dec_0=dec_0,
         )
 
         cosmo_bkg = Background(cosmo)

--- a/lenstronomy/LensModel/MultiPlane/multi_plane.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane.py
@@ -35,9 +35,6 @@ class MultiPlane(object):
         distance_ratio_sampling=False,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         use_jax=False,
     ):
         """
@@ -71,12 +68,6 @@ class MultiPlane(object):
             distance ratios to update T_ij value in multi-lens plane computation.
         :param cosmology_sampling: bool, if True, will use sampled cosmology
         :param cosmology_model: str, name of the cosmology model to use for
-        :param perturber_model_list: list of deflector models that are treated as perturbations
-            (subtract shear and convergence contributions at ra_0/dec_0)
-        :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
-            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -122,9 +113,6 @@ class MultiPlane(object):
             "distance_ratio_sampling": distance_ratio_sampling,
             "cosmology_sampling": cosmology_sampling,
             "cosmology_model": cosmology_model,
-            "perturber_model_list": perturber_model_list,
-            "ra_0": ra_0,
-            "dec_0": dec_0,
         }
         if z_source_convention is None:
             z_source_convention = z_source
@@ -156,9 +144,6 @@ class MultiPlane(object):
             z_interp_stop=z_interp_stop,
             num_z_interp=num_z_interp,
             profile_kwargs_list=profile_kwargs_list,
-            perturber_model_list=perturber_model_list,
-            ra_0=ra_0,
-            dec_0=dec_0,
             use_jax=use_jax,
         )
         self._z_source = z_source

--- a/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/lenstronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -23,9 +23,6 @@ class MultiPlaneBase(ProfileListBase):
         z_interp_stop=None,
         num_z_interp=100,
         profile_kwargs_list=None,
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         use_jax=False,
     ):
         """
@@ -44,12 +41,6 @@ class MultiPlaneBase(ProfileListBase):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
-        :param perturber_model_list: list of deflector models that are treated as perturbations
-            (subtract shear and convergence contributions at ra_0/dec_0)
-        :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
-            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -80,9 +71,6 @@ class MultiPlaneBase(ProfileListBase):
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
             profile_kwargs_list=profile_kwargs_list,
-            perturber_model_list=perturber_model_list,
-            ra_0=ra_0,
-            dec_0=dec_0,
             use_jax=use_jax,
         )
 

--- a/lenstronomy/LensModel/Profiles/perturber_model.py
+++ b/lenstronomy/LensModel/Profiles/perturber_model.py
@@ -7,15 +7,20 @@ class PerturberModel(LensProfileBase):
     """Class to use a lens Profile and subtract shear and convergence contribution such
     that at specific point there are only higher-order contributions."""
 
-    def __init__(self, profile, ra_0, dec_0):
+    def __init__(self, profile, ra_0=0, dec_0=0):
         """
 
-        :param profile: LensModel.profile class
+        :param profile: LensModel.profile class or a string indicating which model to use, e.g. "SIS".
+            See _SUPPORTED_MODELS in lenstronomy.LensModel.profile_list_base for the full list.
         :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
         :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
             (usually center of the main deflector)
         """
         super(PerturberModel, self).__init__()
+        if isinstance(profile, str):
+            from lenstronomy.LensModel.profile_list_base import lens_class
+
+            profile = lens_class(profile)
         self._profile = profile
         self._ra_0 = ra_0
         self._dec_0 = dec_0
@@ -26,7 +31,13 @@ class PerturberModel(LensProfileBase):
         self._shift = Shift()
 
     def function(self, x, y, **kwargs):
+        """
 
+        :param x: x coordinates (typically in arcseconds)
+        :param y: y coordinates (typically in arcseconds)
+        :param kwargs: keyword arguments for the profile class supplied at initialization
+        :return: lensing potential of perturber with the first and second order contributions subtracted
+        """
         f_ = self._profile.function(x, y, **kwargs)
         alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
         f_xx, f_xy, f_yx, f_yy = self._profile.hessian(
@@ -50,10 +61,10 @@ class PerturberModel(LensProfileBase):
     def derivatives(self, x, y, **kwargs):
         """
 
-        :param x:
-        :param y:
-        :param kwargs:
-        :return:
+        :param x: x coordinates (typically in arcseconds)
+        :param y: y coordinates (typically in arcseconds)
+        :param kwargs: keyword arguments for the profile class supplied at initialization
+        :return: deflection angles of perturber with the first and second order contributions subtracted
         """
         f_x, f_y = self._profile.derivatives(x, y, **kwargs)
         alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)
@@ -82,10 +93,11 @@ class PerturberModel(LensProfileBase):
     def hessian(self, x, y, **kwargs):
         """
 
-        :param x:
-        :param y:
-        :param kwargs:
-        :return:
+        :param x: x coordinates (typically in arcseconds)
+        :param y: y coordinates (typically in arcseconds)
+        :param kwargs: keyword arguments for the profile class supplied at initialization
+        :return: hessian matrix of perturber's lensing potential with the first and
+            second order contributions subtracted
         """
         f_xx, f_xy, f_yx, f_yy = self._profile.hessian(x, y, **kwargs)
         alpha_x, alpha_y = self._profile.derivatives(self._ra_0, self._dec_0, **kwargs)

--- a/lenstronomy/LensModel/lens_model.py
+++ b/lenstronomy/LensModel/lens_model.py
@@ -39,9 +39,6 @@ class LensModel(object):
         decouple_multi_plane=False,
         kwargs_multiplane_model=None,
         distance_ratio_sampling=False,
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         cosmology_sampling=False,
         cosmology_model="FlatLambdaCDM",
         use_jax=False,
@@ -80,12 +77,6 @@ class LensModel(object):
             to update T_ij value in multi-lens plane computation.
         :param cosmology_model: str, name of the cosmology model to be used for
             cosmology sampling. Default is 'FlatLambdaCDM'.
-        :param perturber_model_list: list of deflector models that are treated as perturbations
-            (subtract shear and convergence contributions at ra_0/dec_0)
-        :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
-            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
             Only supported for MultiPlane(), MultiPlaneDecoupled(), and SinglePlane() at the moment
@@ -192,9 +183,6 @@ class LensModel(object):
                     num_z_interp=num_z_interp,
                     profile_kwargs_list=profile_kwargs_list,
                     use_jax=use_jax,
-                    perturber_model_list=perturber_model_list,
-                    ra_0=ra_0,
-                    dec_0=dec_0,
                     **kwargs_multiplane_model
                 )
                 self.type = "MultiPlaneDecoupled"
@@ -214,9 +202,6 @@ class LensModel(object):
                     distance_ratio_sampling=distance_ratio_sampling,
                     cosmology_sampling=cosmology_sampling,
                     cosmology_model=cosmology_model,
-                    perturber_model_list=perturber_model_list,
-                    ra_0=ra_0,
-                    dec_0=dec_0,
                     use_jax=use_jax,
                 )
                 self.type = "MultiPlane"
@@ -247,9 +232,6 @@ class LensModel(object):
                     z_source_convention=z_source_convention,
                     profile_kwargs_list=profile_kwargs_list,
                     use_jax=use_jax,
-                    perturber_model_list=perturber_model_list,
-                    ra_0=ra_0,
-                    dec_0=dec_0,
                 )
                 self.type = "SinglePlane"
                 if z_source is not None and z_source_convention is not None:

--- a/lenstronomy/LensModel/profile_list_base.py
+++ b/lenstronomy/LensModel/profile_list_base.py
@@ -74,6 +74,7 @@ _SUPPORTED_MODELS = [
     "NIE_POTENTIAL",
     "NIE_SIMPLE",
     "PEMD",
+    "PERTURBER",
     "PJAFFE",
     "PJAFFE_ELLIPSE_POTENTIAL",
     "POINT_MASS",
@@ -140,9 +141,6 @@ class ProfileListBase(object):
         profile_kwargs_list=None,
         lens_redshift_list=None,
         z_source_convention=None,
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         use_jax=False,
     ):
         """
@@ -151,12 +149,6 @@ class ProfileListBase(object):
         :param profile_kwargs_list: list of dicts, keyword arguments used to initialize profile classes
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
-        :param perturber_model_list: list of deflector models that are treated as perturbations
-            (subtract shear and convergence contributions at ra_0/dec_0)
-        :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
-            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -165,9 +157,6 @@ class ProfileListBase(object):
             profile_kwargs_list=profile_kwargs_list,
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
-            perturber_model_list=perturber_model_list,
-            ra_0=ra_0,
-            dec_0=dec_0,
             use_jax=use_jax,
         )
         self._num_func = len(self.func_list)
@@ -184,17 +173,12 @@ class ProfileListBase(object):
         profile_kwargs_list=None,
         lens_redshift_list=None,
         z_source_convention=None,
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         use_jax=False,
     ):
         if lens_redshift_list is None:
             lens_redshift_list = [None] * len(lens_model_list)
         if profile_kwargs_list is None:
             profile_kwargs_list = [{} for _ in range(len(lens_model_list))]
-        if perturber_model_list is None:
-            perturber_model_list = [False] * len(lens_model_list)
 
         # use_jax can be either a bool or list of bools to select specific models to be imported from jaxtronomy
         # If it's a bool, convert to list of bools
@@ -238,12 +222,7 @@ class ProfileListBase(object):
                         (lens_type, profile_kwargs_list[i])
                     )
                     lensmodel_class = imported_classes[index]
-            if perturber_model_list[i] is True:
-                from lenstronomy.LensModel.Profiles.perturber_model import (
-                    PerturberModel,
-                )
 
-                lensmodel_class = PerturberModel(lensmodel_class, ra_0, dec_0)
             func_list.append(lensmodel_class)
         return func_list
 
@@ -673,6 +652,10 @@ def lens_class(
         from lenstronomy.LensModel.Profiles.pemd import PEMD
 
         return PEMD(**profile_kwargs)
+    elif lens_type == "PERTURBER":
+        from lenstronomy.LensModel.Profiles.perturber_model import PerturberModel
+
+        return PerturberModel(**profile_kwargs)
     elif lens_type == "PJAFFE":
         from lenstronomy.LensModel.Profiles.pseudo_jaffe import PseudoJaffe
 

--- a/lenstronomy/LensModel/single_plane.py
+++ b/lenstronomy/LensModel/single_plane.py
@@ -16,9 +16,6 @@ class SinglePlane(ProfileListBase):
         lens_redshift_list=None,
         z_source_convention=None,
         alpha_scaling=1,
-        perturber_model_list=None,
-        ra_0=0,
-        dec_0=0,
         use_jax=False,
     ):
         """
@@ -28,12 +25,6 @@ class SinglePlane(ProfileListBase):
             in the same order of the lens_model_list. If any of the profile_kwargs are None, then that
             profile will be initialized using default settings.
         :param alpha_scaling: scaling factor of deflection angle relative to z_source_convention
-        :param perturber_model_list: list of deflector models that are treated as perturbations
-            (subtract shear and convergence contributions at ra_0/dec_0)
-        :type perturber_model_list: None or list of bools
-        :param ra_0: RA coordinate for which perturber models have zero shear and convergence contributions
-        :param dec_0: DEC coordinate for which perturber models have zero shear and convergence contributions
-            (usually center of the main deflector)
         :param use_jax: bool, if True, uses deflector profiles from jaxtronomy.
             Can also be a list of bools, selecting which models in the lens_model_list to use from jaxtronomy
         """
@@ -44,9 +35,6 @@ class SinglePlane(ProfileListBase):
             profile_kwargs_list=profile_kwargs_list,
             lens_redshift_list=lens_redshift_list,
             z_source_convention=z_source_convention,
-            perturber_model_list=perturber_model_list,
-            ra_0=ra_0,
-            dec_0=dec_0,
             use_jax=use_jax,
         )
 

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -450,7 +450,8 @@ class TestNumericsProfile(object):
     def test_perturber_model(self):
 
         lensModel = LensModel(
-            lens_model_list=["PERTURBER"], profile_kwargs_list=[{"profile": "SIS", "ra_0": 10, "dec_0": 10}]
+            lens_model_list=["PERTURBER"],
+            profile_kwargs_list=[{"profile": "SIS", "ra_0": 10, "dec_0": 10}],
         )
         kwargs_sis = {"theta_E": 1, "center_x": 0, "center_y": 0}
         self.assert_differentials(

--- a/test/test_LensModel/test_numeric_lens_differentials.py
+++ b/test/test_LensModel/test_numeric_lens_differentials.py
@@ -450,7 +450,7 @@ class TestNumericsProfile(object):
     def test_perturber_model(self):
 
         lensModel = LensModel(
-            lens_model_list=["SIS"], perturber_model_list=[True], ra_0=10, dec_0=10
+            lens_model_list=["PERTURBER"], profile_kwargs_list=[{"profile": "SIS", "ra_0": 10, "dec_0": 10}]
         )
         kwargs_sis = {"theta_E": 1, "center_x": 0, "center_y": 0}
         self.assert_differentials(

--- a/test/test_LensModel/test_single_plane.py
+++ b/test/test_LensModel/test_single_plane.py
@@ -108,6 +108,14 @@ class TestLensModel(object):
         lensModel = SinglePlane(lens_model_list=lens_model_list)
         assert lensModel.func_list[0].param_names[0] == "Rs"
 
+        lens_model_list = ["PERTURBER"]
+        profile_kwargs_list = [{"profile": "EPL", "ra_0": 0.1, "dec_0": -0.1}]
+        lens_model = SinglePlane(lens_model_list=lens_model_list, profile_kwargs_list=profile_kwargs_list)
+        kwargs_lens = [{"theta_E": 1.2, "gamma": 1.7, "e1": 0.2, "e2": -0.07, "center_x": 0, "center_y": 0}]
+        alpha_x, alpha_y = lens_model.alpha(0.1, -0.1, kwargs_lens)
+        npt.assert_almost_equal(alpha_x, 0, decimal=10)
+        npt.assert_almost_equal(alpha_y, 0, decimal=10)
+
     def test_alpha_scaling(self):
         """Test the behavior of scaling the deflection angle :return:"""
         x, y = 1, 0

--- a/test/test_LensModel/test_single_plane.py
+++ b/test/test_LensModel/test_single_plane.py
@@ -110,8 +110,19 @@ class TestLensModel(object):
 
         lens_model_list = ["PERTURBER"]
         profile_kwargs_list = [{"profile": "EPL", "ra_0": 0.1, "dec_0": -0.1}]
-        lens_model = SinglePlane(lens_model_list=lens_model_list, profile_kwargs_list=profile_kwargs_list)
-        kwargs_lens = [{"theta_E": 1.2, "gamma": 1.7, "e1": 0.2, "e2": -0.07, "center_x": 0, "center_y": 0}]
+        lens_model = SinglePlane(
+            lens_model_list=lens_model_list, profile_kwargs_list=profile_kwargs_list
+        )
+        kwargs_lens = [
+            {
+                "theta_E": 1.2,
+                "gamma": 1.7,
+                "e1": 0.2,
+                "e2": -0.07,
+                "center_x": 0,
+                "center_y": 0,
+            }
+        ]
         alpha_x, alpha_y = lens_model.alpha(0.1, -0.1, kwargs_lens)
         npt.assert_almost_equal(alpha_x, 0, decimal=10)
         npt.assert_almost_equal(alpha_y, 0, decimal=10)


### PR DESCRIPTION
Currently, using the PerturberModel class requires 3 extra keyword arguments to be supplied to the LensModel class. In order to use this feature in lens modeling, these 3 arguments would have to be included in `kwargs_model` and propagated through the class creator util functions.

To simplify usage and implementation in e.g. dolphin, this PR removes these extra keyword arguments in favor of placing them within `profile_kwargs_list`. Models in the `lens_model_list` are no longer flagged with the `perturber_model_list` but are instead initialized directly with the `"PERTURBER"` lens type.