### PR TITLE
Fix eccentricity upper limit defaults

### DIFF
--- a/lenstronomy/LightModel/Profiles/gaussian.py
+++ b/lenstronomy/LightModel/Profiles/gaussian.py
@@ -87,8 +87,8 @@ class GaussianEllipse(object):
     upper_limit_default = {
         "amp": 1000,
         "sigma": 100,
-        "e1": -0.5,
-        "e2": -0.5,
+        "e1": 0.5,
+        "e2": 0.5,
         "center_x": 100,
         "center_y": 100,
     }
@@ -247,8 +247,8 @@ class MultiGaussianEllipse(object):
     upper_limit_default = {
         "amp": 1000,
         "sigma": 100,
-        "e1": -0.5,
-        "e2": -0.5,
+        "e1": 0.5,
+        "e2": 0.5,
         "center_x": 100,
         "center_y": 100,
     }

--- a/lenstronomy/LightModel/Profiles/linear.py
+++ b/lenstronomy/LightModel/Profiles/linear.py
@@ -75,8 +75,8 @@ class LinearEllipse(object):
     upper_limit_default = {
         "k": 1000,
         "amp": 100,
-        "e1": -0.5,
-        "e2": -0.5,
+        "e1": 0.5,
+        "e2": 0.5,
         "center_x": 100,
         "center_y": 100,
     }


### PR DESCRIPTION
This PR updates the default upper limits for the ellipticity parameters (`e1` and `e2`) in several light profile classes to use positive values. I suspect this was a typo that got propagated with copy-paste.