### PR TITLE
change scipy requirement to allow >= 1.18.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 astropy
-scipy>=0.19.1, <1.18.0
+scipy>=0.19.1, !=1.18.0
 mpmath
 emcee>=3.0.0
 matplotlib


### PR DESCRIPTION
Previously scipy was restricted to <1.18.0 due to a bug (see [PR 870](https://github.com/lenstronomy/lenstronomy/pull/870#issuecomment-4772950157)). The bug has been fixed in 1.18.1.