### PR TITLE
Add gradient beyond prior bound to bring back walkers

### DIFF
--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -351,11 +351,6 @@ class Likelihood(object):
                 args, self._lower_limit, self._upper_limit, verbose=verbose
             )
             if bound_hit is True:
-                # the -1e18 floor guarantees any out-of-bounds point scores
-                # worse than a legitimate finite likelihood; it cancels out of
-                # any Metropolis ratio between two out-of-bounds points, so the
-                # (distance-based) penalty is what still provides a restoring
-                # gradient back toward the allowed region
                 return -(10**18) - penalty
         # extract parameters
         kwargs_return = self.param.args2kwargs(args)

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -449,15 +449,15 @@ class Likelihood(object):
     @staticmethod
     def check_bounds(args, lowerLimit, upperLimit, verbose=False):
         """Checks whether the parameter vector has left its bounds. If so, returns a
-        penalty that grows with the (bound-range-normalized) distance past the
-        violated bound(s), summed over all violated parameters.
+        penalty that grows with the (bound-range-normalized) distance past the violated
+        bound(s), summed over all violated parameters.
 
-        A flat penalty (independent of how far a parameter is out of bounds) creates
-        a plateau with no likelihood gradient, which lets samplers with proposals
+        A flat penalty (independent of how far a parameter is out of bounds) creates a
+        plateau with no likelihood gradient, which lets samplers with proposals
         referenced to other walkers' positions (e.g. emcee's stretch move) drift
-        arbitrarily far from the bounds once they land in that region, since every
-        out-of-bounds point looks equally "bad". Scaling the penalty with distance
-        keeps a restoring gradient pointing back toward the allowed region.
+        arbitrarily far from the bounds once they land in that region, since every out-
+        of-bounds point looks equally "bad". Scaling the penalty with distance keeps a
+        restoring gradient pointing back toward the allowed region.
         """
         args = np.atleast_1d(args)
         penalty = 0.0

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -451,7 +451,6 @@ class Likelihood(object):
         """Checks whether the parameter vector has left its bounds. If so, returns a
         penalty that grows with the (bound-range-normalized) distance past the violated
         bound(s), summed over all violated parameters.
-
         """
         args = np.atleast_1d(args)
         penalty = 0.0

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -351,7 +351,12 @@ class Likelihood(object):
                 args, self._lower_limit, self._upper_limit, verbose=verbose
             )
             if bound_hit is True:
-                return -(10**18)
+                # the -1e18 floor guarantees any out-of-bounds point scores
+                # worse than a legitimate finite likelihood; it cancels out of
+                # any Metropolis ratio between two out-of-bounds points, so the
+                # (distance-based) penalty is what still provides a restoring
+                # gradient back toward the allowed region
+                return -(10**18) - penalty
         # extract parameters
         kwargs_return = self.param.args2kwargs(args)
         return self.log_likelihood(kwargs_return, verbose=verbose)
@@ -443,21 +448,34 @@ class Likelihood(object):
 
     @staticmethod
     def check_bounds(args, lowerLimit, upperLimit, verbose=False):
-        """Checks whether the parameter vector has left its bound, if so, adds a big
-        number."""
+        """Checks whether the parameter vector has left its bounds. If so, returns a
+        penalty that grows with the (bound-range-normalized) distance past the
+        violated bound(s), summed over all violated parameters.
+
+        A flat penalty (independent of how far a parameter is out of bounds) creates
+        a plateau with no likelihood gradient, which lets samplers with proposals
+        referenced to other walkers' positions (e.g. emcee's stretch move) drift
+        arbitrarily far from the bounds once they land in that region, since every
+        out-of-bounds point looks equally "bad". Scaling the penalty with distance
+        keeps a restoring gradient pointing back toward the allowed region.
+        """
+        args = np.atleast_1d(args)
         penalty = 0.0
         bound_hit = False
-        args = np.atleast_1d(args)
         for i in range(0, len(args)):
-            if args[i] < lowerLimit[i] or args[i] > upperLimit[i]:
-                penalty = 10.0**5
+            range_i = (upperLimit[i] - lowerLimit[i]) * 1e-2
+
+            if args[i] < lowerLimit[i]:
+                penalty += ((lowerLimit[i] - args[i]) / range_i) ** 2
                 bound_hit = True
-                if verbose is True:
-                    print(
-                        "parameter %s with value %s hit the bounds [%s, %s] "
-                        % (i, args[i], lowerLimit[i], upperLimit[i])
-                    )
-                return penalty, bound_hit
+            elif args[i] > upperLimit[i]:
+                penalty += ((args[i] - upperLimit[i]) / range_i) ** 2
+                bound_hit = True
+            if bound_hit is True and verbose is True:
+                print(
+                    "parameter %s with value %s hit the bounds [%s, %s] "
+                    % (i, args[i], lowerLimit[i], upperLimit[i])
+                )
         return penalty, bound_hit
 
     @property

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -443,9 +443,10 @@ class Likelihood(object):
 
     @staticmethod
     def check_bounds(args, lowerLimit, upperLimit, verbose=False):
-        """Checks whether the parameter vector has left its bounds. If so, returns a
-        penalty that grows with the (bound-range-normalized) distance past the violated
-        bound(s), summed over all violated parameters.
+        """Checks whether the parameter vector has left its bounds.
+
+        If so, returns a penalty that grows with the (bound-range-normalized) distance
+        past the violated bound(s), summed over all violated parameters.
         """
         args = np.atleast_1d(args)
         penalty = 0.0

--- a/lenstronomy/Sampling/likelihood.py
+++ b/lenstronomy/Sampling/likelihood.py
@@ -452,12 +452,6 @@ class Likelihood(object):
         penalty that grows with the (bound-range-normalized) distance past the violated
         bound(s), summed over all violated parameters.
 
-        A flat penalty (independent of how far a parameter is out of bounds) creates a
-        plateau with no likelihood gradient, which lets samplers with proposals
-        referenced to other walkers' positions (e.g. emcee's stretch move) drift
-        arbitrarily far from the bounds once they land in that region, since every out-
-        of-bounds point looks equally "bad". Scaling the penalty with distance keeps a
-        restoring gradient pointing back toward the allowed region.
         """
         args = np.atleast_1d(args)
         penalty = 0.0


### PR DESCRIPTION
## Summary
`Likelihood.logL` returned a flat `-1e18` penalty for any out-of-bounds parameter vector, regardless of how far outside the bounds it was. Because that constant offset cancels out of the Metropolis acceptance ratio between two out-of-bounds points, walkers that land in that region see zero likelihood gradient. This can happen if a set of walkers are initiated in the MCMC that land outside the prior bounds. With `emcee`'s stretch move (multiplicative, referenced to another walker's position), this manifests as an unconstrained multiplicative random walk: a walker can drift from O(1) to O(10^100+) over a few hundred steps with 100% acceptance the entire time, which diminishes the effectiveness of the number of walkers used.

## Change
`check_bounds` now accumulates a penalty that scales with the (bound-range normalized) distance past each violated bound, summed over all violated parameters, instead of a fixed value. `logL` adds this penalty on top of the `-1e18` floor. The floor still guarantees any out-of-bounds point scores worse than a legitimate finite likelihood, but the penalty term no longer cancels between two out-of-bounds points — restoring a gradient that pulls divergent walkers back toward the allowed region.
