### PR TITLE
Pixelated source reconstruction py update

### DIFF
--- a/lenstronomy/ImSim/SourceReconstruction/pixelated_source_reconstruction.py
+++ b/lenstronomy/ImSim/SourceReconstruction/pixelated_source_reconstruction.py
@@ -217,9 +217,9 @@ class PixelatedSourceReconstruction(object):
         
         # b_i = (Ls_i)^T(d/sigma_map)
         b = np.matmul(lensed_pixel_conv_set, (image_data * inverse_variance))
-        lensed_pixel_conv_set *= np.sqrt(inverse_variance)
         
         # M_ij = (Ls_i/sqrt(sigma_map))^T(Ls_j/sqrt(sigma_map))
+        lensed_pixel_conv_set *= np.sqrt(inverse_variance)
         M = np.matmul(lensed_pixel_conv_set, lensed_pixel_conv_set.T)
 
         # Enforce exact symmetry to remove small floating-point asymmetries from matrix multiplication.

--- a/lenstronomy/ImSim/SourceReconstruction/pixelated_source_reconstruction.py
+++ b/lenstronomy/ImSim/SourceReconstruction/pixelated_source_reconstruction.py
@@ -9,33 +9,33 @@ __all__ = ["PixelatedSourceReconstruction"]
 
 class PixelatedSourceReconstruction(object):
     """This class provides methods for pixelated source-plane reconstruction in
-    gravitational lensing. It is initialized with data, PSF, lens model, and
-    source pixel grid class instances. It provides methods for generating the :math:`M` matrix
+    gravitational lensing. It is initialized with data, PSF, lens model, and source
+    pixel grid class instances. It provides methods for generating the :math:`M` matrix
     and :math:`b` vector using diagonal image noise covariance matrix specified by C_D,
-    or using the interferometric image-plane natwt covariance matrix. Their definitions follow
-    arXiv:2508.08393; see the documentation of ``generate_M_b`` for details. 
+    or using the interferometric image-plane natwt covariance matrix. Their definitions
+    follow arXiv:2508.08393; see the documentation of ``generate_M_b`` for details.
 
     We use a nested list ``lensed_sp`` to store the contribution from source pixels to
     lensed pixels through strong lensing and bilinear interpolation in the source plane.
 
     The length of ``lensed_sp`` is equal to the number of source pixels in the reconstruction.
-    And each element is 
+    And each element is
     ``lensed_sp[idx_s] = [[idx_y_lensed, idx_x_lensed, ratio_contributing], ...]``
-    where ``idx_s``, ``idx_y_lensed``, ``idx_x_lensed`` are integers. 
-    
-    Here, ``idx_s`` is the flattened (1D) index of a source pixel. 
-    Each entry ``[idx_y_lensed, idx_x_lensed, ratio_contributing]`` is a lensed-image pixel that 
-    receives a contribution from this source pixel, where ``idx_y_lensed`` and ``idx_x_lensed`` are 
+    where ``idx_s``, ``idx_y_lensed``, ``idx_x_lensed`` are integers.
+
+    Here, ``idx_s`` is the flattened (1D) index of a source pixel.
+    Each entry ``[idx_y_lensed, idx_x_lensed, ratio_contributing]`` is a lensed-image pixel that
+    receives a contribution from this source pixel, where ``idx_y_lensed`` and ``idx_x_lensed`` are
     its 2D image-plane indices and ``ratio_contributing`` is the corresponding contribution weight.
 
-    For example, if the source pixel has a value of 1.0, it contributes ``1.0 x ratio_contributing`` to the 
+    For example, if the source pixel has a value of 1.0, it contributes ``1.0 x ratio_contributing`` to the
     specified lensed pixel. A lensed pixel may receive contributions from multiple neighboring source pixels.
 
-    For the interferometric likelihood, ``ratio_contributing`` includes the effect of the primary beam, 
+    For the interferometric likelihood, ``ratio_contributing`` includes the effect of the primary beam,
     i.e., ratio_contributing = primary beam x lensing effect, if a primary beam is provided.
 
-    We also refer to each element of lensed_sp, i.e., the list ``[[idx_y_lensed, idx_x_lensed, value], ...]``, 
-    as ``a sparse image`` in the documentation below. It represents an image in which the pixel 
+    We also refer to each element of lensed_sp, i.e., the list ``[[idx_y_lensed, idx_x_lensed, value], ...]``,
+    as ``a sparse image`` in the documentation below. It represents an image in which the pixel
     at [idx_y_lensed, idx_x_lensed] has the corresponding ``value``.
     """
 
@@ -101,26 +101,27 @@ class PixelatedSourceReconstruction(object):
                     )
 
     def generate_M_b(self, kwargs_lens, verbose=False, show_progress=True):
-        """Generates the M matrix and the b vector for source reconstruction based on the selected likelihood method.
+        """Generates the M matrix and the b vector for source reconstruction based on
+        the selected likelihood method.
 
-        :math:`M` and :math:`b` are intermediate quantities used to maximize the likelihood over the source-pixel amplitudes. 
-        
+        :math:`M` and :math:`b` are intermediate quantities used to maximize the likelihood over the source-pixel amplitudes.
+
         For a pixelated source model, the source image is a linear combination of single-pixel basis images:
 
         .. math::
 
             s = \\sum_{i=1}^{N} a_i s_i,
 
-        where :math:`s_i` is the source image containing only the :math:`i`-th source pixel, :math:`a_i` is its amplitude, 
-        and :math:`N` is the total number of source pixels. 
+        where :math:`s_i` is the source image containing only the :math:`i`-th source pixel, :math:`a_i` is its amplitude,
+        and :math:`N` is the total number of source pixels.
         The chi-square is
 
         .. math::
 
             \\chi^2 = (d - BL\\sum_{i=1}^{N}a_i s_i)^T C^{-1}(d - BL\\sum_{j=1}^{N}a_j s_j),
 
-        where :math:`d` is the data, :math:`B` is a data-related linear operator such as PSF convolution, 
-        :math:`L` is the lensing operator, and :math:`C` is the noise covariance matrix. 
+        where :math:`d` is the data, :math:`B` is a data-related linear operator such as PSF convolution,
+        :math:`L` is the lensing operator, and :math:`C` is the noise covariance matrix.
         The source amplitudes :math:`a_i` that minimize :math:`\\chi^2` are obtained by solving
 
         .. math::
@@ -172,8 +173,8 @@ class PixelatedSourceReconstruction(object):
     def generate_M_b_diagonal_likelihood(
         self, kwargs_lens, verbose=False, show_progress=True
     ):
-        """Generates M and b matrices assuming spatially uncorrelated noise with
-        noise covariance specified by data_class.C_D
+        """Generates M and b matrices assuming spatially uncorrelated noise with noise
+        covariance specified by data_class.C_D.
 
         This method performs lensing, convolution, and then computes M and b.
 
@@ -186,7 +187,9 @@ class PixelatedSourceReconstruction(object):
         """
         if verbose:
             print("Step 1: Lensing the source pixels")
-        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(kwargs_lens)
+        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(
+            kwargs_lens
+        )
         if verbose:
             print("Step 1: Finished!")
 
@@ -214,10 +217,10 @@ class PixelatedSourceReconstruction(object):
         lensed_pixel_conv_set = lensed_pixel_conv_set.reshape(N_lensed, -1)
         image_data = self._image_data.ravel()
         inverse_variance = 1.0 / self._C_D.ravel()
-        
+
         # b_i = (Ls_i)^T(d/sigma_map)
         b = np.matmul(lensed_pixel_conv_set, (image_data * inverse_variance))
-        
+
         # M_ij = (Ls_i/sqrt(sigma_map))^T(Ls_j/sqrt(sigma_map))
         lensed_pixel_conv_set *= np.sqrt(inverse_variance)
         M = np.matmul(lensed_pixel_conv_set, lensed_pixel_conv_set.T)
@@ -245,14 +248,16 @@ class PixelatedSourceReconstruction(object):
         """
         if verbose:
             print("Step 1: Lensing the source pixels")
-        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(kwargs_lens)
+        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(
+            kwargs_lens
+        )
         if verbose:
             print("Step 1: Finished!")
 
         if verbose:
             print(
                 "Step 2: Compute the matrix M and vector b (including the convolution step)"
-        )
+            )
         N_lensed = lensing_matrix.shape[1]
         lensing_matrix_transpose = lensing_matrix.T.tocsr(copy=False)
         M = np.zeros((N_lensed, N_lensed))
@@ -287,9 +292,9 @@ class PixelatedSourceReconstruction(object):
         source grid, considering lensing deflections and applying bilinear
         interpolation.
 
-        This method computes the contribution of each source pixel to each lensed image pixel. 
-        These contributions form a matrix with shape ``(num_lensed_image_pixels, num_source_pixels)``. 
-        Because most of its elements are zero, the matrix is stored as a :class:`scipy.sparse.csc_matrix`. 
+        This method computes the contribution of each source pixel to each lensed image pixel.
+        These contributions form a matrix with shape ``(num_lensed_image_pixels, num_source_pixels)``.
+        Because most of its elements are zero, the matrix is stored as a :class:`scipy.sparse.csc_matrix`.
         This function is called directly by the ``generate_M_b`` methods to compute :math:`M` and :math:`b`.
 
         :param kwargs_lens: List of keyword arguments for the lens_model_class.
@@ -367,11 +372,11 @@ class PixelatedSourceReconstruction(object):
         source_indices = np.concatenate(source_index_parts)
         weights = np.concatenate(weight_parts)
 
-        #Construct a CSC matrix from image_indices, source_indices, and weights, with data = weights.
-        #The CSC matrix has num_lensed_image_pixels rows, so its indices correspond to image_indices.
-        #The CSC matrix has num_source_pixels columns, so indptr[1:] is the cumulative sum of elements of source_indices.
-        #image_indices, source_indices, and weights should first be sorted in increasing order of source_indices.   
-        
+        # Construct a CSC matrix from image_indices, source_indices, and weights, with data = weights.
+        # The CSC matrix has num_lensed_image_pixels rows, so its indices correspond to image_indices.
+        # The CSC matrix has num_source_pixels columns, so indptr[1:] is the cumulative sum of elements of source_indices.
+        # image_indices, source_indices, and weights should first be sorted in increasing order of source_indices.
+
         order = np.lexsort((image_indices, source_indices))
         image_indices = image_indices[order]
         source_indices = source_indices[order]
@@ -401,28 +406,33 @@ class PixelatedSourceReconstruction(object):
             contributes with `ratio_contributing` to the image plane pixel at `[idx_y_lensed, idx_x_lensed]` when lensed.
         :rtype: list
         """
-        lensing_matrix = (
-            self._lens_pixel_source_of_a_rectangular_region_csc_matrix(kwargs_lens)
+        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(
+            kwargs_lens
         )
         return self._csc_matrix_to_lensed_sp(lensing_matrix)
 
     def _csc_matrix_to_lensed_sp(self, csc):
         """Converts a CSC lensing matrix to the lensed_sp.
 
-        :param csc: The CSC matrix with shape = (num_lensed_image_pixels, num_source_pixels).
-        :returns: A nested list containing the image pixel indices and contributions from each
-            source pixel.
+        :param csc: The CSC matrix with shape = (num_lensed_image_pixels,
+            num_source_pixels).
+        :returns: A nested list containing the image pixel indices and contributions
+            from each source pixel.
         :rtype: list
         """
-        
+
         if not isspmatrix_csc(csc):
             raise TypeError("csc must be a scipy.sparse.csc_matrix.")
 
         num_lensed_pixels, num_source_pixels = csc.shape
         if num_lensed_pixels != self._num_pix**2:
-            raise ValueError("The number of rows in the CSC matrix should be equal to the number of lensed image pixels.")
+            raise ValueError(
+                "The number of rows in the CSC matrix should be equal to the number of lensed image pixels."
+            )
         if num_source_pixels != self._num_pixel_source:
-            raise ValueError("The number of columns in the CSC matrix should be equal to the number of source pixels.")
+            raise ValueError(
+                "The number of columns in the CSC matrix should be equal to the number of source pixels."
+            )
 
         if not csc.has_sorted_indices:
             csc = csc.copy()
@@ -436,16 +446,16 @@ class PixelatedSourceReconstruction(object):
             ]
             for source in range(csc.shape[1])
         ]
-        
+
     def lens_an_image_by_rayshooting(self, kwargs_lens, source_image):
-        """Lenses a pixelated source image to the image plane using ray-shooting
-        and bilinear interpolation. The input image should have the same dimension and
+        """Lenses a pixelated source image to the image plane using ray-shooting and
+        bilinear interpolation. The input image should have the same dimension and
         coordinates defined by source_pixel_grid_class.
 
-        This method works by ray-shooting image plane pixels back to the source plane to 
+        This method works by ray-shooting image plane pixels back to the source plane to
         find the corresponding source coordinate, and then interpolating the flux from the input
-        source image at that coordinate. 
-        
+        source image at that coordinate.
+
         Note that the primary beam will NOT be applied on the lensed image for interferometric data.
 
         :param kwargs_lens: List of keyword arguments for the lens_model_class.
@@ -482,10 +492,7 @@ class PixelatedSourceReconstruction(object):
         # If the ray shoots the image pixel outside the defined source image boundaries, valid = False
         # valid = True means the image pixels are rayshot back to the source plane within the source image region
         valid = (
-            (n_x >= 0)
-            & (n_x < self._nx_source)
-            & (n_y >= 0)
-            & (n_y < self._ny_source)
+            (n_x >= 0) & (n_x < self._nx_source) & (n_y >= 0) & (n_y < self._ny_source)
         )
 
         lensed_image = np.zeros(self._num_pix**2)
@@ -521,9 +528,7 @@ class PixelatedSourceReconstruction(object):
                 - beta_y_valid
             )
             * np.abs(
-                self._source_min_x
-                + n_x_valid * self._pixel_width_source
-                - beta_x_valid
+                self._source_min_x + n_x_valid * self._pixel_width_source - beta_x_valid
             )
             / (self._pixel_width_source**2)
         )
@@ -535,22 +540,16 @@ class PixelatedSourceReconstruction(object):
                 - beta_x_valid
             )
             * np.abs(
-                self._source_min_y
-                + n_y_valid * self._pixel_width_source
-                - beta_y_valid
+                self._source_min_y + n_y_valid * self._pixel_width_source - beta_y_valid
             )
             / (self._pixel_width_source**2)
         )
         weight_lower_right = (
             np.abs(
-                self._source_min_x
-                + n_x_valid * self._pixel_width_source
-                - beta_x_valid
+                self._source_min_x + n_x_valid * self._pixel_width_source - beta_x_valid
             )
             * np.abs(
-                self._source_min_y
-                + n_y_valid * self._pixel_width_source
-                - beta_y_valid
+                self._source_min_y + n_y_valid * self._pixel_width_source - beta_y_valid
             )
             / (self._pixel_width_source**2)
         )
@@ -590,8 +589,8 @@ class PixelatedSourceReconstruction(object):
         return lensed_image
 
     def sparse_to_array(self, sparse):
-        """Converts a sparse image representation (list of `[idx_y, idx_x, value]`) 
-        to a 2D NumPy array.
+        """Converts a sparse image representation (list of `[idx_y, idx_x, value]`) to a
+        2D NumPy array.
 
         :param sparse: A list representing non-zero elements of the sparse image.
         :returns: A 2D NumPy array representing the full image.
@@ -673,10 +672,9 @@ class PixelatedSourceReconstruction(object):
             return np.zeros((self._num_pix, self._num_pix))
 
         sparse_array = np.asarray(sp)
-        indices = (
-            sparse_array[:, 0].astype(np.intp) * self._num_pix
-            + sparse_array[:, 1].astype(np.intp)
-        )
+        indices = sparse_array[:, 0].astype(np.intp) * self._num_pix + sparse_array[
+            :, 1
+        ].astype(np.intp)
         return self._sparse_convolution_from_image_indices(
             indices, sparse_array[:, 2], kernel
         )
@@ -703,13 +701,9 @@ class PixelatedSourceReconstruction(object):
 
             # Calculate slice indices for the kernel relative to the sparse element
             slice_y_start = max(kernel_center - y_sp, 0)
-            slice_y_end = min(
-                kernel_center - y_sp + self._num_pix, kernel.shape[0]
-            )
+            slice_y_end = min(kernel_center - y_sp + self._num_pix, kernel.shape[0])
             slice_x_start = max(kernel_center - x_sp, 0)
-            slice_x_end = min(
-                kernel_center - x_sp + self._num_pix, kernel.shape[1]
-            )
+            slice_x_end = min(kernel_center - x_sp + self._num_pix, kernel.shape[1])
 
             convolved_image_y_start = y_sp - min(y_sp, kernel_center)
             convolved_image_y_end = y_sp + min(

--- a/lenstronomy/ImSim/SourceReconstruction/pixelated_source_reconstruction.py
+++ b/lenstronomy/ImSim/SourceReconstruction/pixelated_source_reconstruction.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.sparse import csc_matrix, isspmatrix_csc
 from tqdm import tqdm
 
 import lenstronomy.Util.util as util
@@ -7,15 +8,35 @@ __all__ = ["PixelatedSourceReconstruction"]
 
 
 class PixelatedSourceReconstruction(object):
-    """This class defines useful functions for pixelated source plane reconstruction in
-    gravitational lensing. It handles initialization of data, lens model, and PSF
-    kernel, and provides methods for generating the M and b matrices (definition see
-    'placeholder for Nan Zhang's paper) for source reconstruction based on different
-    likelihood methods.
+    """This class provides methods for pixelated source-plane reconstruction in
+    gravitational lensing. It is initialized with data, PSF, lens model, and
+    source pixel grid class instances. It provides methods for generating the :math:`M` matrix
+    and :math:`b` vector using diagonal image noise covariance matrix specified by C_D,
+    or using the interferometric image-plane natwt covariance matrix. Their definitions follow
+    arXiv:2508.08393; see the documentation of ``generate_M_b`` for details. 
 
-    All sparse matrices (sp) in this class are represented as a list of lists:
-    [[y_coord, x_coord, pixel_value], ...], where [y_coord, x_coord] are
-    the pixel coordinates and pixel_value is the corresponding pixel's value.
+    We use a nested list ``lensed_sp`` to store the contribution from source pixels to
+    lensed pixels through strong lensing and bilinear interpolation in the source plane.
+
+    The length of ``lensed_sp`` is equal to the number of source pixels in the reconstruction.
+    And each element is 
+    ``lensed_sp[idx_s] = [[idx_y_lensed, idx_x_lensed, ratio_contributing], ...]``
+    where ``idx_s``, ``idx_y_lensed``, ``idx_x_lensed`` are integers. 
+    
+    Here, ``idx_s`` is the flattened (1D) index of a source pixel. 
+    Each entry ``[idx_y_lensed, idx_x_lensed, ratio_contributing]`` is a lensed-image pixel that 
+    receives a contribution from this source pixel, where ``idx_y_lensed`` and ``idx_x_lensed`` are 
+    its 2D image-plane indices and ``ratio_contributing`` is the corresponding contribution weight.
+
+    For example, if the source pixel has a value of 1.0, it contributes ``1.0 x ratio_contributing`` to the 
+    specified lensed pixel. A lensed pixel may receive contributions from multiple neighboring source pixels.
+
+    For the interferometric likelihood, ``ratio_contributing`` includes the effect of the primary beam, 
+    i.e., ratio_contributing = primary beam x lensing effect, if a primary beam is provided.
+
+    We also refer to each element of lensed_sp, i.e., the list ``[[idx_y_lensed, idx_x_lensed, value], ...]``, 
+    as ``a sparse image`` in the documentation below. It represents an image in which the pixel 
+    at [idx_y_lensed, idx_x_lensed] has the corresponding ``value``.
     """
 
     def __init__(
@@ -80,9 +101,43 @@ class PixelatedSourceReconstruction(object):
                     )
 
     def generate_M_b(self, kwargs_lens, verbose=False, show_progress=True):
-        """Generates the M matrix and the b vector for source reconstruction based on
-        the selected likelihood method. Definitions of the M and b is given by
-        (placeholder for Nan Zhang's paper).
+        """Generates the M matrix and the b vector for source reconstruction based on the selected likelihood method.
+
+        :math:`M` and :math:`b` are intermediate quantities used to maximize the likelihood over the source-pixel amplitudes. 
+        
+        For a pixelated source model, the source image is a linear combination of single-pixel basis images:
+
+        .. math::
+
+            s = \\sum_{i=1}^{N} a_i s_i,
+
+        where :math:`s_i` is the source image containing only the :math:`i`-th source pixel, :math:`a_i` is its amplitude, 
+        and :math:`N` is the total number of source pixels. 
+        The chi-square is
+
+        .. math::
+
+            \\chi^2 = (d - BL\\sum_{i=1}^{N}a_i s_i)^T C^{-1}(d - BL\\sum_{j=1}^{N}a_j s_j),
+
+        where :math:`d` is the data, :math:`B` is a data-related linear operator such as PSF convolution, 
+        :math:`L` is the lensing operator, and :math:`C` is the noise covariance matrix. 
+        The source amplitudes :math:`a_i` that minimize :math:`\\chi^2` are obtained by solving
+
+        .. math::
+
+            Ma = b,
+
+        where
+
+        .. math::
+
+            M_{ij} = (BLs_i)^T C^{-1}(BLs_j)
+
+        and
+
+        .. math::
+
+            b_i = d^T C^{-1}(BLs_i).
 
         :param kwargs_lens: List of keyword arguments for the lens_model_class.
         :param verbose: If True, print progress messages during matrix generation steps.
@@ -117,8 +172,8 @@ class PixelatedSourceReconstruction(object):
     def generate_M_b_diagonal_likelihood(
         self, kwargs_lens, verbose=False, show_progress=True
     ):
-        """Generates M and b matrices assuming spatially uncorrelated noise with uniform
-        RMS across the image. This approach is typically used for CCD image data.
+        """Generates M and b matrices assuming spatially uncorrelated noise with
+        noise covariance specified by data_class.C_D
 
         This method performs lensing, convolution, and then computes M and b.
 
@@ -131,38 +186,45 @@ class PixelatedSourceReconstruction(object):
         """
         if verbose:
             print("Step 1: Lensing the source pixels")
-        lensed_sp = self.lens_pixel_source_of_a_rectangular_region(kwargs_lens)
+        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(kwargs_lens)
         if verbose:
             print("Step 1: Finished!")
 
         if verbose:
             print("Step 2: Convolve the lensed pixels")
-        N_lensed = len(lensed_sp)
+        N_lensed = lensing_matrix.shape[1]
         lensed_pixel_conv_set = np.zeros((N_lensed, self._num_pix, self._num_pix))
-        for i in range(N_lensed):
-            lensed_pixel_conv_set[i] = self.sparse_convolution(
-                lensed_sp[i], self._kernel
+        for i in tqdm(
+            range(N_lensed),
+            desc="Running (Convolving lensed pixels)",
+            disable=not show_progress,
+        ):
+            start = lensing_matrix.indptr[i]
+            end = lensing_matrix.indptr[i + 1]
+            lensed_pixel_conv_set[i] = self._sparse_convolution_from_image_indices(
+                lensing_matrix.indices[start:end],
+                lensing_matrix.data[start:end],
+                self._kernel,
             )
         if verbose:
             print("Step 2: Finished!")
 
         if verbose:
             print("Step 3: Compute the matrix M and vector b")
-        M = np.zeros((N_lensed, N_lensed))
-        b = np.zeros((N_lensed))
-        for i in tqdm(
-            range(N_lensed),
-            desc="Running (iteration times vary)",
-            disable=not show_progress,
-        ):
-            b[i] = np.sum(lensed_pixel_conv_set[i] * self._image_data / self._C_D)
-            for j in range(N_lensed):
-                if j < i:
-                    M[i, j] = M[j, i]  # Exploit symmetry
-                else:
-                    M[i, j] = np.sum(
-                        lensed_pixel_conv_set[i] * lensed_pixel_conv_set[j] / self._C_D
-                    )
+        lensed_pixel_conv_set = lensed_pixel_conv_set.reshape(N_lensed, -1)
+        image_data = self._image_data.ravel()
+        inverse_variance = 1.0 / self._C_D.ravel()
+        
+        # b_i = (Ls_i)^T(d/sigma_map)
+        b = np.matmul(lensed_pixel_conv_set, (image_data * inverse_variance))
+        lensed_pixel_conv_set *= np.sqrt(inverse_variance)
+        
+        # M_ij = (Ls_i/sqrt(sigma_map))^T(Ls_j/sqrt(sigma_map))
+        M = np.matmul(lensed_pixel_conv_set, lensed_pixel_conv_set.T)
+
+        # Enforce exact symmetry to remove small floating-point asymmetries from matrix multiplication.
+        for i in range(1, N_lensed):
+            M[i, :i] = M[:i, i]
         if verbose:
             print("Step 3: Finished!")
 
@@ -174,9 +236,6 @@ class PixelatedSourceReconstruction(object):
         """Generates the M and b matrices for interferometric data with natural
         weighting.
 
-        This method integrates the convolution step implicitly via specialized sparse
-        product functions.
-
         :param kwargs_lens: List of keyword arguments for the lens_model_class.
         :param verbose: If True, print progress messages during matrix generation steps.
             Defaults to False.
@@ -186,33 +245,36 @@ class PixelatedSourceReconstruction(object):
         """
         if verbose:
             print("Step 1: Lensing the source pixels")
-        lensed_sp = self.lens_pixel_source_of_a_rectangular_region(kwargs_lens)
+        lensing_matrix = self._lens_pixel_source_of_a_rectangular_region_csc_matrix(kwargs_lens)
         if verbose:
             print("Step 1: Finished!")
 
         if verbose:
             print(
                 "Step 2: Compute the matrix M and vector b (including the convolution step)"
-            )
-        N_lensed = len(lensed_sp)
+        )
+        N_lensed = lensing_matrix.shape[1]
+        lensing_matrix_transpose = lensing_matrix.T.tocsr(copy=False)
         M = np.zeros((N_lensed, N_lensed))
-        b = np.zeros((N_lensed))
+        b = lensing_matrix_transpose @ self._image_data.ravel()
         for i in tqdm(
             range(N_lensed),
             desc="Running (iteration times vary)",
             disable=not show_progress,
         ):
-            b[i] = self.sum_sparse_elementwise_product(lensed_sp[i], self._image_data)
-            pixel_lensed_convolved = self.sparse_convolution(
-                lensed_sp[i], self._kernel
-            )  # convolution
-            for j in range(N_lensed):
-                if j < i:
-                    M[i, j] = M[j, i]  # Exploit symmetry
-                else:
-                    M[i, j] = self.sum_sparse_elementwise_product(
-                        lensed_sp[j], pixel_lensed_convolved
-                    )
+            start = lensing_matrix.indptr[i]
+            end = lensing_matrix.indptr[i + 1]
+            pixel_lensed_convolved = self._sparse_convolution_from_image_indices(
+                lensing_matrix.indices[start:end],
+                lensing_matrix.data[start:end],
+                self._kernel,
+            ).ravel()
+            products = lensing_matrix_transpose @ pixel_lensed_convolved
+            M[i, i:] = products[i:]
+
+        # Exploit symmetry
+        for i in range(1, N_lensed):
+            M[i, :i] = M[:i, i]
         b /= self._noise_rms**2
         M /= self._noise_rms**2
         if verbose:
@@ -220,21 +282,20 @@ class PixelatedSourceReconstruction(object):
 
         return M, b
 
-    def lens_pixel_source_of_a_rectangular_region(self, kwargs_lens):
+    def _lens_pixel_source_of_a_rectangular_region_csc_matrix(self, kwargs_lens):
         """Maps image plane pixels to source plane pixels within a specified rectangular
         source grid, considering lensing deflections and applying bilinear
         interpolation.
 
+        This method computes the contribution of each source pixel to each lensed image pixel. 
+        These contributions form a matrix with shape ``(num_lensed_image_pixels, num_source_pixels)``. 
+        Because most of its elements are zero, the matrix is stored as a :class:`scipy.sparse.csc_matrix`. 
+        This function is called directly by the ``generate_M_b`` methods to compute :math:`M` and :math:`b`.
+
         :param kwargs_lens: List of keyword arguments for the lens_model_class.
-        :returns: A list of lists. Each element in the outer list corresponds to a single source pixel
-            within the defined source grid (ordered by their linear index). Each inner list contains
-            `[y_coord, x_coord, weight]` tuples, indicating that the source pixel at this index
-            contributes with `weight` to the image plane pixel at `(y_coord, x_coord)` when lensed.
-        :rtype: list
+        :returns: A CSC sparse matrix with shape = (num_lensed_image_pixels, num_source_pixels).
+        :rtype: scipy.sparse.csc_matrix
         """
-
-        lensed_pixel_sp = [[] for _ in range(self._num_pixel_source)]
-
         beta_x_grid_2d, beta_y_grid_2d = self._lens_model_class.ray_shooting(
             self._x_grid_data, self._y_grid_data, kwargs=kwargs_lens
         )
@@ -276,62 +337,116 @@ class PixelatedSourceReconstruction(object):
             w01 *= self._primary_beam
             w11 *= self._primary_beam
 
-        for i in range(self._num_pix):
-            for j in range(self._num_pix):
-                # Skip if the lensed image pixel falls entirely outside the source region
-                if (
-                    x_ceiling[i][j] < 0
-                    or x_floor[i][j] > (self._nx_source - 1)
-                    or y_ceiling[i][j] < 0
-                    or y_floor[i][j] > (self._ny_source - 1)
-                ):
-                    continue
+        image_indices = np.arange(self._num_pix**2)
+        image_index_parts = []
+        source_index_parts = []
+        weight_parts = []
 
-                # Calculate linear indices of the four potential source pixels
-                source_pixel_index00 = self._nx_source * (y_floor[i][j]) + x_floor[i][j]
-                source_pixel_index10 = source_pixel_index00 + 1
-                source_pixel_index01 = source_pixel_index00 + self._nx_source
-                source_pixel_index11 = source_pixel_index01 + 1
+        for source_x, source_y, weights in (
+            (x_floor, y_floor, w00),
+            (x_ceiling, y_floor, w10),
+            (x_floor, y_ceiling, w01),
+            (x_ceiling, y_ceiling, w11),
+        ):
+            source_x = source_x.ravel()
+            source_y = source_y.ravel()
+            weights = weights.ravel()
+            valid = (
+                (source_x >= 0)
+                & (source_x < self._nx_source)
+                & (source_y >= 0)
+                & (source_y < self._ny_source)
+            )
+            image_index_parts.append(image_indices[valid])
+            source_index_parts.append(
+                source_y[valid] * self._nx_source + source_x[valid]
+            )
+            weight_parts.append(weights[valid])
 
-                # Flags for boundary checking
-                check00, check01, check10, check11 = True, True, True, True
+        image_indices = np.concatenate(image_index_parts)
+        source_indices = np.concatenate(source_index_parts)
+        weights = np.concatenate(weight_parts)
 
-                # Adjust flags for contributions near the boundary
-                if x_floor[i][j] == -1:
-                    check00 = False
-                    check01 = False
-                elif x_ceiling[i][j] == self._nx_source:
-                    check10 = False
-                    check11 = False
+        #Construct a CSC matrix from image_indices, source_indices, and weights, with data = weights.
+        #The CSC matrix has num_lensed_image_pixels rows, so its indices correspond to image_indices.
+        #The CSC matrix has num_source_pixels columns, so indptr[1:] is the cumulative sum of elements of source_indices.
+        #image_indices, source_indices, and weights should first be sorted in increasing order of source_indices.   
+        
+        order = np.lexsort((image_indices, source_indices))
+        image_indices = image_indices[order]
+        source_indices = source_indices[order]
+        weights = weights[order]
 
-                if y_floor[i][j] == -1:
-                    check00 = False
-                    check10 = False
-                elif y_ceiling[i][j] == self._ny_source:
-                    check11 = False
-                    check01 = False
+        indptr = np.empty(self._num_pixel_source + 1, dtype=np.int64)
+        indptr[0] = 0
+        np.cumsum(
+            np.bincount(source_indices, minlength=self._num_pixel_source),
+            out=indptr[1:],
+        )
 
-                # Append the contribution of each source pixel to the image pixel (i,j) with weight.
-                if check00:
-                    lensed_pixel_sp[source_pixel_index00].append([i, j, w00[i][j]])
-                if check10:
-                    lensed_pixel_sp[source_pixel_index10].append([i, j, w10[i][j]])
-                if check01:
-                    lensed_pixel_sp[source_pixel_index01].append([i, j, w01[i][j]])
-                if check11:
-                    lensed_pixel_sp[source_pixel_index11].append([i, j, w11[i][j]])
-        return lensed_pixel_sp
+        return csc_matrix(
+            (weights, image_indices, indptr),
+            shape=(self._num_pix**2, self._num_pixel_source),
+            copy=False,
+        )
 
+    def lens_pixel_source_of_a_rectangular_region(self, kwargs_lens):
+        """Maps image plane pixels to source plane pixels within a specified rectangular
+        source grid.
+
+        :param kwargs_lens: List of keyword arguments for the lens_model_class.
+        :returns: A nested list. Each element in the outer list corresponds to a single source pixel
+            within the defined source grid (ordered by their flatten 1D index). Each inner list contains
+            elements `[idx_y_lensed, idx_x_lensed, ratio_contributing]`, indicating that the source pixel at this index
+            contributes with `ratio_contributing` to the image plane pixel at `[idx_y_lensed, idx_x_lensed]` when lensed.
+        :rtype: list
+        """
+        lensing_matrix = (
+            self._lens_pixel_source_of_a_rectangular_region_csc_matrix(kwargs_lens)
+        )
+        return self._csc_matrix_to_lensed_sp(lensing_matrix)
+
+    def _csc_matrix_to_lensed_sp(self, csc):
+        """Converts a CSC lensing matrix to the lensed_sp.
+
+        :param csc: The CSC matrix with shape = (num_lensed_image_pixels, num_source_pixels).
+        :returns: A nested list containing the image pixel indices and contributions from each
+            source pixel.
+        :rtype: list
+        """
+        
+        if not isspmatrix_csc(csc):
+            raise TypeError("csc must be a scipy.sparse.csc_matrix.")
+
+        num_lensed_pixels, num_source_pixels = csc.shape
+        if num_lensed_pixels != self._num_pix**2:
+            raise ValueError("The number of rows in the CSC matrix should be equal to the number of lensed image pixels.")
+        if num_source_pixels != self._num_pixel_source:
+            raise ValueError("The number of columns in the CSC matrix should be equal to the number of source pixels.")
+
+        if not csc.has_sorted_indices:
+            csc = csc.copy()
+            csc.sort_indices()
+
+        image_y, image_x = np.divmod(csc.indices, self._num_pix)
+        return [
+            [
+                [int(image_y[index]), int(image_x[index]), csc.data[index]]
+                for index in range(csc.indptr[source], csc.indptr[source + 1])
+            ]
+            for source in range(csc.shape[1])
+        ]
+        
     def lens_an_image_by_rayshooting(self, kwargs_lens, source_image):
-        """Lenses a pixelated source plane image to the image plane using ray-shooting
-        and bilinear interpolation. The imput image should have the same dimension and
+        """Lenses a pixelated source image to the image plane using ray-shooting
+        and bilinear interpolation. The input image should have the same dimension and
         coordinates defined by source_pixel_grid_class.
 
-        This method works by iterating through each pixel in the image plane, ray-shooting back to the source
-        plane to find the corresponding source coordinate, and then interpolating the flux from the input
-        source image at that coordinate. This provides an approximate lensed image, as flux between exact
-        source pixels is derived via interpolation. Note that the primary beam will NOT be applied on the
-        lensed image in this function.
+        This method works by ray-shooting image plane pixels back to the source plane to 
+        find the corresponding source coordinate, and then interpolating the flux from the input
+        source image at that coordinate. 
+        
+        Note that the primary beam will NOT be applied on the lensed image for interferometric data.
 
         :param kwargs_lens: List of keyword arguments for the lens_model_class.
         :param image: 2D NumPy array representing the pixelated source plane image. Expected to have
@@ -339,7 +454,7 @@ class PixelatedSourceReconstruction(object):
         :type image: numpy.ndarray
         :returns: 2D NumPy array representing the lensed image in the image plane.
         :rtype: numpy.ndarray
-        :raises ValueError: If the input `image` dimensions do not match the dimensions of the
+        :raises ValueError: If the input `source_image` dimensions do not match the dimensions of the
                             defined source pixel grid (`self._ny_source`, `self._nx_source`).
         """
 
@@ -350,127 +465,124 @@ class PixelatedSourceReconstruction(object):
                 f"source grid class dimension ({self._ny_source}, {self._nx_source})."
             )
 
-        lensed_image = np.zeros((self._num_pix, self._num_pix))
-
         beta_x_grid_2d, beta_y_grid_2d = self._lens_model_class.ray_shooting(
             self._x_grid_data, self._y_grid_data, kwargs=kwargs_lens
         )
         beta_x_grid = util.image2array(beta_x_grid_2d)
         beta_y_grid = util.image2array(beta_y_grid_2d)
 
-        # Iterate through each pixel in the image plane (i, j)
-        for i in range(self._num_pix):
-            for j in range(self._num_pix):
-                # Calculate the linear index for accessing pre-computed ray-shot coordinates
-                n_beta = (
-                    i * self._num_pix + j
-                )  # Assuming beta_x_grid and beta_y_grid are flattened row-major
+        # Compute the floor indices of the ray-shot image pixels in the source plane.
+        n_x = np.floor(
+            (beta_x_grid - self._source_min_x) / self._pixel_width_source
+        ).astype(int)
+        n_y = np.floor(
+            (beta_y_grid - self._source_min_y) / self._pixel_width_source
+        ).astype(int)
 
-                # Get the source plane angular coordinates (beta_x, beta_y) corresponding
-                # to the current image plane pixel (i,j) after ray-shooting.
-                cor_beta_x = beta_x_grid[n_beta]
-                cor_beta_y = beta_y_grid[n_beta]
+        # If the ray shoots the image pixel outside the defined source image boundaries, valid = False
+        # valid = True means the image pixels are rayshot back to the source plane within the source image region
+        valid = (
+            (n_x >= 0)
+            & (n_x < self._nx_source)
+            & (n_y >= 0)
+            & (n_y < self._ny_source)
+        )
 
-                # Convert source plane angular coordinates to integer pixel indices (n_y, n_x)
-                # within the source grid, relative to self._minx, self._miny.
-                n_x = np.floor(
-                    (cor_beta_x - self._source_min_x) / self._pixel_width_source
-                ).astype(int)
-                n_y = np.floor(
-                    (cor_beta_y - self._source_min_y) / self._pixel_width_source
-                ).astype(int)
+        lensed_image = np.zeros(self._num_pix**2)
+        n_x_valid = n_x[valid]
+        n_y_valid = n_y[valid]
+        beta_x_valid = beta_x_grid[valid]
+        beta_y_valid = beta_y_grid[valid]
 
-                # If the ray shoots outside the defined source image boundaries, set flux to zero
-                if (
-                    n_x > self._nx_source - 1
-                    or n_y > self._ny_source - 1
-                    or n_x < 0
-                    or n_y < 0
-                ):
-                    lensed_image[i, j] = 0
-                else:
-                    # Calculate bilinear interpolation weights for the four surrounding source pixels.
-                    # These weights depend on the sub-pixel position of (cor_beta_y, cor_beta_x)
-                    # within the source pixel (n_y, n_x).
-                    weight_upper_left = (
-                        np.abs(
-                            self._source_min_y
-                            + n_y * self._pixel_width_source
-                            + self._pixel_width_source
-                            - cor_beta_y
-                        )
-                        * (
-                            np.abs(
-                                self._source_min_x
-                                + n_x * self._pixel_width_source
-                                + self._pixel_width_source
-                                - cor_beta_x
-                            )
-                        )
-                        / (self._pixel_width_source**2)
-                    )
-                    weight_upper_right = (
-                        np.abs(
-                            self._source_min_y
-                            + n_y * self._pixel_width_source
-                            + self._pixel_width_source
-                            - cor_beta_y
-                        )
-                        * (
-                            np.abs(
-                                self._source_min_x
-                                + n_x * self._pixel_width_source
-                                - cor_beta_x
-                            )
-                        )
-                        / (self._pixel_width_source**2)
-                    )
-                    weight_lower_left = (
-                        np.abs(
-                            self._source_min_x
-                            + n_x * self._pixel_width_source
-                            + self._pixel_width_source
-                            - cor_beta_x
-                        )
-                        * (
-                            np.abs(
-                                self._source_min_y
-                                + n_y * self._pixel_width_source
-                                - cor_beta_y
-                            )
-                        )
-                        / (self._pixel_width_source**2)
-                    )
-                    weight_lower_right = (
-                        np.abs(
-                            self._source_min_x
-                            + n_x * self._pixel_width_source
-                            - cor_beta_x
-                        )
-                        * (
-                            np.abs(
-                                self._source_min_y
-                                + n_y * self._pixel_width_source
-                                - cor_beta_y
-                            )
-                        )
-                        / (self._pixel_width_source**2)
-                    )
+        # Calculate bilinear interpolation weights for the four surrounding source pixels, for valid image pixels
+        # These weights depend on the sub-pixel position of (beta_y_valid, beta_x_valid)
+        # within the source pixel (n_y_valid, n_x_valid).
 
-                    # Interpolate flux from the source image using the calculated weights
-                    lensed_image[i, j] = source_image[n_y, n_x] * weight_upper_left
-                    if n_x + 1 < self._nx_source:
-                        lensed_image[i, j] += (
-                            source_image[n_y, n_x + 1] * weight_upper_right
-                        )
-                    if n_y + 1 < self._ny_source:
-                        lensed_image[i, j] += (
-                            source_image[n_y + 1, n_x] * weight_lower_left
-                        )
-                        if n_x + 1 < self._nx_source:
-                            lensed_image[i, j] += (
-                                source_image[n_y + 1, n_x + 1] * weight_lower_right
-                            )
+        weight_upper_left = (
+            np.abs(
+                self._source_min_y
+                + n_y_valid * self._pixel_width_source
+                + self._pixel_width_source
+                - beta_y_valid
+            )
+            * np.abs(
+                self._source_min_x
+                + n_x_valid * self._pixel_width_source
+                + self._pixel_width_source
+                - beta_x_valid
+            )
+            / (self._pixel_width_source**2)
+        )
+        weight_upper_right = (
+            np.abs(
+                self._source_min_y
+                + n_y_valid * self._pixel_width_source
+                + self._pixel_width_source
+                - beta_y_valid
+            )
+            * np.abs(
+                self._source_min_x
+                + n_x_valid * self._pixel_width_source
+                - beta_x_valid
+            )
+            / (self._pixel_width_source**2)
+        )
+        weight_lower_left = (
+            np.abs(
+                self._source_min_x
+                + n_x_valid * self._pixel_width_source
+                + self._pixel_width_source
+                - beta_x_valid
+            )
+            * np.abs(
+                self._source_min_y
+                + n_y_valid * self._pixel_width_source
+                - beta_y_valid
+            )
+            / (self._pixel_width_source**2)
+        )
+        weight_lower_right = (
+            np.abs(
+                self._source_min_x
+                + n_x_valid * self._pixel_width_source
+                - beta_x_valid
+            )
+            * np.abs(
+                self._source_min_y
+                + n_y_valid * self._pixel_width_source
+                - beta_y_valid
+            )
+            / (self._pixel_width_source**2)
+        )
+
+        # Interpolate flux from the source image using the calculated weights for valid image pixels
+        valid_values = source_image[n_y_valid, n_x_valid] * weight_upper_left
+
+        # For all valid image pixels
+        # "valid_upper_right = True" means the right neighbor source pixel is also in the source region
+        valid_upper_right = n_x_valid + 1 < self._nx_source
+        valid_values[valid_upper_right] += (
+            source_image[n_y_valid[valid_upper_right], n_x_valid[valid_upper_right] + 1]
+            * weight_upper_right[valid_upper_right]
+        )
+
+        valid_lower_left = n_y_valid + 1 < self._ny_source
+        valid_values[valid_lower_left] += (
+            source_image[n_y_valid[valid_lower_left] + 1, n_x_valid[valid_lower_left]]
+            * weight_lower_left[valid_lower_left]
+        )
+
+        valid_lower_right = valid_upper_right & valid_lower_left
+        valid_values[valid_lower_right] += (
+            source_image[
+                n_y_valid[valid_lower_right] + 1,
+                n_x_valid[valid_lower_right] + 1,
+            ]
+            * weight_lower_right[valid_lower_right]
+        )
+
+        lensed_image[valid] = valid_values
+        lensed_image = lensed_image.reshape(self._num_pix, self._num_pix)
 
         # Apply the ratio (data image pixel area / source grid pixel area) to ensure the flux conservation
         lensed_image *= self._ratio_data_pixel_source_pixel
@@ -478,8 +590,8 @@ class PixelatedSourceReconstruction(object):
         return lensed_image
 
     def sparse_to_array(self, sparse):
-        """Converts a sparse image representation (list of `[y_coord, x_coord, value]`
-        tuples) to a 2D NumPy array.
+        """Converts a sparse image representation (list of `[idx_y, idx_x, value]`) 
+        to a 2D NumPy array.
 
         :param sparse: A list representing non-zero elements of the sparse image.
         :returns: A 2D NumPy array representing the full image.
@@ -491,12 +603,12 @@ class PixelatedSourceReconstruction(object):
             image[sparse[i][0], sparse[i][1]] = sparse[i][2]
         return image
 
-    def sum_sparse_elementwise_product(self, sparse, ordinary):
-        """Computes the element-wise sum of products between a sparse matrix and a dense
+    @staticmethod
+    def sum_sparse_elementwise_product(sparse, ordinary):
+        """Computes the element-wise sum of products between a sparse image and a dense
         2D NumPy array image.
 
-        :param sparse: Sparse matrix representation (list of `[y_coord, x_coord, value]`
-            tuples).
+        :param sparse: A sparse image representation (list of `[idx_y, idx_x, value]`).
         :param ordinary: A 2D NumPy array (dense matrix).
         :returns: The sum of the element-wise products.
         :rtype: float
@@ -508,12 +620,12 @@ class PixelatedSourceReconstruction(object):
         return sum_temp
 
     def sparse_convolve_and_dot_product(self, sp1, sp2, kernel=None):
-        """Computes the convolution product of two sparse matrices using a given kernel.
-        Equivalent to `(sp1 * kernel) . (sp2)` where '*' is convolution and '.' is dot
+        """Computes the convolution product of two sparse images using a given kernel.
+        Equivalent to `(sp1 * kernel) . (sp2)` where `*` is convolution and `.` is dot
         product.
 
-        :param sp1: First sparse matrix representation.
-        :param sp2: Second sparse matrix representation.
+        :param sp1: First sparse image.
+        :param sp2: Second sparse image.
         :param kernel: The 2D PSF kernel (NumPy array). Assumed to be square with odd dimensions,
                        with its center at the central pixel. If None, `self._kernel` is used
         :returns: The result of the convolution product.
@@ -546,9 +658,9 @@ class PixelatedSourceReconstruction(object):
         return inner_product
 
     def sparse_convolution(self, sp, kernel=None):
-        """Performs convolution of a sparse matrix with a given kernel.
+        """Performs convolution of a sparse image with a given kernel.
 
-        :param sp: Sparse matrix representation.
+        :param sp: A sparse image.
         :param kernel: The 2D PSF kernel (NumPy array). Assumed to be square with odd dimensions,
                        with its center at the central pixel. If None, `self._kernel` is used
         :returns: A 2D NumPy array representing the convolved image.
@@ -556,32 +668,56 @@ class PixelatedSourceReconstruction(object):
         """
         if kernel is None:
             kernel = self._kernel
-        kernel_center = int(
-            len(kernel) / 2
-        )  # Assumes kernel is square and has odd dimensions
-        convolved = np.zeros((self._num_pix, self._num_pix))
-        num_element_sparse = len(sp)
 
-        for i in range(num_element_sparse):
-            y_sp, x_sp, val_sp = sp[i][0], sp[i][1], sp[i][2]
+        if len(sp) == 0:
+            return np.zeros((self._num_pix, self._num_pix))
+
+        sparse_array = np.asarray(sp)
+        indices = (
+            sparse_array[:, 0].astype(np.intp) * self._num_pix
+            + sparse_array[:, 1].astype(np.intp)
+        )
+        return self._sparse_convolution_from_image_indices(
+            indices, sparse_array[:, 2], kernel
+        )
+
+    def _sparse_convolution_from_image_indices(self, indices, values, kernel=None):
+        """Performs convolution from flattened sparse indices and values.
+
+        :param indices: Flattened image pixel indices.
+        :param values: Values at the corresponding image pixel indices.
+        :param kernel: The 2D PSF kernel. If None, `self._kernel` is used.
+        :returns: A 2D NumPy array representing the convolved image.
+        :rtype: numpy.ndarray
+        """
+        if kernel is None:
+            kernel = self._kernel
+
+        # Assume kernel is square and has odd dimensions
+        kernel_center = kernel.shape[0] // 2
+        convolved = np.zeros((self._num_pix, self._num_pix))
+
+        for index, val_sp in zip(indices, values):
+            y_sp = index // self._num_pix
+            x_sp = index % self._num_pix
 
             # Calculate slice indices for the kernel relative to the sparse element
-            slice_y_start = np.max([kernel_center - y_sp, 0])
-            slice_y_end = np.min(
-                [kernel_center - y_sp + self._num_pix, self._shape_kernel[0]]
+            slice_y_start = max(kernel_center - y_sp, 0)
+            slice_y_end = min(
+                kernel_center - y_sp + self._num_pix, kernel.shape[0]
             )
-            slice_x_start = np.max([kernel_center - x_sp, 0])
-            slice_x_end = np.min(
-                [kernel_center - x_sp + self._num_pix, self._shape_kernel[1]]
+            slice_x_start = max(kernel_center - x_sp, 0)
+            slice_x_end = min(
+                kernel_center - x_sp + self._num_pix, kernel.shape[1]
             )
 
-            convolved_image_y_start = y_sp - np.min([y_sp, kernel_center])
-            convolved_image_y_end = y_sp + np.min(
-                [self._num_pix - y_sp, self._shape_kernel[0] - kernel_center]
+            convolved_image_y_start = y_sp - min(y_sp, kernel_center)
+            convolved_image_y_end = y_sp + min(
+                self._num_pix - y_sp, kernel.shape[0] - kernel_center
             )
-            convolved_image_x_start = x_sp - np.min([x_sp, kernel_center])
-            convolved_image_x_end = x_sp + np.min(
-                [self._num_pix - x_sp, self._shape_kernel[1] - kernel_center]
+            convolved_image_x_start = x_sp - min(x_sp, kernel_center)
+            convolved_image_x_end = x_sp + min(
+                self._num_pix - x_sp, kernel.shape[1] - kernel_center
             )
 
             convolved[

--- a/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
+++ b/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from scipy.sparse import csc_matrix, csr_matrix
 
 from lenstronomy.ImSim.SourceReconstruction.pixelated_source_reconstruction import (
     PixelatedSourceReconstruction,
@@ -276,7 +277,7 @@ class TestPixelatedSourceReconstruction(object):
         psr.generate_M_b(kwargs_lens=self.kwargs_lens)
         captured1 = capsys.readouterr()
         assert captured1.out == ""
-        assert "Running (iteration times vary)" in captured1.err
+        assert "Running" in captured1.err
 
         psr.generate_M_b(kwargs_lens=self.kwargs_lens, show_progress=False)
         captured2 = capsys.readouterr()
@@ -297,12 +298,12 @@ class TestPixelatedSourceReconstruction(object):
             "Step 3: Compute the matrix M and vector b\n"
             "Step 3: Finished!"
         ) in captured3.out
-        assert "Running (iteration times vary)" in captured3.err
+        assert "Running" in captured3.err
 
         psr.generate_M_b_diagonal_likelihood(kwargs_lens=self.kwargs_lens)
         captured4 = capsys.readouterr()
         assert captured4.out == ""
-        assert "Running (iteration times vary)" in captured4.err
+        assert "Running" in captured4.err
 
         psr.generate_M_b_diagonal_likelihood(
             kwargs_lens=self.kwargs_lens, show_progress=False
@@ -321,7 +322,7 @@ class TestPixelatedSourceReconstruction(object):
             "Step 3: Compute the matrix M and vector b\n"
             "Step 3: Finished!"
         ) in captured6.out
-        assert "Running (iteration times vary)" in captured6.err
+        assert "Running" in captured6.err
 
         psr.generate_M_b_interferometry_natwt_likelihood(kwargs_lens=self.kwargs_lens)
         captured7 = capsys.readouterr()
@@ -532,6 +533,24 @@ class TestPixelatedSourceReconstruction(object):
         assert np.allclose(M_expected, M_result, atol=1e-5)
         assert np.allclose(b_expected, b_result, atol=1e-5)
 
+    def test_lens_pixel_source_of_a_rectangular_region_csc_matrix(self):
+        psr = PixelatedSourceReconstruction(
+            self.data_class,
+            self.psf_class,
+            self.lens_model_class,
+            self.source_pixel_grid_class,
+        )
+        csc_lensed_pixels = psr._lens_pixel_source_of_a_rectangular_region_csc_matrix(
+            kwargs_lens=self.kwargs_lens
+        )
+        csc_data_10_to_15_expected = np.array([0.92592581, 0.70520107, 0.65491768, 0.39804771, 0.12537181])
+        csc_indices_25_to_29_expected = np.array([13, 14, 21, 22], dtype=int)
+        csc_indptr_expected = np.array([ 0,  6, 14, 22, 37, 47, 70], dtype=int)
+        
+        assert np.allclose(csc_lensed_pixels.data[10:15], csc_data_10_to_15_expected, atol=1e-8)
+        assert np.array_equal(csc_lensed_pixels.indices[25:29], csc_indices_25_to_29_expected)
+        assert np.array_equal(csc_lensed_pixels.indptr, csc_indptr_expected)
+
     def test_lens_pixel_source_of_a_rectangular_region(self):
         psr = PixelatedSourceReconstruction(
             self.data_class,
@@ -659,6 +678,73 @@ class TestPixelatedSourceReconstruction(object):
         with pytest.raises(ValueError):
             psr.lens_an_image_by_rayshooting(self.kwargs_lens, np.random.rand(9, 9))
 
+    def test_csc_matrix_to_lensed_sp(self):
+        
+        # Define a source reconstrution with a smaller data image size
+        kwargs_data_small = sim_util.data_configure_simple(5, 0.05, np.inf, 1)
+        data_class_small = ImageData(**kwargs_data_small)
+        psr_small = PixelatedSourceReconstruction(
+            data_class_small,
+            self.psf_class,
+            self.lens_model_class,
+            self.source_pixel_grid_class,
+        )
+
+        # Test invalid input type
+        invalid_csr = csr_matrix((25, 6))
+        with pytest.raises(TypeError):
+            psr_small._csc_matrix_to_lensed_sp(invalid_csr)
+        with pytest.raises(TypeError):
+            psr_small._csc_matrix_to_lensed_sp(1)
+        with pytest.raises(TypeError):
+            psr_small._csc_matrix_to_lensed_sp([0,1,0.5])
+
+        # Test invalid number of lensed image pixels
+        invalid_csc_rows = csc_matrix((24, 6))
+        with pytest.raises(ValueError):
+            psr_small._csc_matrix_to_lensed_sp(invalid_csc_rows)
+
+        # Test invalid number of source pixels
+        invalid_csc_cols = csc_matrix((25, 5))
+        with pytest.raises(ValueError):
+            psr_small._csc_matrix_to_lensed_sp(invalid_csc_cols)
+
+        sp1_indices = np.array([0,  1,  5,  6, 12], dtype=int)
+        sp1_values = np.array([0.6862915211329877, 0.333126273654468, 0.3331262933721124, 0.029437248042628716, 0])
+        sp1_indptr = np.array([0,5,5,5,5,5,5], dtype=int)
+        sp1_csc = csc_matrix((sp1_values, sp1_indices, sp1_indptr), shape=(data_class_small.num_pixel, self.source_pixel_grid_class.num_pixel))
+        sp1 = psr_small._csc_matrix_to_lensed_sp(sp1_csc)
+        
+        sp1_expected = [
+            [[0, 0, 0.6862915211329877],
+            [0, 1, 0.333126273654468],
+            [1, 0, 0.3331262933721124],
+            [1, 1, 0.029437248042628716],
+            [2, 2, 0.0]], [], [], [], [], []
+        ]
+
+        assert len(sp1) == self.source_pixel_grid_class.num_pixel
+        assert np.allclose(sp1[0], sp1_expected[0])
+        for idx_y, idx_x, value in sp1[0]:
+            assert type(idx_y) is int
+            assert type(idx_x) is int
+        assert all(element == [] for element in sp1[1:])
+
+        # test unsorted indices in the csc matrix
+        sp1_indices_unsorted = np.array([0, 12, 6, 1,  5], dtype=int)
+        sp1_values_unsorted = np.array([0.6862915211329877, 0, 0.029437248042628716, 0.333126273654468, 0.3331262933721124])
+        sp1_indptr = np.array([0,5,5,5,5,5,5], dtype=int)
+        sp1_csc_unsorted = csc_matrix((sp1_values_unsorted, sp1_indices_unsorted, sp1_indptr), shape=(data_class_small.num_pixel, self.source_pixel_grid_class.num_pixel))
+        sp1_unsorted_result = psr_small._csc_matrix_to_lensed_sp(sp1_csc_unsorted)
+
+        assert len(sp1_unsorted_result) == self.source_pixel_grid_class.num_pixel
+        assert np.allclose(sp1_unsorted_result[0], sp1_expected[0])
+        for idx_y, idx_x, value in sp1_unsorted_result[0]:
+            assert type(idx_y) is int
+            assert type(idx_x) is int
+        assert all(element == [] for element in sp1_unsorted_result[1:])
+
+
     def test_sparse_matrix_manipulation_functions(self):
 
         # Define a source reconstrution with a smaller data image size
@@ -750,6 +836,14 @@ class TestPixelatedSourceReconstruction(object):
         assert np.allclose(sp1_convolved, sp1_convolved_expected, atol=1e-5)
         assert np.allclose(sp1_convolved_default, sp1_convolved_expected, atol=1e-5)
 
+        # Test _sparse_convolution_from_image_indices
+        sp1_indices = np.array([0,  1,  5,  6, 12], dtype=int)
+        sp1_values = np.array([0.6862915211329877, 0.333126273654468, 0.3331262933721124, 0.029437248042628716, 0])
+        sp1_convolved_default_from_image_indices = psr_small._sparse_convolution_from_image_indices(sp1_indices, sp1_values)
+        sp1_convolved_from_image_indices = psr_small._sparse_convolution_from_image_indices(sp1_indices, sp1_values, self.kernel)
+        assert np.allclose(sp1_convolved_from_image_indices, sp1_convolved_expected, atol=1e-5)
+        assert np.allclose(sp1_convolved_default_from_image_indices, sp1_convolved_expected, atol=1e-5)
+
         # Test sparse_convolution (when the kernel size is smaller than the image size)
         conolved1 = psr_small_kernel.sparse_convolution([[0, 0, 0.8]])
         conolved2 = psr_small_kernel.sparse_convolution([[0, 1, 0.8]])
@@ -769,7 +863,6 @@ class TestPixelatedSourceReconstruction(object):
         assert np.allclose(compare2, 0, atol=1e-5)
         assert np.allclose(compare3, 0, atol=1e-5)
         assert np.allclose(compare4, 0, atol=1e-5)
-
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
+++ b/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
@@ -897,18 +897,18 @@ class TestPixelatedSourceReconstruction(object):
         )
 
         # Test sparse_convolution (when the kernel size is smaller than the image size)
-        conolved1 = psr_small_kernel.sparse_convolution([[0, 0, 0.8]])
-        conolved2 = psr_small_kernel.sparse_convolution([[0, 1, 0.8]])
-        conolved3 = psr_small_kernel.sparse_convolution([[1, 1, 0.8]])
-        conolved4 = psr_small_kernel.sparse_convolution([[4, 4, 0.8]])
+        convolved1 = psr_small_kernel.sparse_convolution([[0, 0, 0.8]])
+        convolved2 = psr_small_kernel.sparse_convolution([[0, 1, 0.8]])
+        convolved3 = psr_small_kernel.sparse_convolution([[1, 1, 0.8]])
+        convolved4 = psr_small_kernel.sparse_convolution([[4, 4, 0.8]])
 
-        compare1 = conolved1.copy()
+        compare1 = convolved1.copy()
         compare1[:2, :2] -= 0.8 * kernel_small[1:, 1:]
-        compare2 = conolved2.copy()
+        compare2 = convolved2.copy()
         compare2[:2, :3] -= 0.8 * kernel_small[1:]
-        compare3 = conolved3.copy()
+        compare3 = convolved3.copy()
         compare3[:3, :3] -= 0.8 * kernel_small
-        compare4 = conolved4.copy()
+        compare4 = convolved4.copy()
         compare4[3:, 3:] -= 0.8 * kernel_small[:2, :2]
 
         assert np.allclose(compare1, 0, atol=1e-5)
@@ -916,6 +916,10 @@ class TestPixelatedSourceReconstruction(object):
         assert np.allclose(compare3, 0, atol=1e-5)
         assert np.allclose(compare4, 0, atol=1e-5)
 
+        # Test sparse_convolution (when the input is an empty list), the result should be an image with all pixels being zero
+        convolved_empty = psr_small_kernel.sparse_convolution([])
+        assert convolved_empty.shape == (5, 5)
+        assert np.all(convolved_empty == 0)
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
+++ b/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
@@ -543,12 +543,18 @@ class TestPixelatedSourceReconstruction(object):
         csc_lensed_pixels = psr._lens_pixel_source_of_a_rectangular_region_csc_matrix(
             kwargs_lens=self.kwargs_lens
         )
-        csc_data_10_to_15_expected = np.array([0.92592581, 0.70520107, 0.65491768, 0.39804771, 0.12537181])
+        csc_data_10_to_15_expected = np.array(
+            [0.92592581, 0.70520107, 0.65491768, 0.39804771, 0.12537181]
+        )
         csc_indices_25_to_29_expected = np.array([13, 14, 21, 22], dtype=int)
-        csc_indptr_expected = np.array([ 0,  6, 14, 22, 37, 47, 70], dtype=int)
-        
-        assert np.allclose(csc_lensed_pixels.data[10:15], csc_data_10_to_15_expected, atol=1e-8)
-        assert np.array_equal(csc_lensed_pixels.indices[25:29], csc_indices_25_to_29_expected)
+        csc_indptr_expected = np.array([0, 6, 14, 22, 37, 47, 70], dtype=int)
+
+        assert np.allclose(
+            csc_lensed_pixels.data[10:15], csc_data_10_to_15_expected, atol=1e-8
+        )
+        assert np.array_equal(
+            csc_lensed_pixels.indices[25:29], csc_indices_25_to_29_expected
+        )
         assert np.array_equal(csc_lensed_pixels.indptr, csc_indptr_expected)
 
     def test_lens_pixel_source_of_a_rectangular_region(self):
@@ -679,7 +685,7 @@ class TestPixelatedSourceReconstruction(object):
             psr.lens_an_image_by_rayshooting(self.kwargs_lens, np.random.rand(9, 9))
 
     def test_csc_matrix_to_lensed_sp(self):
-        
+
         # Define a source reconstrution with a smaller data image size
         kwargs_data_small = sim_util.data_configure_simple(5, 0.05, np.inf, 1)
         data_class_small = ImageData(**kwargs_data_small)
@@ -697,7 +703,7 @@ class TestPixelatedSourceReconstruction(object):
         with pytest.raises(TypeError):
             psr_small._csc_matrix_to_lensed_sp(1)
         with pytest.raises(TypeError):
-            psr_small._csc_matrix_to_lensed_sp([0,1,0.5])
+            psr_small._csc_matrix_to_lensed_sp([0, 1, 0.5])
 
         # Test invalid number of lensed image pixels
         invalid_csc_rows = csc_matrix((24, 6))
@@ -709,18 +715,36 @@ class TestPixelatedSourceReconstruction(object):
         with pytest.raises(ValueError):
             psr_small._csc_matrix_to_lensed_sp(invalid_csc_cols)
 
-        sp1_indices = np.array([0,  1,  5,  6, 12], dtype=int)
-        sp1_values = np.array([0.6862915211329877, 0.333126273654468, 0.3331262933721124, 0.029437248042628716, 0])
-        sp1_indptr = np.array([0,5,5,5,5,5,5], dtype=int)
-        sp1_csc = csc_matrix((sp1_values, sp1_indices, sp1_indptr), shape=(data_class_small.num_pixel, self.source_pixel_grid_class.num_pixel))
+        sp1_indices = np.array([0, 1, 5, 6, 12], dtype=int)
+        sp1_values = np.array(
+            [
+                0.6862915211329877,
+                0.333126273654468,
+                0.3331262933721124,
+                0.029437248042628716,
+                0,
+            ]
+        )
+        sp1_indptr = np.array([0, 5, 5, 5, 5, 5, 5], dtype=int)
+        sp1_csc = csc_matrix(
+            (sp1_values, sp1_indices, sp1_indptr),
+            shape=(data_class_small.num_pixel, self.source_pixel_grid_class.num_pixel),
+        )
         sp1 = psr_small._csc_matrix_to_lensed_sp(sp1_csc)
-        
+
         sp1_expected = [
-            [[0, 0, 0.6862915211329877],
-            [0, 1, 0.333126273654468],
-            [1, 0, 0.3331262933721124],
-            [1, 1, 0.029437248042628716],
-            [2, 2, 0.0]], [], [], [], [], []
+            [
+                [0, 0, 0.6862915211329877],
+                [0, 1, 0.333126273654468],
+                [1, 0, 0.3331262933721124],
+                [1, 1, 0.029437248042628716],
+                [2, 2, 0.0],
+            ],
+            [],
+            [],
+            [],
+            [],
+            [],
         ]
 
         assert len(sp1) == self.source_pixel_grid_class.num_pixel
@@ -731,10 +755,21 @@ class TestPixelatedSourceReconstruction(object):
         assert all(element == [] for element in sp1[1:])
 
         # test unsorted indices in the csc matrix
-        sp1_indices_unsorted = np.array([0, 12, 6, 1,  5], dtype=int)
-        sp1_values_unsorted = np.array([0.6862915211329877, 0, 0.029437248042628716, 0.333126273654468, 0.3331262933721124])
-        sp1_indptr = np.array([0,5,5,5,5,5,5], dtype=int)
-        sp1_csc_unsorted = csc_matrix((sp1_values_unsorted, sp1_indices_unsorted, sp1_indptr), shape=(data_class_small.num_pixel, self.source_pixel_grid_class.num_pixel))
+        sp1_indices_unsorted = np.array([0, 12, 6, 1, 5], dtype=int)
+        sp1_values_unsorted = np.array(
+            [
+                0.6862915211329877,
+                0,
+                0.029437248042628716,
+                0.333126273654468,
+                0.3331262933721124,
+            ]
+        )
+        sp1_indptr = np.array([0, 5, 5, 5, 5, 5, 5], dtype=int)
+        sp1_csc_unsorted = csc_matrix(
+            (sp1_values_unsorted, sp1_indices_unsorted, sp1_indptr),
+            shape=(data_class_small.num_pixel, self.source_pixel_grid_class.num_pixel),
+        )
         sp1_unsorted_result = psr_small._csc_matrix_to_lensed_sp(sp1_csc_unsorted)
 
         assert len(sp1_unsorted_result) == self.source_pixel_grid_class.num_pixel
@@ -743,7 +778,6 @@ class TestPixelatedSourceReconstruction(object):
             assert type(idx_y) is int
             assert type(idx_x) is int
         assert all(element == [] for element in sp1_unsorted_result[1:])
-
 
     def test_sparse_matrix_manipulation_functions(self):
 
@@ -837,12 +871,30 @@ class TestPixelatedSourceReconstruction(object):
         assert np.allclose(sp1_convolved_default, sp1_convolved_expected, atol=1e-5)
 
         # Test _sparse_convolution_from_image_indices
-        sp1_indices = np.array([0,  1,  5,  6, 12], dtype=int)
-        sp1_values = np.array([0.6862915211329877, 0.333126273654468, 0.3331262933721124, 0.029437248042628716, 0])
-        sp1_convolved_default_from_image_indices = psr_small._sparse_convolution_from_image_indices(sp1_indices, sp1_values)
-        sp1_convolved_from_image_indices = psr_small._sparse_convolution_from_image_indices(sp1_indices, sp1_values, self.kernel)
-        assert np.allclose(sp1_convolved_from_image_indices, sp1_convolved_expected, atol=1e-5)
-        assert np.allclose(sp1_convolved_default_from_image_indices, sp1_convolved_expected, atol=1e-5)
+        sp1_indices = np.array([0, 1, 5, 6, 12], dtype=int)
+        sp1_values = np.array(
+            [
+                0.6862915211329877,
+                0.333126273654468,
+                0.3331262933721124,
+                0.029437248042628716,
+                0,
+            ]
+        )
+        sp1_convolved_default_from_image_indices = (
+            psr_small._sparse_convolution_from_image_indices(sp1_indices, sp1_values)
+        )
+        sp1_convolved_from_image_indices = (
+            psr_small._sparse_convolution_from_image_indices(
+                sp1_indices, sp1_values, self.kernel
+            )
+        )
+        assert np.allclose(
+            sp1_convolved_from_image_indices, sp1_convolved_expected, atol=1e-5
+        )
+        assert np.allclose(
+            sp1_convolved_default_from_image_indices, sp1_convolved_expected, atol=1e-5
+        )
 
         # Test sparse_convolution (when the kernel size is smaller than the image size)
         conolved1 = psr_small_kernel.sparse_convolution([[0, 0, 0.8]])
@@ -863,6 +915,7 @@ class TestPixelatedSourceReconstruction(object):
         assert np.allclose(compare2, 0, atol=1e-5)
         assert np.allclose(compare3, 0, atol=1e-5)
         assert np.allclose(compare4, 0, atol=1e-5)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
+++ b/test/test_ImSim/test_SourceReconstruction/test_pixelated_source_reconstruction.py
@@ -921,5 +921,6 @@ class TestPixelatedSourceReconstruction(object):
         assert convolved_empty.shape == (5, 5)
         assert np.all(convolved_empty == 0)
 
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Update:

Updated pixelated_source_reconstruction.py to make it run faster for pixelated source reconstruction tasks. The main reason it now runs faster is that the double for loops in the relevant functions are reduced by using np.matmul or scipy sparse matrix @ np.array, replacing them with either no loop or only one loop.

Additional functions were added to manipulate scipy csc matrices. The inputs and outputs of all original functions remain unchanged, but the internal flow has changed. The modified functions passed all the old test functions, except for the test that checks the printed text of the progress bar, which changed slightly. I've also tested the new and old versions against a large number of different cases to make sure their outputs remain the same with rtol=1e-9 and atol=1e-12.

All documentation was also modified to make the ideas clearer.

pixelated_source_reconstruction.py

- (+) _lens_pixel_source_of_a_rectangular_region_csc_matrix

This function performs the original task of lens_pixel_source_of_a_rectangular_region. It computes the lens mapping from image pixels to source pixels, but the result returned by this function is now stored in scipy csc_matrix form.

- (+) _csc_matrix_to_lensed_sp

Converts the csc_matrix into the old nested-list form used to store the lensing map.

- (changed) lens_pixel_source_of_a_rectangular_region

Combined the above two functions to keep its input and output unchanged from the older version.

- (changed) generate_M_b_diagonal_likelihood and generate_M_b_interferometry_natwt_likelihood

Changed the internal flow and reduced the depth of the for loops to accelerate the computation.

- (changed) lens_pixel_source_of_a_rectangular_region

Also changed the internal flow and reduced the double for loops.

- (changed) sum_sparse_elementwise_product

Changed into a ``@staticmethod`` because it does not rely on self or other instance properties.

- (+) _sparse_convolution_from_image_indices

This function was added to perform the convolution of a set of lensed pixels using their pixel indices and values. It performs the same task as the original sparse_convolution function takes the image pixel indices as input which works better with csc_matrix.

- (changed) sparse_convolution

Now invokes _sparse_convolution_from_image_indices to perform sparse image convolution.


test_pixelated_source_reconstruction.py

- (changed) test_generate_M_b_print

Changed the detection of the printed text from "Running (iteration times vary)" to "Running".

- (+) test_lens_pixel_source_of_a_rectangular_region_csc_matrix

- (+) test_csc_matrix_to_lensed_sp

- (changed) test_sparse_matrix_manipulation_functions

Added tests for _sparse_convolution_from_image_indices.


AI acknowledgement:

This version was inspired by an AI review of the older version of pixelated_source_reconstruction.py. After the AI-generated changes, I reviewed them carefully and found that the main changes were the reduction of for loops and the use of the CSC matrice. I decided to keep these changes, but revised the code myself. The core part of the code, including lensing and bilinear interpolation in the source plane, was not touched by AI. 
AI model used: GPT-5.6 Sol.